### PR TITLE
fix: update predict method of model runners to not extract when no jmespath is present

### DIFF
--- a/src/amazon_fmeval/model_runners/sm_jumpstart_model_runner.py
+++ b/src/amazon_fmeval/model_runners/sm_jumpstart_model_runner.py
@@ -71,6 +71,14 @@ class JumpStartModelRunner(ModelRunner):
         """
         composed_data = self._composer.compose(prompt)
         model_output = self._predictor.predict(data=composed_data, custom_attributes=self._custom_attributes)
-        output = self._extractor.extract_output(data=model_output, num_records=1)
-        log_probability = self._extractor.extract_log_probability(data=model_output, num_records=1)
+        output = (
+            self._extractor.extract_output(data=model_output, num_records=1)
+            if self._extractor.output_jmespath_expression
+            else None
+        )
+        log_probability = (
+            self._extractor.extract_log_probability(data=model_output, num_records=1)
+            if self._extractor.log_probability_jmespath_expression
+            else None
+        )
         return output, log_probability

--- a/src/amazon_fmeval/model_runners/sm_model_runner.py
+++ b/src/amazon_fmeval/model_runners/sm_model_runner.py
@@ -61,6 +61,14 @@ class SageMakerModelRunner(ModelRunner):
         """
         composed_data = self._composer.compose(prompt)
         model_output = self._predictor.predict(data=composed_data, custom_attributes=self._custom_attributes)
-        output = self._extractor.extract_output(data=model_output, num_records=1)
-        log_probability = self._extractor.extract_log_probability(data=model_output, num_records=1)
+        output = (
+            self._extractor.extract_output(data=model_output, num_records=1)
+            if self._extractor.output_jmespath_expression
+            else None
+        )
+        log_probability = (
+            self._extractor.extract_log_probability(data=model_output, num_records=1)
+            if self._extractor.log_probability_jmespath_expression
+            else None
+        )
         return output, log_probability

--- a/test/unit/model_runners/test_sm_jumpstart_model_runner.py
+++ b/test/unit/model_runners/test_sm_jumpstart_model_runner.py
@@ -1,5 +1,7 @@
+from typing import NamedTuple, Optional
 from unittest.mock import Mock, patch
 
+import pytest
 import sagemaker
 
 from amazon_fmeval.constants import MIME_TYPE_JSON
@@ -58,8 +60,78 @@ class TestJumpStartModelRunner:
                 sagemaker_session=sagemaker_session_class.return_value,
             )
 
+    class TestCasePredict(NamedTuple):
+        output_jmespath: Optional[str]
+        log_probability_jmespath: Optional[str]
+        output: Optional[str]
+        log_probability: Optional[float]
+
+    @pytest.mark.parametrize(
+        "test_case",
+        [
+            TestCasePredict(
+                output_jmespath=OUTPUT_JMES_PATH,
+                log_probability_jmespath=LOG_PROBABILITY_JMES_PATH,
+                output=OUTPUT,
+                log_probability=LOG_PROBABILITY,
+            ),
+            TestCasePredict(
+                output_jmespath=None,
+                log_probability_jmespath=LOG_PROBABILITY_JMES_PATH,
+                output=None,
+                log_probability=LOG_PROBABILITY,
+            ),
+            TestCasePredict(
+                output_jmespath=OUTPUT_JMES_PATH, log_probability_jmespath=None, output=OUTPUT, log_probability=None
+            ),
+        ],
+    )
     @patch("sagemaker.session.Session")
-    def test_jumpstart_model_runner_predict(self, sagemaker_session_class):
+    def test_jumpstart_model_runner_predict(self, sagemaker_session_class, test_case):
+        """
+        GIVEN valid JumpStartModelRunner
+        WHEN predict() called
+        THEN SageMaker Predictor predict method is called once with expected parameters,
+            and extract output and log probability as expected
+        """
+        mock_sagemaker_session = sagemaker_session_class()
+        mock_sagemaker_session.sagemaker_client.describe_endpoint.return_value = {"EndpointStatus": "InService"}
+
+        with patch.object(
+            sagemaker.serializers, "retrieve_default", return_value=sagemaker.serializers.JSONSerializer()
+        ) as default_serializer, patch.object(
+            sagemaker.deserializers, "retrieve_default", return_value=sagemaker.deserializers.JSONDeserializer()
+        ) as default_deserializer, patch.object(
+            sagemaker.accept_types, "retrieve_default", return_value=MIME_TYPE_JSON
+        ) as default_accept_type, patch.object(
+            sagemaker.content_types, "retrieve_default", return_value=MIME_TYPE_JSON
+        ):
+            js_model_runner = JumpStartModelRunner(
+                endpoint_name=ENDPOINT_NAME,
+                model_id=MODEL_ID,
+                model_version=MODEL_VERSION,
+                content_template=CONTENT_TEMPLATE,
+                custom_attributes=CUSTOM_ATTRIBUTES,
+                output=test_case.output_jmespath,
+                log_probability=test_case.log_probability_jmespath,
+            )
+            # Mocking sagemaker.predictor serializing byte into JSON
+            js_model_runner._predictor.deserializer.deserialize = Mock(return_value=MODEL_OUTPUT)
+
+            result = js_model_runner.predict(PROMPT)
+            assert mock_sagemaker_session.sagemaker_runtime_client.invoke_endpoint.called
+            call_args, kwargs = mock_sagemaker_session.sagemaker_runtime_client.invoke_endpoint.call_args
+            assert kwargs == {
+                "Accept": MIME_TYPE_JSON,
+                "Body": MODEL_INPUT,
+                "ContentType": MIME_TYPE_JSON,
+                "CustomAttributes": CUSTOM_ATTRIBUTES,
+                "EndpointName": ENDPOINT_NAME,
+            }
+            assert result == (test_case.output, test_case.log_probability)
+
+    @patch("sagemaker.session.Session")
+    def test_jumpstart_model_runner_predict_no_output(self, sagemaker_session_class):
         """
         GIVEN valid JumpStartModelRunner
         WHEN predict() called


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Currently, if a SageMakerModelRunner or JumpStartModelRunner is initialized with `output` or `log_probability` set to None, the predict() method will fail when attempting to extract the output or log_probability (whichever one is None).

Fix the predict() method of SageMakerModelRunner and JumpStartModelRunner so that `self._extractor.extract_output` and `self._extractor.extract_log_probability` only get called if the respective JMESPath expressions are not None.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
