### PR TITLE
refactor: move refactor: move get_eval_algorithm under amazon_fmeval

### DIFF
--- a/src/amazon_fmeval/__init__.py
+++ b/src/amazon_fmeval/__init__.py
@@ -1,0 +1,18 @@
+from typing import Type
+
+from amazon_fmeval.eval_algo_mapping import EVAL_ALGORITHMS
+from amazon_fmeval.eval_algorithms.eval_algorithm import EvalAlgorithmInterface
+from amazon_fmeval.exceptions import EvalAlgorithmClientError
+
+
+def get_eval_algorithm(eval_name: str) -> Type[EvalAlgorithmInterface]:
+    """
+    Get eval algorithm class with name
+
+    :param eval_name: eval algorithm name
+    :return: eval algorithm class
+    """
+    if eval_name in EVAL_ALGORITHMS:
+        return EVAL_ALGORITHMS[eval_name]
+    else:
+        raise EvalAlgorithmClientError(f"Unknown eval algorithm {eval_name}")

--- a/src/amazon_fmeval/eval_algo_mapping.py
+++ b/src/amazon_fmeval/eval_algo_mapping.py
@@ -7,7 +7,6 @@ from amazon_fmeval.eval_algorithms.prompt_stereotyping import PromptStereotyping
 from amazon_fmeval.eval_algorithms.qa_accuracy import QAAccuracy
 from amazon_fmeval.eval_algorithms.summarization_accuracy import SummarizationAccuracy
 from amazon_fmeval.eval_algorithms.classification_accuracy import ClassificationAccuracy
-from amazon_fmeval.exceptions import EvalAlgorithmClientError
 
 EVAL_ALGORITHMS: Dict[str, Type["EvalAlgorithmInterface"]] = {
     EvalAlgorithm.FACTUAL_KNOWLEDGE.value: FactualKnowledge,
@@ -16,16 +15,3 @@ EVAL_ALGORITHMS: Dict[str, Type["EvalAlgorithmInterface"]] = {
     EvalAlgorithm.PROMPT_STEREOTYPING.value: PromptStereotyping,
     EvalAlgorithm.CLASSIFICATION_ACCURACY.value: ClassificationAccuracy,
 }
-
-
-def get_eval_algorithm(eval_name: str) -> Type["EvalAlgorithmInterface"]:
-    """
-    Get eval algorithm class with name
-
-    :param eval_name: eval algorithm name
-    :return: eval algorithm class
-    """
-    if eval_name in EVAL_ALGORITHMS:
-        return EVAL_ALGORITHMS[eval_name]
-    else:
-        raise EvalAlgorithmClientError(f"Unknown eval algorithm {eval_name}")

--- a/test/unit/test_eval_algo_mapping.py
+++ b/test/unit/test_eval_algo_mapping.py
@@ -1,6 +1,6 @@
 import pytest
 
-from amazon_fmeval.eval_algo_mapping import get_eval_algorithm
+from amazon_fmeval import get_eval_algorithm
 from amazon_fmeval.eval_algorithms.factual_knowledge import FactualKnowledge
 from amazon_fmeval.exceptions import EvalAlgorithmClientError
 


### PR DESCRIPTION
*Description of changes:*
refactor: move get_eval_algo under amazon_fmeval

Earlier, import of `get_eval_algorithm` was `from amazon_fmeval.eval_algo_mapping import get_eval_algorithm` which seems weird. So, I'm moving it under `amazon_fmeval`. Now, it looks like so: `from amazon_fmeval import get_eval_algorithm`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
