### PR TITLE
fix: change trivia_qa dataset format to jsonl

### DIFF
--- a/src/fmeval/eval_algorithms/__init__.py
+++ b/src/fmeval/eval_algorithms/__init__.py
@@ -255,7 +255,7 @@ DATASET_CONFIGS: Dict[str, DataConfig] = {
     ),
     TRIVIA_QA: DataConfig(
         dataset_name=TRIVIA_QA,
-        dataset_uri="s3://fmeval/datasets/triviaQA/triviaQA.json",
+        dataset_uri="s3://fmeval/datasets/triviaQA/triviaQA.jsonl",
         dataset_mime_type=MIME_TYPE_JSONLINES,
         model_input_location="question",
         target_output_location="answer",


### PR DESCRIPTION
*Description of changes:*
Will replace dataset format in s3 accordingly after this change being approved and merged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
