### PR TITLE
feat: removing seed as a parameter for semantic robustness eval configs

### DIFF
--- a/src/amazon_fmeval/eval_algorithms/classification_accuracy_semantic_robustness.py
+++ b/src/amazon_fmeval/eval_algorithms/classification_accuracy_semantic_robustness.py
@@ -84,7 +84,6 @@ class ClassificationAccuracySemanticRobustnessConfig(EvalAlgorithmConfig):
     :param converter_fn: Function to process model output to labels, defaults to simple integer conversion
     :param perturbation_type: perturbation type for generating perturbed inputs
     :param num_perturbations: Number of perturbed inputs to be generated for robustness evaluation
-    :param seed: Seed to be configured for generating perturbations
     :param butter_finger_perturbation_prob: The probability that a given character will be perturbed. Used for
         butter_finger perturbation_type
     :param random_uppercase_corrupt_proportion: Fraction of characters to be changed to uppercase. Used for
@@ -99,7 +98,6 @@ class ClassificationAccuracySemanticRobustnessConfig(EvalAlgorithmConfig):
     converter_fn: Callable[[str, List[str]], str] = convert_model_output_to_label
     perturbation_type: str = BUTTER_FINGER
     num_perturbations: int = 5
-    seed: int = 5
     butter_finger_perturbation_prob: float = 0.1
     random_uppercase_corrupt_proportion: float = 0.1
     whitespace_remove_prob: float = 0.1
@@ -300,9 +298,7 @@ class ClassificationAccuracySemanticRobustness(EvalAlgorithmInterface):
             if model.predict(original_prompt)[0] != original_model_output:
                 raise EvalAlgorithmClientError("For evaluating semantic robustness, the model should be deterministic.")
 
-        perturbation = PERTURBATION_TYPE_TO_HELPER_CLASS[self._eval_algorithm_config.perturbation_type](
-            seed=self._eval_algorithm_config.seed
-        )
+        perturbation = PERTURBATION_TYPE_TO_HELPER_CLASS[self._eval_algorithm_config.perturbation_type]()
 
         perturbed_inputs = perturbation.perturb(
             text=model_input,

--- a/src/amazon_fmeval/eval_algorithms/general_semantic_robustness.py
+++ b/src/amazon_fmeval/eval_algorithms/general_semantic_robustness.py
@@ -15,7 +15,6 @@ from amazon_fmeval.constants import (
     RANDOM_UPPER_CASE,
     WHITESPACE_ADD_REMOVE,
     MODEL_OUTPUT_COLUMN_NAME,
-    NUM_ROWS_DETERMINISTIC,
 )
 from amazon_fmeval.data_loaders.data_config import DataConfig
 from amazon_fmeval.data_loaders.util import get_dataset
@@ -72,7 +71,6 @@ class GeneralSemanticRobustnessConfig(EvalAlgorithmConfig):
 
     :param perturbation_type: perturbation type for generating perturbed inputs
     :param num_perturbations: Number of perturbed inputs to be generated for robustness evaluation
-    :param seed: Seed to be configured for generating perturbations
     :param butter_finger_perturbation_prob: The probability that a given character will be perturbed. Used for
         butter_finger perturbation_type
     :param random_uppercase_corrupt_proportion: Fraction of characters to be changed to uppercase. Used for
@@ -85,7 +83,6 @@ class GeneralSemanticRobustnessConfig(EvalAlgorithmConfig):
 
     perturbation_type: str = BUTTER_FINGER
     num_perturbations: int = 5
-    seed: int = 5
     butter_finger_perturbation_prob: float = 0.1
     random_uppercase_corrupt_proportion: float = 0.1
     whitespace_remove_prob: float = 0.1
@@ -162,9 +159,7 @@ class GeneralSemanticRobustness(EvalAlgorithmInterface):
             if model.predict(original_prompt)[0] != original_model_output:
                 raise EvalAlgorithmClientError("For evaluating semantic robustness, the model should be deterministic.")
 
-        perturbation = PERTURBATION_TYPE_TO_HELPER_CLASS[self._eval_algorithm_config.perturbation_type](
-            seed=self._eval_algorithm_config.seed
-        )
+        perturbation = PERTURBATION_TYPE_TO_HELPER_CLASS[self._eval_algorithm_config.perturbation_type]()
         perturbed_inputs = perturbation.perturb(
             text=model_input,
             config=self._perturbation_config,

--- a/src/amazon_fmeval/eval_algorithms/qa_accuracy_semantic_robustness.py
+++ b/src/amazon_fmeval/eval_algorithms/qa_accuracy_semantic_robustness.py
@@ -90,7 +90,6 @@ class QAAccuracySemanticRobustnessConfig(EvalAlgorithmConfig):
         if the answers are ["UK", "England"] and the delimiter="<OR>", then the target_output should be "UK<OR>England".
     :param perturbation_type: perturbation type for generating perturbed inputs
     :param num_perturbations: Number of perturbed inputs to be generated for robustness evaluation
-    :param seed: Seed to be configured for generating perturbations
     :param butter_finger_perturbation_prob: The probability that a given character will be perturbed. Used for
         butter_finger perturbation_type
     :param random_uppercase_corrupt_proportion: Fraction of characters to be changed to uppercase. Used for
@@ -104,7 +103,6 @@ class QAAccuracySemanticRobustnessConfig(EvalAlgorithmConfig):
     target_output_delimiter: Optional[str] = "<OR>"
     perturbation_type: str = BUTTER_FINGER
     num_perturbations: int = 5
-    seed: int = 5
     butter_finger_perturbation_prob: float = 0.1
     random_uppercase_corrupt_proportion: float = 0.1
     whitespace_remove_prob: float = 0.1
@@ -297,9 +295,7 @@ class QAAccuracySemanticRobustness(EvalAlgorithmInterface):
             if model.predict(original_prompt)[0] != original_model_output:
                 raise EvalAlgorithmClientError("For evaluating semantic robustness, the model should be deterministic.")
 
-        perturbation = PERTURBATION_TYPE_TO_HELPER_CLASS[self._eval_algorithm_config.perturbation_type](
-            seed=self._eval_algorithm_config.seed
-        )
+        perturbation = PERTURBATION_TYPE_TO_HELPER_CLASS[self._eval_algorithm_config.perturbation_type]()
 
         perturbed_inputs = perturbation.perturb(
             text=model_input,

--- a/src/amazon_fmeval/eval_algorithms/semantic_perturbation_utils.py
+++ b/src/amazon_fmeval/eval_algorithms/semantic_perturbation_utils.py
@@ -60,7 +60,7 @@ class SemanticPerturbationUtil(ABC):
     The interface that each perturbation should implement.
     """
 
-    def __init__(self, seed: int = 97123):
+    def __init__(self, seed: int = 5):
         self.set_seed(seed)
 
     @abstractmethod

--- a/src/amazon_fmeval/eval_algorithms/summarization_accuracy_semantic_robustness.py
+++ b/src/amazon_fmeval/eval_algorithms/summarization_accuracy_semantic_robustness.py
@@ -89,7 +89,6 @@ class SummarizationAccuracySemanticRobustnessConfig(EvalAlgorithmConfig):
 
     :param perturbation_type: perturbation type for generating perturbed inputs
     :param num_perturbations: Number of perturbed inputs to be generated for robustness evaluation
-    :param seed: Seed to be configured for generating perturbations
     :param butter_finger_perturbation_prob: The probability that a given character will be perturbed. Used for
         butter_finger perturbation_type
     :param random_uppercase_corrupt_proportion: Fraction of characters to be changed to uppercase. Used for
@@ -105,7 +104,6 @@ class SummarizationAccuracySemanticRobustnessConfig(EvalAlgorithmConfig):
 
     perturbation_type: str = BUTTER_FINGER
     num_perturbations: int = 5
-    seed: int = 5
     butter_finger_perturbation_prob: float = 0.1
     random_uppercase_corrupt_proportion: float = 0.1
     whitespace_remove_prob: float = 0.1
@@ -225,9 +223,7 @@ class SummarizationAccuracySemanticRobustness(EvalAlgorithmInterface):
             if model.predict(original_prompt)[0] != original_model_output:
                 raise EvalAlgorithmClientError("For evaluating semantic robustness, the model should be deterministic.")
 
-        perturbation = PERTURBATION_TYPE_TO_HELPER_CLASS[self._eval_algorithm_config.perturbation_type](
-            seed=self._eval_algorithm_config.seed
-        )
+        perturbation = PERTURBATION_TYPE_TO_HELPER_CLASS[self._eval_algorithm_config.perturbation_type]()
         perturbed_inputs = perturbation.perturb(
             text=model_input,
             config=self._perturbation_config,

--- a/test/integration/test_qa_accuracy_semantic_robustness.py
+++ b/test/integration/test_qa_accuracy_semantic_robustness.py
@@ -31,7 +31,7 @@ class TestQAAccuracySemanticRobustness:
         [
             TestCaseEvaluateSample(
                 config=QAAccuracySemanticRobustnessConfig(
-                    perturbation_type=BUTTER_FINGER, num_perturbations=5, seed=5, butter_finger_perturbation_prob=0.1
+                    perturbation_type=BUTTER_FINGER, num_perturbations=5, butter_finger_perturbation_prob=0.1
                 ),
                 expected_scores={DELTA_F1_SCORE: 0.8, DELTA_EXACT_MATCH_SCORE: 0.8, DELTA_QUASI_EXACT_MATCH_SCORE: 0.8},
             ),
@@ -39,7 +39,6 @@ class TestQAAccuracySemanticRobustness:
                 config=QAAccuracySemanticRobustnessConfig(
                     perturbation_type=RANDOM_UPPER_CASE,
                     num_perturbations=5,
-                    seed=5,
                     random_uppercase_corrupt_proportion=0.1,
                 ),
                 expected_scores={DELTA_F1_SCORE: 1.0, DELTA_EXACT_MATCH_SCORE: 1.0, DELTA_QUASI_EXACT_MATCH_SCORE: 1.0},
@@ -48,7 +47,6 @@ class TestQAAccuracySemanticRobustness:
                 config=QAAccuracySemanticRobustnessConfig(
                     perturbation_type=WHITESPACE_ADD_REMOVE,
                     num_perturbations=5,
-                    seed=5,
                     whitespace_remove_prob=0.1,
                     whitespace_add_prob=0.05,
                 ),
@@ -77,7 +75,7 @@ class TestQAAccuracySemanticRobustness:
         [
             TestCaseEvaluate(
                 config=QAAccuracySemanticRobustnessConfig(
-                    perturbation_type=BUTTER_FINGER, num_perturbations=5, seed=5, butter_finger_perturbation_prob=0.1
+                    perturbation_type=BUTTER_FINGER, num_perturbations=5, butter_finger_perturbation_prob=0.1
                 ),
                 expected_scores={
                     DELTA_F1_SCORE: 0.1879,
@@ -89,7 +87,6 @@ class TestQAAccuracySemanticRobustness:
                 config=QAAccuracySemanticRobustnessConfig(
                     perturbation_type=RANDOM_UPPER_CASE,
                     num_perturbations=5,
-                    seed=5,
                     random_uppercase_corrupt_proportion=0.1,
                 ),
                 expected_scores={
@@ -102,7 +99,6 @@ class TestQAAccuracySemanticRobustness:
                 config=QAAccuracySemanticRobustnessConfig(
                     perturbation_type=WHITESPACE_ADD_REMOVE,
                     num_perturbations=5,
-                    seed=5,
                     whitespace_remove_prob=0.1,
                     whitespace_add_prob=0.05,
                 ),

--- a/test/unit/eval_algorithms/test_semantic_perturbation_utils.py
+++ b/test/unit/eval_algorithms/test_semantic_perturbation_utils.py
@@ -121,3 +121,56 @@ class TestSemanticPerturbationUtils:
             )
             == test_case.expected_outputs
         )
+
+    @pytest.mark.parametrize(
+        "test_case, perturbation_type",
+        [
+            (
+                TestData(
+                    seed=5,
+                    input_text="A quick brown fox jumps over the lazy dog 10 times.",
+                    expected_outputs=[
+                        "A quick trowm fox jumpa over tne lazy dog 10 times.",
+                        "A quicy brodn fud jumps oveg tke lasj dog 10 times.",
+                        "A quick bwown fox jumps ovev the lazy dkg 10 times.",
+                    ],
+                    config=ButterFingerConfig(),
+                    num_perturbations=3,
+                ),
+                ButterFinger,
+            ),
+            (
+                TestData(
+                    seed=5,
+                    input_text="A quick brown fox jumps over the lazy dog 10 times.",
+                    expected_outputs=[
+                        "A quick  brown fox  jumps ove r the lazy dog 10 time s.",
+                        "A quick b row n fo x  jumps over the  lazy dog 10 time s.",
+                        "A quick b rown fox jumps over the lazy dog 10 times.",
+                    ],
+                    config=WhitespaceAddRemoveConfig(),
+                    num_perturbations=3,
+                ),
+                WhitespaceAddRemove,
+            ),
+            (
+                TestData(
+                    seed=5,
+                    input_text="A quick brown fox jumps over the lazy dog 10 times.",
+                    expected_outputs=[
+                        "A quick brown fox jUmps over The Lazy doG 10 times.",
+                        "A quIck brown fox jumps over the lazy dog 10 times.",
+                        "A quick brown Fox jumps over the lAzy dog 10 tImes.",
+                    ],
+                    config=RandomUpperCaseConfig(),
+                    num_perturbations=3,
+                ),
+                RandomUpperCase,
+            ),
+        ],
+    )
+    def test_default_seed(self, test_case, perturbation_type):
+        assert (
+            perturbation_type().perturb(test_case.input_text, test_case.config, test_case.num_perturbations)
+            == test_case.expected_outputs
+        )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
