### PR TITLE
[fix] Fix example notebook unit tests

### DIFF
--- a/.github/workflows/unit_test_coverage.yml
+++ b/.github/workflows/unit_test_coverage.yml
@@ -28,12 +28,17 @@ jobs:
         run: |
           ./devtool install_deps
 
-      - name: Test with code coverage
-        run: |
-          ./devtool unit_test_with_coverage
-          echo "All build and tests passed."
-
       - name: Build Package binary wheel
         run: |
           ./devtool build_package
           echo "Package build Succeeded. 😊"
+
+      - name: Install package from wheel
+        run: |
+          ./devtool install_package
+          echo "Installed fmeval package from wheel."
+
+      - name: Test with code coverage
+        run: |
+          ./devtool unit_test_with_coverage
+          echo "All build and tests passed."

--- a/devtool
+++ b/devtool
@@ -176,15 +176,16 @@ install_deps_dev() {
 
 install_package() {
     wheel_name=$(ls -t dist | head -n 1)
-    pip3 install --upgrade dist/$wheel_name --upgrade --upgrade-strategy only-if-needed --force-reinstall
+    pip3 install --upgrade dist/$wheel_name
 }
 
 all() {
     env_setup
     install_deps
     lint
-    unit_test_with_coverage
     build_package
+    install_package
+    unit_test_with_coverage
     echo "All build and tests passed. 😊"
 }
 

--- a/devtool
+++ b/devtool
@@ -176,7 +176,7 @@ install_deps_dev() {
 
 install_package() {
     wheel_name=$(ls -t dist | head -n 1)
-    pip3 install --upgrade dist/$wheel_name
+    pip3 install dist/$wheel_name --force-reinstall
 }
 
 all() {

--- a/test/unit/examples/test_example_notebooks.py
+++ b/test/unit/examples/test_example_notebooks.py
@@ -1,5 +1,7 @@
 import os
 from testbook import testbook
+from testbook.client import TestbookNotebookClient
+
 from fmeval.util import project_root
 
 
@@ -34,7 +36,17 @@ def test_bedrock_model_notebook(tb):
         p4.start()
         """
     )
-    tb.execute()
+
+    # Skip execution of the first code cell, which installs the *currently-released* fmeval package.
+    # We want to test the example notebooks against the package built from the latest code
+    # (see devtool build_package and install_package), not the released package.
+    seen_code_cell = False
+    for index, cell in enumerate(tb.cells):
+        if cell["cell_type"] == "code" and not seen_code_cell:
+            seen_code_cell = True
+            continue
+        super(TestbookNotebookClient, tb).execute_cell(cell, index)
+
     tb.inject(
         """
         p1.stop()
@@ -72,7 +84,17 @@ def test_js_model_notebook(tb):
         p4.start()
         """
     )
-    tb.execute()
+
+    # Skip execution of the first code cell, which installs the *currently-released* fmeval package.
+    # We want to test the example notebooks against the package built from the latest code
+    # (see devtool build_package and install_package), not the released package.
+    seen_code_cell = False
+    for index, cell in enumerate(tb.cells):
+        if cell["cell_type"] == "code" and not seen_code_cell:
+            seen_code_cell = True
+            continue
+        super(TestbookNotebookClient, tb).execute_cell(cell, index)
+
     tb.inject(
         """
         p1.stop()
@@ -110,7 +132,17 @@ def test_custom_model_chat_gpt_notebook(tb):
         p3.start()
         """
     )
-    tb.execute()
+
+    # Skip execution of the first code cell, which installs the *currently-released* fmeval package.
+    # We want to test the example notebooks against the package built from the latest code
+    # (see devtool build_package and install_package), not the released package.
+    seen_code_cell = False
+    for index, cell in enumerate(tb.cells):
+        if cell["cell_type"] == "code" and not seen_code_cell:
+            seen_code_cell = True
+            continue
+        super(TestbookNotebookClient, tb).execute_cell(cell, index)
+
     tb.inject(
         """
         p1.stop()
@@ -153,7 +185,17 @@ def test_custom_model_hf_notebook(tb):
         p4.start()
         """
     )
-    tb.execute()
+
+    # Skip execution of the first code cell, which installs the *currently-released* fmeval package.
+    # We want to test the example notebooks against the package built from the latest code
+    # (see devtool build_package and install_package), not the released package.
+    seen_code_cell = False
+    for index, cell in enumerate(tb.cells):
+        if cell["cell_type"] == "code" and not seen_code_cell:
+            seen_code_cell = True
+            continue
+        super(TestbookNotebookClient, tb).execute_cell(cell, index)
+
     tb.inject(
         """
         p1.stop()


### PR DESCRIPTION
*Description of changes:*

This PR updates the example notebook unit tests so that they use the `fmeval` package that is built from the latest code instead of the package available on PyPI (i.e. the latest released version). Since the example notebooks all have an initial code cell that installs `fmeval` from PyPI, I have updated the unit tests to manually skip the execution of said cell.

The for loop that iterates through `tb.cells` and runs `execute_cell()` is directly copied from the body of `execute()`; I simply added the extra logic for skipping the initial cell. The `testbook` library doesn't provide a good way to skip cells that get run _during_ the test (there is a way to specify cells to run _before_ the test, but that's not what we want to do).

This PR also changes the Github action for running unit tests such that the unit tests are run on the built package, instead of the package installed via `poetry`. This is mainly to follow the good practice of testing against the package that will be released, instead of the "development mode" package.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
