### PR TITLE
perf: materialize code at the end of each component to avoid duplicat…

### DIFF
--- a/src/amazon_fmeval/eval_algorithms/factual_knowledge.py
+++ b/src/amazon_fmeval/eval_algorithms/factual_knowledge.py
@@ -1,3 +1,4 @@
+import logging
 from dataclasses import dataclass
 from typing import Optional, List
 
@@ -34,8 +35,11 @@ from amazon_fmeval.eval_algorithms.util import (
 )
 from amazon_fmeval.exceptions import EvalAlgorithmClientError
 from amazon_fmeval.model_runners.model_runner import ModelRunner
+from amazon_fmeval.perf_util import timed_block
 
 PROMPT_COLUMN_NAME = "prompt"
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -158,30 +162,31 @@ class FactualKnowledge(EvalAlgorithmInterface):
                     model_output_column_name=MODEL_OUTPUT_COLUMN_NAME,
                     model_log_probability_column_name=MODEL_LOG_PROBABILITY_COLUMN_NAME,
                 )
+            with timed_block(f"Computing score and aggregation on dataset {dataset_config.dataset_name}", logger):
 
-            def _generate_eval_scores(df: pd.DataFrame) -> pd.Series:  # pragma: no cover
-                """
-                Map function generating the scores for every input record in input dataset
-                """
-                return pd.Series(
-                    data=[
-                        self._get_score(row[TARGET_OUTPUT_COLUMN_NAME], row[MODEL_OUTPUT_COLUMN_NAME])
-                        for index, row in df.iterrows()
-                    ]
-                )
+                def _generate_eval_scores(df: pd.DataFrame) -> pd.Series:  # pragma: no cover
+                    """
+                    Map function generating the scores for every input record in input dataset
+                    """
+                    return pd.Series(
+                        data=[
+                            self._get_score(row[TARGET_OUTPUT_COLUMN_NAME], row[MODEL_OUTPUT_COLUMN_NAME])
+                            for index, row in df.iterrows()
+                        ]
+                    )
 
-            dataset = dataset.add_column(SCORE_NAME, _generate_eval_scores)
-            dataset_scores, category_scores = aggregate_evaluation_scores(dataset, [SCORE_NAME], agg_method=MEAN)
-            eval_outputs.append(
-                EvalOutput(
-                    eval_name=self.eval_name,
-                    dataset_name=dataset_config.dataset_name,
-                    prompt_template=prompt_template,
-                    dataset_scores=dataset_scores,
-                    category_scores=category_scores,
-                    output_path=self._eval_results_path,
+                dataset = dataset.add_column(SCORE_NAME, _generate_eval_scores)
+                dataset_scores, category_scores = aggregate_evaluation_scores(dataset, [SCORE_NAME], agg_method=MEAN)
+                eval_outputs.append(
+                    EvalOutput(
+                        eval_name=self.eval_name,
+                        dataset_name=dataset_config.dataset_name,
+                        prompt_template=prompt_template,
+                        dataset_scores=dataset_scores,
+                        category_scores=category_scores,
+                        output_path=self._eval_results_path,
+                    )
                 )
-            )
             if save:
                 save_dataset(
                     dataset=dataset,

--- a/src/amazon_fmeval/perf_util.py
+++ b/src/amazon_fmeval/perf_util.py
@@ -1,0 +1,19 @@
+import contextlib
+from timeit import default_timer as timer
+import logging
+
+
+@contextlib.contextmanager
+def timed_block(block_name: str, logger: logging.Logger):
+    """
+    Measure and log execution time for the code block in the context
+    :param block_name: a string describing the code block
+    :param logger: used to log the execution time
+    """
+    start = timer()
+    try:
+        yield
+    finally:
+        end = timer()
+        logger.info(f"{block_name} took {(end - start):.2f} seconds.")
+        logger.info("===================================================")

--- a/test/unit/data_loaders/test_util.py
+++ b/test/unit/data_loaders/test_util.py
@@ -27,6 +27,7 @@ class TestDataLoaderUtil:
         THEN all of get_dataset's helper methods get called with expected arguments
         """
         config = Mock(spec=DataConfig)
+        config.dataset_name = "dataset1"
         config.dataset_uri = "unused"
         config.dataset_mime_type = "unused"
         get_dataset(config)


### PR DESCRIPTION
*Description of changes:*
Materialize code at the end of each component to avoid duplicate computations

We are using Ray to perform parallel executions, and Ray does this by lazy computations in worker nodes. When we materialize the Ray Dataset, it will actually complete the computations recorded in the computation graph. If we don't materialzie, we risk doing the same computations multiple times, and this can increase the total workload.

This CR materializes the dataset at the end each component like data loading, model inferencing etc. This change significantly improves performance. One data point is running FactualK Knowledge on Llama2 in JS which took 180s before this change, now takes 41s.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
