### PR TITLE
Strip text when computing precision and recall.

### DIFF
--- a/src/fmeval/eval_algorithms/qa_accuracy.py
+++ b/src/fmeval/eval_algorithms/qa_accuracy.py
@@ -94,6 +94,21 @@ def _normalize_text_quac_protocol(text: str) -> str:
     return " ".join([word for word in text.split(" ") if (word != "" and word not in ENGLISH_ARTICLES)])
 
 
+def _normalize_and_strip_text(text: str, *, normalize_text: bool = False, strip_text: bool = False) -> str:
+    """
+    Combine two common operations -- normalization and stripping -- used by several metrics.
+    :param normalize_text: Normalize the text. We use the QuAC protocol for normalization.
+    :param strip_text: Strip the text, that is, remove whitespace characters from the beginning and end of the text.
+    :returns: The normalized (if the normalize_text flag was set to True) and stripped (if the strip_text flag was set
+              to True). If neither of the flags was set, the function returns the original text.
+    """
+    if strip_text:
+        text = text.strip()
+    if normalize_text:  # pragma: no branch
+        text = _normalize_text_quac_protocol(text)
+    return text
+
+
 def _f1_score(
     model_output: str, target_output: str, *, normalize_text: bool = False, strip_text: bool = False
 ) -> float:
@@ -111,10 +126,8 @@ def _f1_score(
     :param strip_text: Strip the model_output and the target_output before computing the f1 score. Stripping amounts to removing whitespace characters from the beginning and end of the strings.
     :returns: The F1 score.
     """
-    if strip_text:
-        model_output, target_output = (text.strip() for text in (model_output, target_output))
-    if normalize_text:  # pragma: no branch
-        model_output, target_output = (_normalize_text_quac_protocol(text) for text in (model_output, target_output))
+    model_output = _normalize_and_strip_text(model_output, normalize_text=normalize_text, strip_text=strip_text)
+    target_output = _normalize_and_strip_text(target_output, normalize_text=normalize_text, strip_text=strip_text)
     ret = f_measure(reference=set(target_output.split(" ")), test=set(model_output.split(" ")))
     if ret is None:  # pragma: no cover
         return 0.0
@@ -122,7 +135,9 @@ def _f1_score(
         return float(ret)
 
 
-def _precision(model_output: str, target_output: str, *, normalize_text: bool = False) -> float:
+def _precision(
+    model_output: str, target_output: str, *, normalize_text: bool = False, strip_text: bool = False
+) -> float:
     """
     Given the model output and the target output, compute the precision.
     Precision is the fraction of words in the prediction that are also found in the target output.
@@ -130,11 +145,12 @@ def _precision(model_output: str, target_output: str, *, normalize_text: bool = 
 
     :param model_output: The output of a model that we want to evaluate.
     :param target_output: The reference or the "ground truth" output.
-    :param normalize_text: Normalize the text before computing f1.
+    :param normalize_text: Normalize the text before computing precision.
+    :param strip_text: Strip the model_output and the target_output before computing precision. Stripping amounts to removing whitespace characters from the beginning and end of the strings.
     :returns: Precision.
     """
-    if normalize_text:  # pragma: no branch
-        model_output, target_output = (_normalize_text_quac_protocol(text) for text in (model_output, target_output))
+    model_output = _normalize_and_strip_text(model_output, normalize_text=normalize_text, strip_text=strip_text)
+    target_output = _normalize_and_strip_text(target_output, normalize_text=normalize_text, strip_text=strip_text)
     ret = precision(reference=set(target_output.split(" ")), test=set(model_output.split(" ")))
     if ret is None:  # pragma: no cover
         return 0.0
@@ -142,7 +158,7 @@ def _precision(model_output: str, target_output: str, *, normalize_text: bool = 
         return float(ret)
 
 
-def _recall(model_output: str, target_output: str, *, normalize_text: bool = False) -> float:
+def _recall(model_output: str, target_output: str, *, normalize_text: bool = False, strip_text: bool = False) -> float:
     """
     Given the model output and the target output, compute the recall.
     Recall is the fraction of words in the target output that are also found in the answer.
@@ -150,11 +166,12 @@ def _recall(model_output: str, target_output: str, *, normalize_text: bool = Fal
 
     :param model_output: The output of a model that we want to evaluate.
     :param target_output: The reference or the "ground truth" output.
-    :param normalize_text: Normalize the text before computing f1.
+    :param normalize_text: Normalize the text before computing recall.
+    :param strip_text: Strip the model_output and the target_output before computing recall. Stripping amounts to removing whitespace characters from the beginning and end of the strings.
     :returns: Recall.
     """
-    if normalize_text:  # pragma: no branch
-        model_output, target_output = (_normalize_text_quac_protocol(text) for text in (model_output, target_output))
+    model_output = _normalize_and_strip_text(model_output, normalize_text=normalize_text, strip_text=strip_text)
+    target_output = _normalize_and_strip_text(target_output, normalize_text=normalize_text, strip_text=strip_text)
     ret = recall(reference=set(target_output.split(" ")), test=set(model_output.split(" ")))
     if ret is None:  # pragma: no cover
         return 0.0

--- a/src/fmeval/eval_algorithms/qa_accuracy.py
+++ b/src/fmeval/eval_algorithms/qa_accuracy.py
@@ -209,8 +209,8 @@ QA_ACCURACY_SCORES_TO_FUNCS: Dict[str, Callable[..., float]] = {
     F1_SCORE: partial(_f1_score, normalize_text=True, strip_text=True),
     EXACT_MATCH_SCORE: _exact_match_score,
     QUASI_EXACT_MATCH_SCORE: _quasi_exact_match_score,
-    PRECISION: partial(_precision, normalize_text=True),
-    RECALL: partial(_recall, normalize_text=True),
+    PRECISION: partial(_precision, normalize_text=True, strip_text=True),
+    RECALL: partial(_recall, normalize_text=True, strip_text=True),
 }
 
 

--- a/test/unit/eval_algorithms/test_qa_accuracy.py
+++ b/test/unit/eval_algorithms/test_qa_accuracy.py
@@ -36,6 +36,8 @@ from fmeval.eval_algorithms.qa_accuracy import (
     RECALL,
     _f1_score,
     _exact_match_score,
+    _precision,
+    _recall,
 )
 from fmeval.exceptions import EvalAlgorithmClientError
 
@@ -611,6 +613,98 @@ class TestQAAccuracy:
     def test_f1_score(self, test_case):
         assert (
             _f1_score(
+                model_output=test_case.model_output,
+                target_output=test_case.target_output,
+                normalize_text=True,
+                strip_text=test_case.strip_text,
+            )
+            == test_case.expected_score
+        )
+
+    @pytest.mark.parametrize(
+        "test_case",
+        [
+            TestCaseQAAccuracyEvalScore(
+                model_output="I live in New York!",
+                target_output="i     live in new york.",
+                strip_text=True,
+                expected_score=1.0,
+            ),
+            TestCaseQAAccuracyEvalScore(
+                model_output="This is a bad movie",
+                target_output="This is a bad movie",
+                strip_text=True,
+                expected_score=1.0,
+            ),
+            TestCaseQAAccuracyEvalScore(
+                model_output="Love this movie",
+                target_output="Hated that film",
+                strip_text=True,
+                expected_score=0.0,
+            ),
+            TestCaseQAAccuracyEvalScore(
+                model_output="yes.\n",
+                target_output="yes",
+                strip_text=True,
+                expected_score=1.0,
+            ),
+            TestCaseQAAccuracyEvalScore(
+                model_output="yes.\n",
+                target_output="yes",
+                strip_text=False,
+                expected_score=0.0,
+            ),
+        ],
+    )
+    def test_precision(self, test_case):
+        assert (
+            _precision(
+                model_output=test_case.model_output,
+                target_output=test_case.target_output,
+                normalize_text=True,
+                strip_text=test_case.strip_text,
+            )
+            == test_case.expected_score
+        )
+
+    @pytest.mark.parametrize(
+        "test_case",
+        [
+            TestCaseQAAccuracyEvalScore(
+                model_output="I live in New York!",
+                target_output="i     live in new york.",
+                strip_text=True,
+                expected_score=1.0,
+            ),
+            TestCaseQAAccuracyEvalScore(
+                model_output="This is a bad movie",
+                target_output="This is a bad movie",
+                strip_text=True,
+                expected_score=1.0,
+            ),
+            TestCaseQAAccuracyEvalScore(
+                model_output="Love this movie",
+                target_output="Hated that film",
+                strip_text=True,
+                expected_score=0.0,
+            ),
+            TestCaseQAAccuracyEvalScore(
+                model_output="yes.\n",
+                target_output="yes",
+                strip_text=True,
+                expected_score=1.0,
+            ),
+            TestCaseQAAccuracyEvalScore(
+                model_output="yes.\n",
+                target_output="yes",
+                strip_text=False,
+                expected_score=0.0,
+            ),
+        ],
+    )
+    def test_recall(self, test_case):
+        assert (
+            _recall(
                 model_output=test_case.model_output,
                 target_output=test_case.target_output,
                 normalize_text=True,


### PR DESCRIPTION
*Description of changes:*
Prior to this PR, we strip the text when computing f1_score but not when computing precision and recall. This PR makes the stripping functionality uniform across all three metrics.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
