### PR TITLE
feat: conversion of targets to strings

### DIFF
--- a/src/fmeval/eval_algorithms/factual_knowledge.py
+++ b/src/fmeval/eval_algorithms/factual_knowledge.py
@@ -100,7 +100,7 @@ class FactualKnowledge(EvalAlgorithmInterface):
         return [
             EvalScore(
                 name=self.eval_name,
-                value=self._get_score(target_output=target_output, model_output=model_output),
+                value=self._get_score(target_output=str(target_output), model_output=model_output),
             )
         ]
 
@@ -164,7 +164,7 @@ class FactualKnowledge(EvalAlgorithmInterface):
                     Map function generating the scores for every input record in input dataset
                     """
                     row[FACTUAL_KNOWLEDGE] = self._get_score(
-                        row[TARGET_OUTPUT_COLUMN_NAME], row[MODEL_OUTPUT_COLUMN_NAME]
+                        str(row[TARGET_OUTPUT_COLUMN_NAME]), row[MODEL_OUTPUT_COLUMN_NAME]
                     )
                     return row
 

--- a/src/fmeval/eval_algorithms/qa_accuracy.py
+++ b/src/fmeval/eval_algorithms/qa_accuracy.py
@@ -223,7 +223,7 @@ class QAAccuracy(EvalAlgorithmInterface):
                     """
                     for eval_score, eval_fn in QA_ACCURACY_SCORES_TO_FUNCS.items():
                         row[eval_score] = self._get_score(
-                            target_output=row[TARGET_OUTPUT_COLUMN_NAME],
+                            target_output=str(row[TARGET_OUTPUT_COLUMN_NAME]),
                             model_output=row[MODEL_OUTPUT_COLUMN_NAME],
                             eval_fn=eval_fn,
                         )
@@ -293,7 +293,7 @@ class QAAccuracy(EvalAlgorithmInterface):
         return [
             EvalScore(
                 name=eval_score,
-                value=self._get_score(target_output=target_output, model_output=model_output, eval_fn=eval_fn),
+                value=self._get_score(target_output=str(target_output), model_output=model_output, eval_fn=eval_fn),
             )
             for eval_score, eval_fn in QA_ACCURACY_SCORES_TO_FUNCS.items()
         ]


### PR DESCRIPTION
*Issue #, if available:* Factual knowledge and QA evaluations fail if the targets are not string (because we call `split` on the targets). Boolean and integer are common types for targets. One practical issue is that arrow's `to_json` function automatically converts true and false's to boolean even if they are capitalized strings. 

*Description of changes:* Added conversion of targets to strings before calling `_get_score`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
