### PR TITLE
fix(get_dataset): dataset sampling for large datasets

### DIFF
--- a/src/amazon_fmeval/constants.py
+++ b/src/amazon_fmeval/constants.py
@@ -65,3 +65,5 @@ PREFIX_FOR_DELTA_SCORES = "delta_"
 
 # Check if model is deterministic for first NUM_ROWS_DETERMINISTIC rows of dataset
 NUM_ROWS_DETERMINISTIC = 5
+
+MAX_ROWS_TO_TAKE = 1000


### PR DESCRIPTION
*Description of changes:*
dataset sampling for large datasets: For large datasets like `cnn_dailymail` and `xsum`, we were unable to sample the dataset using the `to_pandas()` method - in order to solve for that use case, we are now using `take_batch` as a workaround when there are large datasets. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
