### PR TITLE
fix: use values in algo name map

### DIFF
--- a/src/amazon_fmeval/eval_algo_mapping.py
+++ b/src/amazon_fmeval/eval_algo_mapping.py
@@ -2,7 +2,7 @@ from typing import Dict, Type
 
 from amazon_fmeval.eval_algorithms import EvalAlgorithm
 from amazon_fmeval.eval_algorithms.classification_accuracy_semantic_robustness import (
-    ClassificationAccuracySemanticRobustnessConfig,
+    ClassificationAccuracySemanticRobustness,
 )
 from amazon_fmeval.eval_algorithms.eval_algorithm import EvalAlgorithmInterface
 from amazon_fmeval.eval_algorithms.factual_knowledge import FactualKnowledge
@@ -28,6 +28,6 @@ EVAL_ALGORITHMS: Dict[str, Type["EvalAlgorithmInterface"]] = {
     EvalAlgorithm.SUMMARIZATION_ACCURACY_SEMANTIC_ROBUSTNESS.value: SummarizationAccuracySemanticRobustness,
     EvalAlgorithm.TOXICITY.value: Toxicity,
     EvalAlgorithm.QA_TOXICITY.value: QAToxicity,
-    EvalAlgorithm.SUMMARIZATION_TOXICITY: SummarizationToxicity,
-    EvalAlgorithm.CLASSIFICATION_ACCURACY_SEMANTIC_ROBUSTNESS: ClassificationAccuracySemanticRobustnessConfig,
+    EvalAlgorithm.SUMMARIZATION_TOXICITY.value: SummarizationToxicity,
+    EvalAlgorithm.CLASSIFICATION_ACCURACY_SEMANTIC_ROBUSTNESS.value: ClassificationAccuracySemanticRobustness,
 }


### PR DESCRIPTION
Before:
```
>>> print(amazon_fmeval.EVAL_ALGORITHMS.keys())
dict_keys(['factual_knowledge', 'qa_accuracy', 'summarization_accuracy', 'prompt_stereotyping', 'classification_accuracy', 'general_semantic_robustness', 'summarization_accuracy_semantic_robustness', 'toxicity', 'qa_toxicity', <EvalAlgorithm.SUMMARIZATION_TOXICITY: 'summarization_toxicity'>, <EvalAlgorithm.CLASSIFICATION_ACCURACY_SEMANTIC_ROBUSTNESS: 'classification_accuracy_semantic_robustness'>])
```
After:
```
>>> print(amazon_fmeval.EVAL_ALGORITHMS.keys())
dict_keys(['factual_knowledge', 'qa_accuracy', 'summarization_accuracy', 'prompt_stereotyping', 'classification_accuracy', 'general_semantic_robustness', 'summarization_accuracy_semantic_robustness', 'toxicity', 'qa_toxicity', 'summarization_toxicity', 'classification_accuracy_semantic_robustness'])
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
