### PR TITLE
fix: fix jmespaths with spaces

### DIFF
--- a/src/amazon_fmeval/eval_algorithms/__init__.py
+++ b/src/amazon_fmeval/eval_algorithms/__init__.py
@@ -282,8 +282,8 @@ DATASET_CONFIGS: Dict[str, DataConfig] = {
         dataset_name=WOMENS_CLOTHING_ECOMMERCE_REVIEWS,
         dataset_uri="s3://amazon-fmeval/datasets/womens_clothing_reviews/womens_clothing_reviews.jsonl",
         dataset_mime_type=MIME_TYPE_JSONLINES,
-        model_input_location="\"Review Text\"",
-        target_output_location="\"Recommended IND\"",
+        model_input_location='"Review Text"',
+        target_output_location='"Recommended IND"',
         category_location="Class Name",
     ),
     BOLD: DataConfig(


### PR DESCRIPTION
*Description of changes:*

Classification algorithms on women's clothing ecommerce review dataset are failing due to `Unable to compile JMESPath Review Text`. This PR fixes the JMESPaths containing spaces.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
