### PR TITLE
feat: implement Transform abstract base class

### DIFF
--- a/src/fmeval/transforms/transform.py
+++ b/src/fmeval/transforms/transform.py
@@ -1,0 +1,69 @@
+from abc import ABC, abstractmethod
+from copy import deepcopy
+from typing import Any, Dict, List
+from fmeval.util import assert_condition
+
+
+class Transform(ABC):
+    """A Transform represents a single operation that consumes a record and outputs another.
+
+    Typically, the output record is the same object as the input; the Transform simply
+    mutates its input (usually by augmenting it with new data). However, the output
+    record can also be a new object, independent of the input record.
+
+    The logic for creating the output record is implemented in the Transform's __call__ method,
+    which takes a record as its sole argument. Any additional data besides this record
+    that is required to perform the transformation logic should be stored as instance
+    attributes in the Transform.
+    """
+
+    def __init__(self, input_keys: List[str], output_keys: List[str], *args, **kwargs):
+        """Transform initializer.
+
+        Note: concrete subclasses of Transform should always call super().__init__
+        with every argument passed to their own __init__ method. This is because
+        this method will store a copy of all positional arguments in the `args`
+        instance attribute and all keyword arguments in the `kwargs` instance attribute,
+        so that Ray can create copies of this Transform instance when performing
+        parallel execution.
+
+        :param input_keys: The record keys corresponding to data that this Transform
+            requires as inputs.
+        :param output_keys: The keys introduced by this Transform's __call__ logic
+            that will be present in the output record. If this Transform mutates its
+            input, then these keys should be added to the input record.
+            It is the responsibility of the implementer of a Transform to validate
+            that their __call__ method adds only these keys, and no others.
+            See fmeval.transforms.util.validate_added_keys and some built-in
+            Transforms for examples on how to perform such validations.
+        :param *args: Variable length argument list.
+        :param **kwargs: Arbitrary keyword arguments.
+        """
+        assert_condition(
+            isinstance(input_keys, List), "The input_keys argument for Transform.__init__ should be a list."
+        )
+        assert_condition(
+            all(isinstance(input_key, str) for input_key in input_keys),
+            "All keys in the input_keys argument for Transform.__init__ should be strings.",
+        )
+        assert_condition(
+            isinstance(output_keys, List), "The output_keys argument for Transform.__init__ should be a list."
+        )
+        assert_condition(
+            all(isinstance(output_key, str) for output_key in output_keys),
+            "All keys in the output_keys argument for Transform.__init__ should be strings.",
+        )
+        self.input_keys = deepcopy(input_keys)
+        self.output_keys = deepcopy(output_keys)
+        self.args = (self.input_keys, self.output_keys) + deepcopy(args)
+        self.kwargs = deepcopy(kwargs)
+
+    @abstractmethod
+    def __call__(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        """Return a record containing data that gets computed in this method.
+
+        :param record: The input record to be transformed.
+        :returns: A record containing data that gets computed in this method.
+            This record can be the same object as the input record. In this case,
+            the logic in this method should mutate the input record directly.
+        """

--- a/test/unit/transforms/test_transform.py
+++ b/test/unit/transforms/test_transform.py
@@ -1,0 +1,98 @@
+import pytest
+from unittest.mock import patch
+from typing import List, Dict, Any, NamedTuple
+
+from fmeval.exceptions import EvalAlgorithmInternalError
+from fmeval.transforms.transform import Transform
+
+
+class DummyTransform(Transform):
+    def __init__(
+        self,
+        input_keys: List[str],
+        output_keys: List[str],
+        pos_arg_a: List[int],
+        pos_arg_b: Dict[str, Any],
+        kw_arg_a: int = 42,
+        kw_arg_b: str = "Hello",
+    ):
+        super().__init__(input_keys, output_keys, pos_arg_a, pos_arg_b, kw_arg_a=kw_arg_a, kw_arg_b=kw_arg_b)
+
+    def __call__(self, record: Dict[str, Any]):
+        return record
+
+
+def test_transform_init_success():
+    """
+    GIVEN valid initializer arguments.
+    WHEN a subclass of Transform is initialized.
+    THEN the input_keys, output_keys, args, and kwargs attributes of the transform object
+        match what is expected, and deep copies of the relevant data are made.
+    """
+    with patch("fmeval.transforms.transform.deepcopy") as mock_deepcopy:
+        input_keys = ["input"]
+        output_keys = ["output"]
+        pos_arg_a = [162, 189]
+        pos_arg_b = {"k1": ["v1"], "k2": ["v2"]}
+        kw_arg_a = 123
+        kw_arg_b = "Hi"
+
+        mock_deepcopy.side_effect = [
+            ["input_copy"],  # deepcopy called on input_keys
+            ["output_copy"],  # deepcopy called on output_keys
+            ([163, 190], {"k1_copy": ["v1_copy"], "k2_copy": ["v2_copy"]}),  # deepcopy called on (pos_arg_a, pos_arg_b)
+            {124, "Hi_copy"},  # deepcopy called on {"kw_arg_a": kw_arg_a, "kw_arg_b": kw_arg_b}
+        ]
+
+        dummy = DummyTransform(input_keys, output_keys, pos_arg_a, pos_arg_b, kw_arg_a=kw_arg_a, kw_arg_b=kw_arg_b)
+
+        assert dummy.input_keys == ["input_copy"]
+        assert dummy.output_keys == ["output_copy"]
+        assert dummy.args == (
+            ["input_copy"],
+            ["output_copy"],
+            [163, 190],
+            {"k1_copy": ["v1_copy"], "k2_copy": ["v2_copy"]},
+        )
+        assert dummy.kwargs == {124, "Hi_copy"}
+
+
+class TestCaseTransformInitFailure(NamedTuple):
+    input_keys: Any
+    output_keys: Any
+    err_msg: str
+
+
+@pytest.mark.parametrize(
+    "input_keys, output_keys, err_msg",
+    [
+        TestCaseTransformInitFailure(
+            input_keys="input",
+            output_keys=["output"],
+            err_msg="The input_keys argument for Transform.__init__ should be a list.",
+        ),
+        TestCaseTransformInitFailure(
+            input_keys=["input", 123],
+            output_keys=["output"],
+            err_msg="All keys in the input_keys argument for Transform.__init__ should be strings.",
+        ),
+        TestCaseTransformInitFailure(
+            input_keys=["input"],
+            output_keys="output",
+            err_msg="The output_keys argument for Transform.__init__ should be a list.",
+        ),
+        TestCaseTransformInitFailure(
+            input_keys=["input"],
+            output_keys=["output", 123],
+            err_msg="All keys in the output_keys argument for Transform.__init__ should be strings.",
+        ),
+    ],
+)
+def test_transform_init_failure(input_keys, output_keys, err_msg):
+    """
+    GIVEN invalid initializer arguments.
+    WHEN a Transform is initialized.
+    THEN an EvalAlgorithmInternalError is raised.
+    """
+    with pytest.raises(EvalAlgorithmInternalError, match=err_msg):
+        DummyTransform(input_keys, output_keys, [123], {"k": "v"})


### PR DESCRIPTION
*Description of changes:*
This PR implements the `Transform` abstract base class, which is the fundamental "building block" used in the new, modular design for implementing evaluation algorithms and metrics.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
