### PR TITLE
change prompt_template with summarize instruction

### DIFF
--- a/examples/bedrock-claude-summarization-accuracy.ipynb
+++ b/examples/bedrock-claude-summarization-accuracy.ipynb
@@ -248,7 +248,7 @@
    "source": [
     "eval_algo = SummarizationAccuracy()\n",
     "eval_output = eval_algo.evaluate(model=bedrock_model_runner, dataset_config=config, \n",
-    "                                 prompt_template=\"Human: $feature\\n\\nAssistant:\\n\", save=True)"
+    "                                 prompt_template=\"Human: Summarise the following text in one sentence: $feature\\n\\nAssistant:\\n\", save=True)"
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*

In this example of Summarization accuracy evaluation, prompts "Human: $feature\\n\nAssistant:\\n\" are used. However, since this prompt has no instruction to generate a summary in one sentence, the output of the model produces a result that is far from a summary.

As a way to run a module to perform Evaluation, this prompt is not problematic. In fact, the evaluation method succeeds. However, this prompt could be misinterpreted as the SummarizationAccuracy class having an internally preset instruction of summarization.

*Description of changes:*

This pull request change makes it clear that if a builtin dataset is not used, the user must set the instruction to the prompt_template to match the instruction to the task. Also, the model output will return an appropriate one-sentence summary, and the evaluation score will be improved. This makes the example more relevant to actual use cases.

-----------------
<img width="1075" alt="old_prompt" src="https://github.com/aws/fmeval/assets/65349241/620b5d24-20ac-481a-a311-b5ec7f3e7f8c">
<img width="1064" alt="new_prompt" src="https://github.com/aws/fmeval/assets/65349241/8813076e-3f00-4449-a0a8-cf0193e2c77a">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
