### PR TITLE
fix: sum log prob in JSON extractor

### DIFF
--- a/src/fmeval/model_runners/extractors/json_extractor.py
+++ b/src/fmeval/model_runners/extractors/json_extractor.py
@@ -58,7 +58,7 @@ class JsonExtractor(Extractor):
             return log_probs
         util.require(
             isinstance(log_probs, List) and all(isinstance(value, float) for value in log_probs),
-            f"Extractor found: {log_probs} which does not match expected list of {float}",
+            f"Extractor found: {log_probs} which does not match expected {float} or list of {float}",
         )
         return sum(log_probs)
 

--- a/test/unit/model_runners/extractors/test_json_extractor.py
+++ b/test/unit/model_runners/extractors/test_json_extractor.py
@@ -51,6 +51,6 @@ class TestJsonExtractor:
         )
         with pytest.raises(
             EvalAlgorithmClientError,
-            match="Extractor found: Model response valid which does not match expected list of <class 'float'>",
+            match="Extractor found: Model response valid which does not match expected <class 'float'> or list of <class 'float'>",
         ):
             json_extractor.extract_log_probability(self.valid_model_responses[0], 1)


### PR DESCRIPTION
*Issue #, if available:*
Stereotyping doesnt work with non-Jumpstart models.

*Description of changes:*
We sum the probabilities in Jumpstart extractor but not in JSON extractor. We should do the same. Also removing multi-record partial support.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
