### PR TITLE
fix: jumpstart models support more content types

### DIFF
--- a/src/amazon_fmeval/model_runners/sm_jumpstart_model_runner.py
+++ b/src/amazon_fmeval/model_runners/sm_jumpstart_model_runner.py
@@ -58,9 +58,6 @@ class JumpStartModelRunner(ModelRunner):
             sagemaker_session=self.sagemaker_session,
         )
         util.require(
-            self.predictor.accept == MIME_TYPE_JSON, f"Model accept type `{self.predictor.accept}` is not supported."
-        )
-        util.require(
             self.predictor.content_type == MIME_TYPE_JSON,
             f"Model content type `{self.predictor.content_type}` is not supported.",
         )


### PR DESCRIPTION
*Description of changes:*
jumpstart models support more content types. No need to require `application/json`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
