### PR TITLE
fix: update the default prompt template for boolq dataset

### DIFF
--- a/src/fmeval/eval_algorithms/__init__.py
+++ b/src/fmeval/eval_algorithms/__init__.py
@@ -216,7 +216,7 @@ EVAL_DATASETS: Dict[str, List[str]] = {
 DEFAULT_PROMPT_TEMPLATE = "$feature"
 
 BUILT_IN_DATASET_DEFAULT_PROMPT_TEMPLATES = {
-    BOOLQ: 'Respond to the following question. Valid answers are "true" or "false". $feature Answer:',
+    BOOLQ: 'Respond to the following question. Valid answers are "True" or "False". $feature Answer:',
     TRIVIA_QA: "Respond to the following question with a short answer: $feature Answer:",
     NATURAL_QUESTIONS: "Respond to the following question with a short answer: $feature Answer:",
     XSUM: "Summarise the following text in one sentence: $feature",


### PR DESCRIPTION
*Description of changes:*
fix: update the default prompt template for boolq dataset. 

We are doing this because we expect the model to respond with `True/False` instead of `true/false` (current instruction says `true/false`). 




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
