### PR TITLE
fix: set default evaluation_algorithm_config

### DIFF
--- a/src/amazon_fmeval/eval_algorithms/factual_knowledge.py
+++ b/src/amazon_fmeval/eval_algorithms/factual_knowledge.py
@@ -68,7 +68,7 @@ class FactualKnowledge(EvalAlgorithmInterface):
     Factual Knowledge Eval algorithm
     """
 
-    def __init__(self, eval_algorithm_config: FactualKnowledgeConfig):
+    def __init__(self, eval_algorithm_config: FactualKnowledgeConfig = FactualKnowledgeConfig()):
         """Default constructor
 
         :param eval_algorithm_config: Factual knowledge eval algorithm config.

--- a/src/amazon_fmeval/eval_algorithms/general_semantic_robustness.py
+++ b/src/amazon_fmeval/eval_algorithms/general_semantic_robustness.py
@@ -109,7 +109,7 @@ class GeneralSemanticRobustness(EvalAlgorithmInterface):
     https://huggingface.co/spaces/evaluate-metric/wer
     """
 
-    def __init__(self, eval_algorithm_config: GeneralSemanticRobustnessConfig):
+    def __init__(self, eval_algorithm_config: GeneralSemanticRobustnessConfig = GeneralSemanticRobustnessConfig()):
         """Default constructor
 
         :param eval_algorithm_config: General Semantic Robustness eval algorithm config.

--- a/src/amazon_fmeval/eval_algorithms/qa_accuracy.py
+++ b/src/amazon_fmeval/eval_algorithms/qa_accuracy.py
@@ -157,7 +157,7 @@ class QAAccuracy(EvalAlgorithmInterface):
 
     eval_name = EvalAlgorithm.QA_ACCURACY.value
 
-    def __init__(self, eval_algorithm_config: QAAccuracyConfig):
+    def __init__(self, eval_algorithm_config: QAAccuracyConfig = QAAccuracyConfig()):
         """Default constructor
 
         :param eval_algorithm_config: QA Accuracy eval algorithm config.

--- a/src/amazon_fmeval/eval_algorithms/qa_accuracy_semantic_robustness.py
+++ b/src/amazon_fmeval/eval_algorithms/qa_accuracy_semantic_robustness.py
@@ -128,7 +128,9 @@ class QAAccuracySemanticRobustness(EvalAlgorithmInterface):
     QA Accuracy Semantic Robustness Eval algorithm
     """
 
-    def __init__(self, eval_algorithm_config: QAAccuracySemanticRobustnessConfig):
+    def __init__(
+        self, eval_algorithm_config: QAAccuracySemanticRobustnessConfig = QAAccuracySemanticRobustnessConfig()
+    ):
         """Default constructor
 
         :param eval_algorithm_config: QA Accuracy Semantic Robustness eval algorithm config.

--- a/src/amazon_fmeval/eval_algorithms/qa_toxicity.py
+++ b/src/amazon_fmeval/eval_algorithms/qa_toxicity.py
@@ -20,7 +20,7 @@ class QAToxicity(Toxicity):
     toxicity eval algo with your custom dataset please refer and use Toxicity eval algo
     """
 
-    def __init__(self, eval_algorithm_config: ToxicityConfig):
+    def __init__(self, eval_algorithm_config: ToxicityConfig = ToxicityConfig()):
         """Default constructor
 
         :param eval_algorithm_config: Toxicity eval algorithm config.

--- a/src/amazon_fmeval/eval_algorithms/summarization_accuracy_semantic_robustness.py
+++ b/src/amazon_fmeval/eval_algorithms/summarization_accuracy_semantic_robustness.py
@@ -146,7 +146,10 @@ class SummarizationAccuracySemanticRobustness(EvalAlgorithmInterface):
     scores.
     """
 
-    def __init__(self, eval_algorithm_config: SummarizationAccuracySemanticRobustnessConfig):
+    def __init__(
+        self,
+        eval_algorithm_config: SummarizationAccuracySemanticRobustnessConfig = SummarizationAccuracySemanticRobustnessConfig(),
+    ):
         """Default constructor
 
         :param eval_algorithm_config: Summarization Accuracy Semantic Robustness eval algorithm config.

--- a/src/amazon_fmeval/eval_algorithms/summarization_toxicity.py
+++ b/src/amazon_fmeval/eval_algorithms/summarization_toxicity.py
@@ -20,7 +20,7 @@ class SummarizationToxicity(Toxicity):
     For consuming toxicity eval algo with your custom dataset please refer and use Toxicity eval algo
     """
 
-    def __init__(self, eval_algorithm_config: ToxicityConfig):
+    def __init__(self, eval_algorithm_config: ToxicityConfig = ToxicityConfig()):
         """Default constructor
 
         :param eval_algorithm_config: Toxicity eval algorithm config.

--- a/src/amazon_fmeval/eval_algorithms/toxicity.py
+++ b/src/amazon_fmeval/eval_algorithms/toxicity.py
@@ -70,7 +70,7 @@ class Toxicity(EvalAlgorithmInterface):
     Toxicity eval algorithm
     """
 
-    def __init__(self, eval_algorithm_config: ToxicityConfig):
+    def __init__(self, eval_algorithm_config: ToxicityConfig = ToxicityConfig()):
         """Default constructor
 
         :param eval_algorithm_config: Toxicity eval algorithm config.


### PR DESCRIPTION
*Description of changes:* 
- set default `evaluation_algorithm_config` for eval algos where all `evaluation_algorithm_config` parameters have default values.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
