### PR TITLE
[Draft] fix: increase retries for bedrock_client to avoid throttling errors

### DIFF
--- a/src/fmeval/model_runners/util.py
+++ b/src/fmeval/model_runners/util.py
@@ -62,7 +62,7 @@ def get_sagemaker_session(
 
 def get_bedrock_runtime_client(
     boto_retry_mode: Literal["legacy", "standard", "adaptive"] = "adaptive",
-    retry_attempts: int = 10,
+    retry_attempts: int = 20,
 ) -> boto3.session.Session.client:
     """
     Get Bedrock runtime client with adaptive retry config.


### PR DESCRIPTION
*Issue #, if available:*
Integration tests on the container while running inference for bedrock model client 
```
ThrottlingException: An error occurred (ThrottlingException) when calling the InvokeModel operation (reached max retries: 10): Too many requests, please wait before trying again. You have sent too many requests.  Wait before trying again
```

*Description of changes:*
increase default retries for bedrock_client to avoid throttling errors

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
