### PR TITLE
feat: add dataset details for gigaword and gov_report datasets for reporting

### DIFF
--- a/src/fmeval/reporting/constants.py
+++ b/src/fmeval/reporting/constants.py
@@ -280,7 +280,7 @@ DATASET_DETAILS = {
     ),
     GIGAWORD: DatasetDetails(
         name="Gigaword",
-        url="https://huggingface.co/datasets/gigaword?row=3",
+        url="https://huggingface.co/datasets/gigaword",
         description="A dataset with around 4 million news articles with their summaries. We use the “validation set”, which includes 190k entries.",
         size=189651,
     ),


### PR DESCRIPTION
*Description of changes:*
- Add dataset details for gigaword and gov_report datasets for reporting. Dataset descriptions taken from science documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
