### PR TITLE
fix: update devtool all command so that it works when run from a freshly-cloned repo

### DIFF
--- a/devtool
+++ b/devtool
@@ -178,7 +178,7 @@ install_package() {
 all() {
     env_setup
     lint
-    install_poetry
+    install_deps
     unit_test_with_coverage
     build_package
     echo "All build and tests passed. 😊"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently, our Github actions job is doing the following:
```
./devtool env_setup
./devtool install_deps
./devtool unit_test_with_coverage
./devtool build_package
```

`./devtool all` currently does almost the same thing, except instead of step 2, it does `install_poetry` instead of `install_deps`.

As a result, if you run `devtool all` right after cloning this repo, the `unit_test_with_coverage` command will fail because import statements in unit tests will fail. The key command that needs to be run is `poetry install`, which gets called by `install_deps`. This will install not only the project dependencies, but the **project itself**, which is critical for import statements to work.

Note that subsequent calls to `devtool all` will not take a long time re-installing all of the dependencies; if there is no change to the dependencies, `install_deps` is basically a no-op.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
