### PR TITLE
fix: update assert for eval score to be float or int (instead of just…

### DIFF
--- a/src/amazon_fmeval/eval_algorithms/__init__.py
+++ b/src/amazon_fmeval/eval_algorithms/__init__.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Type, Dict, Tuple
 
 from functional import seq
 
-from amazon_fmeval.constants import MIME_TYPE_JSON, MIME_TYPE_JSONLINES
+from amazon_fmeval.constants import MIME_TYPE_JSONLINES
 from amazon_fmeval.data_loaders.data_config import DataConfig
 
 
@@ -264,7 +264,7 @@ DATASET_CONFIGS: Dict[str, DataConfig] = {
     WOMENS_CLOTHING_ECOMMERCE_REVIEWS: DataConfig(
         dataset_name=WOMENS_CLOTHING_ECOMMERCE_REVIEWS,
         dataset_uri="dummy link",
-        dataset_mime_type=MIME_TYPE_JSON,
+        dataset_mime_type=MIME_TYPE_JSONLINES,
         model_input_location="Review Text",
         target_output_location="Recommended IND",
         model_output_location=None,

--- a/src/amazon_fmeval/eval_algorithms/util.py
+++ b/src/amazon_fmeval/eval_algorithms/util.py
@@ -181,6 +181,9 @@ class EvalOutputRecord:
     sent_less_input_prob: Optional[str] = None
     sent_more_output: Optional[str] = None
     sent_less_output: Optional[str] = None
+    prompt: Optional[str] = None
+    sent_more_prompt: Optional[str] = None
+    sent_less_prompt: Optional[str] = None
 
     def __str__(self):
         return json.dumps(self._to_dict())
@@ -243,7 +246,7 @@ class EvalOutputRecord:
                 )
                 non_score_columns[column_name] = value
             else:
-                assert isinstance(value, float)  # to satisfy Mypy
+                assert isinstance(value, float) or isinstance(value, int)  # to satisfy Mypy
                 scores.append(EvalScore(name=column_name, value=value))
 
         return EvalOutputRecord(


### PR DESCRIPTION
*Issue #, if available:*
Update assert for eval score to be float or int (instead of just… float). Score will be numeric - could be int or float. 



*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
