### PR TITLE
feat: update prompt stereotyping to aggregate on boolean score

### DIFF
--- a/src/amazon_fmeval/eval_algorithms/eval_algorithm.py
+++ b/src/amazon_fmeval/eval_algorithms/eval_algorithm.py
@@ -4,7 +4,7 @@ from amazon_fmeval.data_loaders.util import DataConfig
 from amazon_fmeval.eval_algorithms import EvalScore, EvalOutput
 from amazon_fmeval.model_runners.model_runner import ModelRunner
 
-from amazon_fmeval.util import get_eval_results_path, camel_to_snake
+from amazon_fmeval.util import get_eval_results_path
 
 
 class EvalAlgorithmConfig:
@@ -25,15 +25,6 @@ class EvalAlgorithmInterface(ABC):
                                             current evaluation.
         """
         self._eval_results_path = get_eval_results_path()
-
-    def __init_subclass__(cls, **kwargs):
-        """
-        Method to register algorithms.
-
-        :raises DuplicateEvalNameError if the name of the evaluation being initialized already exists.
-        """
-        super().__init_subclass__(**kwargs)
-        cls.eval_name = camel_to_snake(cls.__name__)
 
     @abstractmethod
     def evaluate(

--- a/src/amazon_fmeval/eval_algorithms/factual_knowledge.py
+++ b/src/amazon_fmeval/eval_algorithms/factual_knowledge.py
@@ -55,7 +55,7 @@ class FactualKnowledgeConfig(EvalAlgorithmConfig):
     target_output_delimiter: str
 
 
-SCORE_NAME = "factual_knowledge"
+FACTUAL_KNOWLEDGE = EvalAlgorithm.FACTUAL_KNOWLEDGE.value
 
 
 class FactualKnowledge(EvalAlgorithmInterface):
@@ -69,7 +69,7 @@ class FactualKnowledge(EvalAlgorithmInterface):
         :param eval_algorithm_config: Factual knowledge eval algorithm config.
         """
         super().__init__(eval_algorithm_config)
-        self.eval_name = EvalAlgorithm.FACTUAL_KNOWLEDGE.value
+        self.eval_name = FACTUAL_KNOWLEDGE
         self._eval_algorithm_config = eval_algorithm_config
 
     def evaluate_sample(self, target_output: str, model_output: str) -> List[EvalScore]:  # type: ignore[override]
@@ -174,8 +174,10 @@ class FactualKnowledge(EvalAlgorithmInterface):
                         ]
                     )
 
-                dataset = dataset.add_column(SCORE_NAME, _generate_eval_scores)
-                dataset_scores, category_scores = aggregate_evaluation_scores(dataset, [SCORE_NAME], agg_method=MEAN)
+                dataset = dataset.add_column(FACTUAL_KNOWLEDGE, _generate_eval_scores)
+                dataset_scores, category_scores = aggregate_evaluation_scores(
+                    dataset, [FACTUAL_KNOWLEDGE], agg_method=MEAN
+                )
                 eval_outputs.append(
                     EvalOutput(
                         eval_name=self.eval_name,
@@ -189,7 +191,7 @@ class FactualKnowledge(EvalAlgorithmInterface):
             if save:
                 save_dataset(
                     dataset=dataset,
-                    score_names=[SCORE_NAME],
+                    score_names=[FACTUAL_KNOWLEDGE],
                     path=generate_output_dataset_path(
                         path_to_parent_dir=self._eval_results_path,
                         eval_name=self.eval_name,

--- a/test/unit/eval_algorithms/test_factual_knowledge.py
+++ b/test/unit/eval_algorithms/test_factual_knowledge.py
@@ -15,7 +15,7 @@ from amazon_fmeval.constants import (
     MODEL_OUTPUT_COLUMN_NAME,
 )
 from amazon_fmeval.eval_algorithms.eval_algorithm import DataConfig
-from amazon_fmeval.eval_algorithms import EvalOutput, CategoryScore, EvalScore
+from amazon_fmeval.eval_algorithms import EvalOutput, CategoryScore, EvalScore, EvalAlgorithm
 from amazon_fmeval.eval_algorithms.factual_knowledge import FactualKnowledge, FactualKnowledgeConfig, PROMPT_COLUMN_NAME
 from amazon_fmeval.exceptions import EvalAlgorithmClientError
 
@@ -44,25 +44,25 @@ class TestFactualKnowledge:
                 model_input="London is the capital of",
                 model_output="England",
                 target_output="England<OR>UK",
-                expected_response=[EvalScore(name=FactualKnowledge.eval_name, value=1)],
+                expected_response=[EvalScore(name=EvalAlgorithm.FACTUAL_KNOWLEDGE.value, value=1)],
             ),
             TestCaseFactualKnowledgeEvaluateSample(
                 model_input="London is the capital of",
                 model_output="England or wait Scotland",
                 target_output="England<OR>UK",
-                expected_response=[EvalScore(name=FactualKnowledge.eval_name, value=1)],
+                expected_response=[EvalScore(name=EvalAlgorithm.FACTUAL_KNOWLEDGE.value, value=1)],
             ),
             TestCaseFactualKnowledgeEvaluateSample(
                 model_input="London is the capital of",
                 model_output="India or maybe Pakistan",
                 target_output="England<OR>UK",
-                expected_response=[EvalScore(name=FactualKnowledge.eval_name, value=0)],
+                expected_response=[EvalScore(name=EvalAlgorithm.FACTUAL_KNOWLEDGE.value, value=0)],
             ),
             TestCaseFactualKnowledgeEvaluateSample(
                 model_input="Pulp Fiction was directed by",
                 model_output="Quentin Tarantino",
                 target_output="QUENTIN TARANTINO",
-                expected_response=[EvalScore(name=FactualKnowledge.eval_name, value=1)],
+                expected_response=[EvalScore(name=EvalAlgorithm.FACTUAL_KNOWLEDGE.value, value=1)],
             ),
         ],
     )

--- a/test/unit/eval_algorithms/test_prompt_stereotyping.py
+++ b/test/unit/eval_algorithms/test_prompt_stereotyping.py
@@ -16,8 +16,12 @@ from amazon_fmeval.constants import (
     DEFAULT_EVAL_RESULTS_PATH,
 )
 from amazon_fmeval.data_loaders.util import DataConfig
-from amazon_fmeval.eval_algorithms import EvalOutput, CategoryScore, EvalScore
-from amazon_fmeval.eval_algorithms.prompt_stereotyping import PromptStereotyping
+from amazon_fmeval.eval_algorithms import EvalOutput, CategoryScore, EvalScore, EvalAlgorithm
+from amazon_fmeval.eval_algorithms.prompt_stereotyping import (
+    PromptStereotyping,
+    PROMPT_STEREOTYPING,
+    LOG_PROBABILITY_DIFFERENCE,
+)
 from amazon_fmeval.exceptions import EvalAlgorithmClientError
 
 GENDER_MORE_STEREOTYPICAL_STATEMENT = "Statement that is more stereotypical about gender"
@@ -122,8 +126,8 @@ class TestPromptStereotyping:
                             SENT_MORE_INPUT_COLUMN_NAME: SOCIO_ECONOMIC_MORE_STEREOTYPICAL_STATEMENT,
                             SENT_LESS_INPUT_COLUMN_NAME: SOCIO_ECONOMIC_LESS_STEREOTYPICAL_STATEMENT,
                             CATEGORY_COLUMN_NAME: "socioeconomic",
-                            SENT_MORE_LOG_PROB_COLUMN_NAME: 0.7,
-                            SENT_LESS_LOG_PROB_COLUMN_NAME: 0.2,
+                            SENT_MORE_LOG_PROB_COLUMN_NAME: 0.2,
+                            SENT_LESS_LOG_PROB_COLUMN_NAME: 0.7,
                         },
                         {
                             SENT_MORE_INPUT_COLUMN_NAME: NATIONALITY_MORE_STEREOTYPICAL_STATEMENT,
@@ -136,27 +140,23 @@ class TestPromptStereotyping:
                             SENT_MORE_INPUT_COLUMN_NAME: SEXUAL_ORIENTIATION_MORE_STEREOTYPICAL_STATEMENT,
                             SENT_LESS_INPUT_COLUMN_NAME: SEXUAL_ORIENTIATION_LESS_STEREOTYPICAL_STATEMENT,
                             CATEGORY_COLUMN_NAME: "sexual-orientation",
-                            SENT_MORE_LOG_PROB_COLUMN_NAME: 0.4,
-                            SENT_LESS_LOG_PROB_COLUMN_NAME: 0.1,
+                            SENT_MORE_LOG_PROB_COLUMN_NAME: 0.1,
+                            SENT_LESS_LOG_PROB_COLUMN_NAME: 0.4,
                         },
                     ]
                 ),
                 expected_response=[
                     EvalOutput(
-                        eval_name="prompt_stereotyping",
+                        eval_name=EvalAlgorithm.PROMPT_STEREOTYPING.value,
                         dataset_name="crow-pairs",
                         prompt_template="$feature",
-                        dataset_scores=[EvalScore(name="prompt_stereotyping", value=0.35)],
+                        dataset_scores=[EvalScore(name=PROMPT_STEREOTYPING, value=0.5)],
                         category_scores=[
-                            CategoryScore(name="gender", scores=[EvalScore(name="prompt_stereotyping", value=0.4)]),
+                            CategoryScore(name="gender", scores=[EvalScore(name=PROMPT_STEREOTYPING, value=1)]),
+                            CategoryScore(name="socioeconomic", scores=[EvalScore(name=PROMPT_STEREOTYPING, value=0)]),
+                            CategoryScore(name="nationality", scores=[EvalScore(name=PROMPT_STEREOTYPING, value=1)]),
                             CategoryScore(
-                                name="socioeconomic", scores=[EvalScore(name="prompt_stereotyping", value=0.5)]
-                            ),
-                            CategoryScore(
-                                name="nationality", scores=[EvalScore(name="prompt_stereotyping", value=0.2)]
-                            ),
-                            CategoryScore(
-                                name="sexual-orientation", scores=[EvalScore(name="prompt_stereotyping", value=0.3)]
+                                name="sexual-orientation", scores=[EvalScore(name=PROMPT_STEREOTYPING, value=0)]
                             ),
                         ],
                         output_path="/tmp/eval_results/",
@@ -209,8 +209,8 @@ class TestPromptStereotyping:
                             SENT_MORE_INPUT_COLUMN_NAME: SOCIO_ECONOMIC_MORE_STEREOTYPICAL_STATEMENT,
                             SENT_LESS_INPUT_COLUMN_NAME: SOCIO_ECONOMIC_LESS_STEREOTYPICAL_STATEMENT,
                             CATEGORY_COLUMN_NAME: "socioeconomic",
-                            SENT_MORE_LOG_PROB_COLUMN_NAME: 0.7,
-                            SENT_LESS_LOG_PROB_COLUMN_NAME: 0.2,
+                            SENT_MORE_LOG_PROB_COLUMN_NAME: 0.2,
+                            SENT_LESS_LOG_PROB_COLUMN_NAME: 0.7,
                         },
                         {
                             SENT_MORE_INPUT_COLUMN_NAME: NATIONALITY_MORE_STEREOTYPICAL_STATEMENT,
@@ -223,28 +223,24 @@ class TestPromptStereotyping:
                             SENT_MORE_INPUT_COLUMN_NAME: SEXUAL_ORIENTIATION_MORE_STEREOTYPICAL_STATEMENT,
                             SENT_LESS_INPUT_COLUMN_NAME: SEXUAL_ORIENTIATION_LESS_STEREOTYPICAL_STATEMENT,
                             CATEGORY_COLUMN_NAME: "sexual-orientation",
-                            SENT_MORE_LOG_PROB_COLUMN_NAME: 0.4,
-                            SENT_LESS_LOG_PROB_COLUMN_NAME: 0.1,
+                            SENT_MORE_LOG_PROB_COLUMN_NAME: 0.1,
+                            SENT_LESS_LOG_PROB_COLUMN_NAME: 0.4,
                         },
                     ]
                 ),
                 output_results_path="/output/results/path",
                 expected_response=[
                     EvalOutput(
-                        eval_name="prompt_stereotyping",
+                        eval_name=EvalAlgorithm.PROMPT_STEREOTYPING.value,
                         dataset_name="my_custom_dataset",
                         prompt_template="Is this stereotypical? $feature",
-                        dataset_scores=[EvalScore(name="prompt_stereotyping", value=0.35)],
+                        dataset_scores=[EvalScore(name=PROMPT_STEREOTYPING, value=0.5)],
                         category_scores=[
-                            CategoryScore(name="gender", scores=[EvalScore(name="prompt_stereotyping", value=0.4)]),
+                            CategoryScore(name="gender", scores=[EvalScore(name=PROMPT_STEREOTYPING, value=1)]),
+                            CategoryScore(name="socioeconomic", scores=[EvalScore(name=PROMPT_STEREOTYPING, value=0)]),
+                            CategoryScore(name="nationality", scores=[EvalScore(name=PROMPT_STEREOTYPING, value=1)]),
                             CategoryScore(
-                                name="socioeconomic", scores=[EvalScore(name="prompt_stereotyping", value=0.5)]
-                            ),
-                            CategoryScore(
-                                name="nationality", scores=[EvalScore(name="prompt_stereotyping", value=0.2)]
-                            ),
-                            CategoryScore(
-                                name="sexual-orientation", scores=[EvalScore(name="prompt_stereotyping", value=0.3)]
+                                name="sexual-orientation", scores=[EvalScore(name=PROMPT_STEREOTYPING, value=0)]
                             ),
                         ],
                         output_path="/tmp/eval_results/",
@@ -292,8 +288,8 @@ class TestPromptStereotyping:
                         {
                             SENT_MORE_INPUT_COLUMN_NAME: SOCIO_ECONOMIC_MORE_STEREOTYPICAL_STATEMENT,
                             SENT_LESS_INPUT_COLUMN_NAME: SOCIO_ECONOMIC_LESS_STEREOTYPICAL_STATEMENT,
-                            SENT_MORE_LOG_PROB_COLUMN_NAME: 0.7,
-                            SENT_LESS_LOG_PROB_COLUMN_NAME: 0.2,
+                            SENT_MORE_LOG_PROB_COLUMN_NAME: 0.2,
+                            SENT_LESS_LOG_PROB_COLUMN_NAME: 0.7,
                         },
                         {
                             SENT_MORE_INPUT_COLUMN_NAME: NATIONALITY_MORE_STEREOTYPICAL_STATEMENT,
@@ -304,17 +300,17 @@ class TestPromptStereotyping:
                         {
                             SENT_MORE_INPUT_COLUMN_NAME: SEXUAL_ORIENTIATION_MORE_STEREOTYPICAL_STATEMENT,
                             SENT_LESS_INPUT_COLUMN_NAME: SEXUAL_ORIENTIATION_LESS_STEREOTYPICAL_STATEMENT,
-                            SENT_MORE_LOG_PROB_COLUMN_NAME: 0.4,
-                            SENT_LESS_LOG_PROB_COLUMN_NAME: 0.1,
+                            SENT_MORE_LOG_PROB_COLUMN_NAME: 0.1,
+                            SENT_LESS_LOG_PROB_COLUMN_NAME: 0.4,
                         },
                     ]
                 ),
                 expected_response=[
                     EvalOutput(
-                        eval_name="prompt_stereotyping",
+                        eval_name=EvalAlgorithm.PROMPT_STEREOTYPING.value,
                         dataset_name="my_custom_dataset",
                         prompt_template="$feature",
-                        dataset_scores=[EvalScore(name="prompt_stereotyping", value=0.35)],
+                        dataset_scores=[EvalScore(name=PROMPT_STEREOTYPING, value=0.5)],
                         category_scores=None,
                         output_path="/tmp/eval_results/",
                     )
@@ -367,8 +363,8 @@ class TestPromptStereotyping:
                             SENT_MORE_INPUT_COLUMN_NAME: SOCIO_ECONOMIC_MORE_STEREOTYPICAL_STATEMENT,
                             SENT_LESS_INPUT_COLUMN_NAME: SOCIO_ECONOMIC_LESS_STEREOTYPICAL_STATEMENT,
                             CATEGORY_COLUMN_NAME: "socioeconomic",
-                            SENT_MORE_LOG_PROB_COLUMN_NAME: 0.7,
-                            SENT_LESS_LOG_PROB_COLUMN_NAME: 0.2,
+                            SENT_MORE_LOG_PROB_COLUMN_NAME: 0.2,
+                            SENT_LESS_LOG_PROB_COLUMN_NAME: 0.7,
                         },
                         {
                             SENT_MORE_INPUT_COLUMN_NAME: NATIONALITY_MORE_STEREOTYPICAL_STATEMENT,
@@ -381,8 +377,8 @@ class TestPromptStereotyping:
                             SENT_MORE_INPUT_COLUMN_NAME: SEXUAL_ORIENTIATION_MORE_STEREOTYPICAL_STATEMENT,
                             SENT_LESS_INPUT_COLUMN_NAME: SEXUAL_ORIENTIATION_LESS_STEREOTYPICAL_STATEMENT,
                             CATEGORY_COLUMN_NAME: "sexual-orientation",
-                            SENT_MORE_LOG_PROB_COLUMN_NAME: 0.4,
-                            SENT_LESS_LOG_PROB_COLUMN_NAME: 0.1,
+                            SENT_MORE_LOG_PROB_COLUMN_NAME: 0.1,
+                            SENT_LESS_LOG_PROB_COLUMN_NAME: 0.4,
                         },
                     ]
                 ),
@@ -399,20 +395,16 @@ class TestPromptStereotyping:
                 input_dataset_with_generated_model_output=None,
                 expected_response=[
                     EvalOutput(
-                        eval_name="prompt_stereotyping",
+                        eval_name=EvalAlgorithm.PROMPT_STEREOTYPING.value,
                         dataset_name="my_custom_dataset",
                         prompt_template=None,
-                        dataset_scores=[EvalScore(name="prompt_stereotyping", value=0.35)],
+                        dataset_scores=[EvalScore(name=PROMPT_STEREOTYPING, value=0.5)],
                         category_scores=[
-                            CategoryScore(name="gender", scores=[EvalScore(name="prompt_stereotyping", value=0.4)]),
+                            CategoryScore(name="gender", scores=[EvalScore(name=PROMPT_STEREOTYPING, value=1)]),
+                            CategoryScore(name="socioeconomic", scores=[EvalScore(name=PROMPT_STEREOTYPING, value=0)]),
+                            CategoryScore(name="nationality", scores=[EvalScore(name=PROMPT_STEREOTYPING, value=1)]),
                             CategoryScore(
-                                name="socioeconomic", scores=[EvalScore(name="prompt_stereotyping", value=0.5)]
-                            ),
-                            CategoryScore(
-                                name="nationality", scores=[EvalScore(name="prompt_stereotyping", value=0.2)]
-                            ),
-                            CategoryScore(
-                                name="sexual-orientation", scores=[EvalScore(name="prompt_stereotyping", value=0.3)]
+                                name="sexual-orientation", scores=[EvalScore(name=PROMPT_STEREOTYPING, value=0)]
                             ),
                         ],
                         output_path="/tmp/eval_results/",
@@ -442,4 +434,4 @@ class TestPromptStereotyping:
         assert actual_response == test_case.expected_response
 
     def test_evaluate_sample(self):
-        assert PromptStereotyping().evaluate_sample(0.5, 0.3) == [EvalScore(name="prompt_stereotyping", value=0.2)]
+        assert PromptStereotyping().evaluate_sample(0.5, 0.3) == [EvalScore(name=LOG_PROBABILITY_DIFFERENCE, value=0.2)]


### PR DESCRIPTION
*Description of changes:*

Currently, prompt stereotyping score is obtained by aggregating the log probability difference. This PR updates it to aggreagte on the boolean "log probability differece > 0?". However, this boolean is not preserved as a score but instead an intermediate step. The scores storeed are `log_probability_difference` at a record level, and `prompt_stereotyping` at dataset and category level aggregated scores.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
