### PR TITLE
fix: Fix example notebook unit tests

### DIFF
--- a/.github/workflows/unit_test_coverage.yml
+++ b/.github/workflows/unit_test_coverage.yml
@@ -24,6 +24,11 @@ jobs:
         run: |
           ./devtool env_setup
 
+      - name: Create virtual env
+        run: |
+          python -m venv .fmeval_venv
+          source .fmeval_venv/bin/activate
+
       - name: Install dependencies with poetry
         run: |
           ./devtool install_deps
@@ -31,7 +36,7 @@ jobs:
       - name: Test with code coverage
         run: |
           ./devtool unit_test_with_coverage
-          echo "All build and tests passed."
+          echo "All build and unit tests passed."
 
       - name: Build Package binary wheel
         run: |

--- a/devtool
+++ b/devtool
@@ -176,7 +176,7 @@ install_deps_dev() {
 
 install_package() {
     wheel_name=$(ls -t dist | head -n 1)
-    pip3 install --upgrade dist/$wheel_name --upgrade --upgrade-strategy only-if-needed --force-reinstall
+    pip3 install dist/$wheel_name --force-reinstall
 }
 
 all() {

--- a/test/unit/example_notebooks/test_example_notebooks.py
+++ b/test/unit/example_notebooks/test_example_notebooks.py
@@ -4,6 +4,27 @@ from testbook.client import TestbookNotebookClient
 from fmeval.util import project_root
 
 
+def execute_notebook_cells(tb: TestbookNotebookClient) -> None:
+    """
+    Performs essentially the exact same behavior as tb.execute(),
+    except it skips the execution of the first code cell.
+
+    The reason behind skipping the first code cell is that for the example notebooks,
+    the first code cell always installs the currently-released fmeval package.
+    This overrides the existing fmeval installation that gets done when we run `poetry install`.
+    We want to test the example notebooks against the latest code, not the released package.
+
+    :param tb: the TestbookNotebookClient used in the example notebook unit test
+    :returns: None
+    """
+    seen_code_cell = False
+    for index, cell in enumerate(tb.cells):
+        if cell["cell_type"] == "code" and not seen_code_cell:
+            seen_code_cell = True
+            continue
+        super(TestbookNotebookClient, tb).execute_cell(cell, index)
+
+
 bedrock_example_notebook_path = os.path.join(
     project_root(__file__), "examples", "bedrock-claude-factual-knowledge.ipynb"
 )
@@ -36,14 +57,7 @@ def test_bedrock_model_notebook(tb):
         """
     )
 
-    # Skip execution of the first code cell, which installs the *currently-released* fmeval package.
-    # We want to test the example notebooks against the latest code, not the released package.
-    seen_code_cell = False
-    for index, cell in enumerate(tb.cells):
-        if cell["cell_type"] == "code" and not seen_code_cell:
-            seen_code_cell = True
-            continue
-        super(TestbookNotebookClient, tb).execute_cell(cell, index)
+    execute_notebook_cells(tb)
 
     tb.inject(
         """
@@ -83,14 +97,7 @@ def test_js_model_notebook(tb):
         """
     )
 
-    # Skip execution of the first code cell, which installs the *currently-released* fmeval package.
-    # We want to test the example notebooks against the latest code, not the released package.
-    seen_code_cell = False
-    for index, cell in enumerate(tb.cells):
-        if cell["cell_type"] == "code" and not seen_code_cell:
-            seen_code_cell = True
-            continue
-        super(TestbookNotebookClient, tb).execute_cell(cell, index)
+    execute_notebook_cells(tb)
 
     tb.inject(
         """
@@ -130,14 +137,7 @@ def test_custom_model_chat_gpt_notebook(tb):
         """
     )
 
-    # Skip execution of the first code cell, which installs the *currently-released* fmeval package.
-    # We want to test the example notebooks against the latest code, not the released package.
-    seen_code_cell = False
-    for index, cell in enumerate(tb.cells):
-        if cell["cell_type"] == "code" and not seen_code_cell:
-            seen_code_cell = True
-            continue
-        super(TestbookNotebookClient, tb).execute_cell(cell, index)
+    execute_notebook_cells(tb)
 
     tb.inject(
         """
@@ -182,14 +182,7 @@ def test_custom_model_hf_notebook(tb):
         """
     )
 
-    # Skip execution of the first code cell, which installs the *currently-released* fmeval package.
-    # We want to test the example notebooks against the latest code, not the released package.
-    seen_code_cell = False
-    for index, cell in enumerate(tb.cells):
-        if cell["cell_type"] == "code" and not seen_code_cell:
-            seen_code_cell = True
-            continue
-        super(TestbookNotebookClient, tb).execute_cell(cell, index)
+    execute_notebook_cells(tb)
 
     tb.inject(
         """

--- a/test/unit/example_notebooks/test_example_notebooks.py
+++ b/test/unit/example_notebooks/test_example_notebooks.py
@@ -1,5 +1,6 @@
 import os
 from testbook import testbook
+from testbook.client import TestbookNotebookClient
 from fmeval.util import project_root
 
 
@@ -34,7 +35,17 @@ def test_bedrock_model_notebook(tb):
         p4.start()
         """
     )
-    tb.execute()
+
+    # Skip execution of the first code cell, which installs the *currently-released* fmeval package.
+    # We want to test the example notebooks against the package built from the latest code
+    # (see devtool build_package and install_package), not the released package.
+    seen_code_cell = False
+    for index, cell in enumerate(tb.cells):
+        if cell["cell_type"] == "code" and not seen_code_cell:
+            seen_code_cell = True
+            continue
+        super(TestbookNotebookClient, tb).execute_cell(cell, index)
+
     tb.inject(
         """
         p1.stop()
@@ -72,7 +83,17 @@ def test_js_model_notebook(tb):
         p4.start()
         """
     )
-    tb.execute()
+
+    # Skip execution of the first code cell, which installs the *currently-released* fmeval package.
+    # We want to test the example notebooks against the package built from the latest code
+    # (see devtool build_package and install_package), not the released package.
+    seen_code_cell = False
+    for index, cell in enumerate(tb.cells):
+        if cell["cell_type"] == "code" and not seen_code_cell:
+            seen_code_cell = True
+            continue
+        super(TestbookNotebookClient, tb).execute_cell(cell, index)
+
     tb.inject(
         """
         p1.stop()
@@ -110,7 +131,17 @@ def test_custom_model_chat_gpt_notebook(tb):
         p3.start()
         """
     )
-    tb.execute()
+
+    # Skip execution of the first code cell, which installs the *currently-released* fmeval package.
+    # We want to test the example notebooks against the package built from the latest code
+    # (see devtool build_package and install_package), not the released package.
+    seen_code_cell = False
+    for index, cell in enumerate(tb.cells):
+        if cell["cell_type"] == "code" and not seen_code_cell:
+            seen_code_cell = True
+            continue
+        super(TestbookNotebookClient, tb).execute_cell(cell, index)
+
     tb.inject(
         """
         p1.stop()
@@ -153,7 +184,17 @@ def test_custom_model_hf_notebook(tb):
         p4.start()
         """
     )
-    tb.execute()
+
+    # Skip execution of the first code cell, which installs the *currently-released* fmeval package.
+    # We want to test the example notebooks against the package built from the latest code
+    # (see devtool build_package and install_package), not the released package.
+    seen_code_cell = False
+    for index, cell in enumerate(tb.cells):
+        if cell["cell_type"] == "code" and not seen_code_cell:
+            seen_code_cell = True
+            continue
+        super(TestbookNotebookClient, tb).execute_cell(cell, index)
+
     tb.inject(
         """
         p1.stop()

--- a/test/unit/example_notebooks/test_example_notebooks.py
+++ b/test/unit/example_notebooks/test_example_notebooks.py
@@ -37,8 +37,7 @@ def test_bedrock_model_notebook(tb):
     )
 
     # Skip execution of the first code cell, which installs the *currently-released* fmeval package.
-    # We want to test the example notebooks against the package built from the latest code
-    # (see devtool build_package and install_package), not the released package.
+    # We want to test the example notebooks against the latest code, not the released package.
     seen_code_cell = False
     for index, cell in enumerate(tb.cells):
         if cell["cell_type"] == "code" and not seen_code_cell:
@@ -85,8 +84,7 @@ def test_js_model_notebook(tb):
     )
 
     # Skip execution of the first code cell, which installs the *currently-released* fmeval package.
-    # We want to test the example notebooks against the package built from the latest code
-    # (see devtool build_package and install_package), not the released package.
+    # We want to test the example notebooks against the latest code, not the released package.
     seen_code_cell = False
     for index, cell in enumerate(tb.cells):
         if cell["cell_type"] == "code" and not seen_code_cell:
@@ -133,8 +131,7 @@ def test_custom_model_chat_gpt_notebook(tb):
     )
 
     # Skip execution of the first code cell, which installs the *currently-released* fmeval package.
-    # We want to test the example notebooks against the package built from the latest code
-    # (see devtool build_package and install_package), not the released package.
+    # We want to test the example notebooks against the latest code, not the released package.
     seen_code_cell = False
     for index, cell in enumerate(tb.cells):
         if cell["cell_type"] == "code" and not seen_code_cell:
@@ -186,8 +183,7 @@ def test_custom_model_hf_notebook(tb):
     )
 
     # Skip execution of the first code cell, which installs the *currently-released* fmeval package.
-    # We want to test the example notebooks against the package built from the latest code
-    # (see devtool build_package and install_package), not the released package.
+    # We want to test the example notebooks against the latest code, not the released package.
     seen_code_cell = False
     for index, cell in enumerate(tb.cells):
         if cell["cell_type"] == "code" and not seen_code_cell:


### PR DESCRIPTION
*Description of changes:*

After PR #180, we've been consistently running into issues where pip installing `fmeval` from pypi within the example notebooks (this installation is always included as the first cell of the notebooks) is causing dependency version issues that cause the `test_custom_model_hf_notebook` test to fail.

Specifically, `tokenizers` is getting re-installed to be a lower version (`0.12.1`) that is used by the current release of `fmeval` , but `transformers` somehow isn't also getting re-installed to its lower version (`4.22.1`); it's still `4.37.2` as dictated by `pyproject.toml`.

This PR updates the example notebook unit tests so that they do not install `fmeval` from pypi. Rather they will continue to use the `fmeval` package installed by poetry during `poetry install`, i.e. the same `fmeval` package that the rest of the unit tests run against.

In order to accomplish this desired behavior, I have updated the unit tests to skip the execution of the first code cell.
The for loop that iterates through `tb.cells` and runs `execute_cell()` is directly copied from the body of `execute()`; I simply added a couple lines of extra logic to skip the first code cell. 

While this is a bit hacky, the testbook library doesn't provide a good way to skip cells that get run during the test (there is a way to specify cells to run before the test, but that's not what we want to do).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
