### PR TITLE
fix: add qa accuracy semantic robustness to eval_algo_mapping.py

### DIFF
--- a/src/amazon_fmeval/eval_algo_mapping.py
+++ b/src/amazon_fmeval/eval_algo_mapping.py
@@ -9,6 +9,7 @@ from amazon_fmeval.eval_algorithms.factual_knowledge import FactualKnowledge
 from amazon_fmeval.eval_algorithms.general_semantic_robustness import GeneralSemanticRobustness
 from amazon_fmeval.eval_algorithms.prompt_stereotyping import PromptStereotyping
 from amazon_fmeval.eval_algorithms.qa_accuracy import QAAccuracy
+from amazon_fmeval.eval_algorithms.qa_accuracy_semantic_robustness import QAAccuracySemanticRobustness
 from amazon_fmeval.eval_algorithms.qa_toxicity import QAToxicity
 from amazon_fmeval.eval_algorithms.summarization_accuracy import SummarizationAccuracy
 from amazon_fmeval.eval_algorithms.classification_accuracy import ClassificationAccuracy
@@ -19,15 +20,16 @@ from amazon_fmeval.eval_algorithms.summarization_toxicity import SummarizationTo
 from amazon_fmeval.eval_algorithms.toxicity import Toxicity
 
 EVAL_ALGORITHMS: Dict[str, Type["EvalAlgorithmInterface"]] = {
-    EvalAlgorithm.FACTUAL_KNOWLEDGE.value: FactualKnowledge,
-    EvalAlgorithm.QA_ACCURACY.value: QAAccuracy,
-    EvalAlgorithm.SUMMARIZATION_ACCURACY.value: SummarizationAccuracy,
-    EvalAlgorithm.PROMPT_STEREOTYPING.value: PromptStereotyping,
     EvalAlgorithm.CLASSIFICATION_ACCURACY.value: ClassificationAccuracy,
-    EvalAlgorithm.GENERAL_SEMANTIC_ROBUSTNESS.value: GeneralSemanticRobustness,
-    EvalAlgorithm.SUMMARIZATION_ACCURACY_SEMANTIC_ROBUSTNESS.value: SummarizationAccuracySemanticRobustness,
-    EvalAlgorithm.TOXICITY.value: Toxicity,
-    EvalAlgorithm.QA_TOXICITY.value: QAToxicity,
-    EvalAlgorithm.SUMMARIZATION_TOXICITY.value: SummarizationToxicity,
     EvalAlgorithm.CLASSIFICATION_ACCURACY_SEMANTIC_ROBUSTNESS.value: ClassificationAccuracySemanticRobustness,
+    EvalAlgorithm.FACTUAL_KNOWLEDGE.value: FactualKnowledge,
+    EvalAlgorithm.GENERAL_SEMANTIC_ROBUSTNESS.value: GeneralSemanticRobustness,
+    EvalAlgorithm.PROMPT_STEREOTYPING.value: PromptStereotyping,
+    EvalAlgorithm.QA_ACCURACY.value: QAAccuracy,
+    EvalAlgorithm.QA_ACCURACY_SEMANTIC_ROBUSTNESS.value: QAAccuracySemanticRobustness,
+    EvalAlgorithm.QA_TOXICITY.value: QAToxicity,
+    EvalAlgorithm.SUMMARIZATION_ACCURACY.value: SummarizationAccuracy,
+    EvalAlgorithm.SUMMARIZATION_ACCURACY_SEMANTIC_ROBUSTNESS.value: SummarizationAccuracySemanticRobustness,
+    EvalAlgorithm.SUMMARIZATION_TOXICITY.value: SummarizationToxicity,
+    EvalAlgorithm.TOXICITY.value: Toxicity,
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The mapping is currently missing QA Accuracy Semantic Robustness, so if you try running a processing job with that algorithm, it'll fail.

I updated the mapping list to be in alphabetical order to match how Pycharm displays files in the sidemenu so that it's easy to visually confirm that no algorithms in the `eval_algorithms` directory are missing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
