### PR TITLE
feat: make sm/br runners easier to subclass

### DIFF
--- a/src/fmeval/model_runners/bedrock_model_runner.py
+++ b/src/fmeval/model_runners/bedrock_model_runner.py
@@ -90,4 +90,4 @@ class BedrockModelRunner(ModelRunner):
             self._content_type,
             self._accept_type,
         )
-        return BedrockModelRunner, serialized_data
+        return self.__class__, serialized_data

--- a/src/fmeval/model_runners/sm_jumpstart_model_runner.py
+++ b/src/fmeval/model_runners/sm_jumpstart_model_runner.py
@@ -111,4 +111,4 @@ class JumpStartModelRunner(ModelRunner):
             self._log_probability,
             self._component_name,
         )
-        return JumpStartModelRunner, serialized_data
+        return self.__class__, serialized_data

--- a/src/fmeval/model_runners/sm_model_runner.py
+++ b/src/fmeval/model_runners/sm_model_runner.py
@@ -102,4 +102,4 @@ class SageMakerModelRunner(ModelRunner):
             self._accept_type,
             self._component_name,
         )
-        return SageMakerModelRunner, serialized_data
+        return self.__class__, serialized_data


### PR DESCRIPTION
*Issue*: when subclassing Jumpstart/SM/Bedrock model runners one has also to override the `__reduce__` function to change the returned class, which is not intuitive 

*Description of changes:* changed return of `__reduce__` functions to `self.__class__` rather than (e.g.) `BedrockRunner`, making overriding of __reduce__ optional (and very likely not necessary).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
