### PR TITLE
fix: jumstart model runner always provides output; optional log_probability

### DIFF
--- a/test/unit/model_runners/test_sm_jumpstart_model_runner.py
+++ b/test/unit/model_runners/test_sm_jumpstart_model_runner.py
@@ -77,12 +77,6 @@ class TestJumpStartModelRunner:
                 log_probability=LOG_PROBABILITY,
             ),
             TestCasePredict(
-                output_jmespath=None,
-                log_probability_jmespath=LOG_PROBABILITY_JMES_PATH,
-                output=None,
-                log_probability=LOG_PROBABILITY,
-            ),
-            TestCasePredict(
                 output_jmespath=OUTPUT_JMES_PATH, log_probability_jmespath=None, output=OUTPUT, log_probability=None
             ),
         ],


### PR DESCRIPTION
*Description of changes:*
jumstart model runner always provides output; optional log_probability. This fixes the issue:
```
huggingface-llm-falcon-7b-bf16 is failing the eval_algorithm because of metadata issues if no model output and model content_template configs are sent.

File \"/var/lang/lib/python3.10/site-packages/amazon_fmeval/eval_algorithms/factual_knowledge.py\", line 214, in _get_score\n model_output_lower_case = model_output.lower()\nAttributeError: 'NoneType' object has no attribute 'lower'" Error: https://tiny.amazon.com/hmqz448j/paste
```
The code used to returns `None` if output was `None`, but in case of JS, this should not happen. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
