### PR TITLE
test: fix the tolerance value used by QA accuracy integ test

### DIFF
--- a/test/integration/test_qa_accuracy.py
+++ b/test/integration/test_qa_accuracy.py
@@ -11,7 +11,7 @@ from amazon_fmeval.data_loaders.data_config import DataConfig
 from amazon_fmeval.constants import MIME_TYPE_JSONLINES
 from test.integration.models.model_runners import js_model_runner, js_model_runner_prompt_template
 
-ABS_TOL = 2e-2
+ABS_TOL = 1e-6  # scores and model are deterministic, so approx() should be used purely to handle floating point error
 os.environ["PARALLELIZATION_FACTOR"] = "2"
 
 config = QAAccuracyConfig("<OR>")
@@ -48,8 +48,8 @@ class TestQAAccuracy:
         )[0]
         for eval_score in eval_output.dataset_scores:
             if eval_score.name == F1_SCORE:  # pragma: no branch
-                assert eval_score.value == approx(0.36, abs=ABS_TOL)
+                assert eval_score.value == approx(0.360630, abs=ABS_TOL)
             elif eval_score.name == EXACT_MATCH_SCORE:
-                assert eval_score.value == approx(0.07, abs=ABS_TOL)
+                assert eval_score.value == approx(0.060606, abs=ABS_TOL)
             elif eval_score.name == QUASI_EXACT_MATCH_SCORE:
-                assert eval_score.value == approx(0.29, abs=ABS_TOL)
+                assert eval_score.value == approx(0.303030, abs=ABS_TOL)

--- a/test/integration/test_qa_accuracy_semantic_robustness.py
+++ b/test/integration/test_qa_accuracy_semantic_robustness.py
@@ -1,4 +1,5 @@
 import os
+import random
 from typing import NamedTuple, Dict
 
 import pytest
@@ -12,9 +13,11 @@ from amazon_fmeval.eval_algorithms.qa_accuracy_semantic_robustness import (
     DELTA_F1_SCORE,
     DELTA_EXACT_MATCH_SCORE,
     DELTA_QUASI_EXACT_MATCH_SCORE,
+    ButterFinger,
 )
 from amazon_fmeval.data_loaders.data_config import DataConfig
 from amazon_fmeval.constants import MIME_TYPE_JSONLINES
+from amazon_fmeval.eval_algorithms.semantic_perturbation_utils import ButterFingerConfig
 from test.integration.models.model_runners import sm_model_runner, sm_model_runner_prompt_template
 
 ABS_TOL = 3e-2
@@ -131,3 +134,21 @@ class TestQAAccuracySemanticRobustness:
         )[0]
         for eval_score in eval_output.dataset_scores:
             assert eval_score.value == approx(expected_scores[eval_score.name], abs=ABS_TOL)
+
+    def test_butterfinger(self):
+        bf = ButterFinger(seed=5)
+        config = ButterFingerConfig(0.1)
+        for i in range(10):
+            perturbed_inputs = bf.perturb(
+                text="London is the capital of",
+                config=config,
+                num_perturbations=5,
+            )
+            print(f"Perturbed inputs: {perturbed_inputs}")
+        assert False  # so that print statements get sent to terminal
+
+    def test_random(self):
+        random.seed(5)
+        x = random.choice(range(0, 100))
+        print(x)
+        assert False


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The scores produced when running `evaluate` should be deterministic since `evaluate_sample` is deterministic, and the model runners we use are deterministic. This PR makes the absolute tolerance used by `pytest.approx` much smaller so that any regressions get caught (and don't get overlooked b/c the tolerance was too large).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
