### PR TITLE
feat: implement GeneratePrompt and GetModelResponse utility transforms

### DIFF
--- a/src/fmeval/transforms/common.py
+++ b/src/fmeval/transforms/common.py
@@ -1,0 +1,108 @@
+from typing import Any, Dict, List
+from fmeval.model_runners.composers.composers import PromptComposer
+from fmeval.model_runners.model_runner import ModelRunner
+from fmeval.transforms.transform import Transform
+from fmeval.transforms.util import (
+    assert_condition,
+    validate_key_uniqueness,
+    validate_existing_keys,
+    validate_added_keys,
+)
+
+
+class GeneratePrompt(Transform):
+    """This transform augments an input record with LLM prompts constructed according to a template.
+
+    If multiple input keys are provided, this transform creates prompts out of all of them,
+    applying the same prompt template to each input.
+    """
+
+    def __init__(self, input_keys: List[str], output_keys: List[str], prompt_template: str):
+        """GeneratePrompt initializer.
+
+        :param input_keys: The keys corresponding to the text that will be used to create prompts.
+            If multiple input keys are provided, a prompt will be constructed from each input, but
+            the created prompts will all utilize the same prompt template.
+        :param output_keys: The keys corresponding to the prompts that get added by this Transform.
+        :param prompt_template: The template used to construct the prompt.
+            Example: "Summarize the following text: $feature".
+        """
+        super().__init__(input_keys, output_keys, prompt_template)
+        self.prompt_composer = PromptComposer(prompt_template)
+
+    def __call__(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        """Augments the input record with LLM prompts and returns said record.
+
+        :param record: The input record.
+        :returns: The input record with prompts added in.
+        """
+        validate_existing_keys(record, self.input_keys)
+        original_keys = set(record.keys())
+
+        for input_key, prompt_key in zip(self.input_keys, self.output_keys):
+            record[prompt_key] = self.prompt_composer.compose(record[input_key])
+
+        # A defensive sanity check; self.output_keys should never be mutated.
+        validate_key_uniqueness(self.output_keys)
+        validate_added_keys(
+            current_keys=set(record.keys()), original_keys=original_keys, keys_to_add=set(self.output_keys)
+        )
+        return record
+
+
+class GetModelResponse(Transform):
+    """This transform augments an input record with a ModelRunner's `predict` response.
+
+    At the moment, this transform only accepts a single input key, meaning that
+    if you wish to invoke the same ModelRunner on a different input, you should
+    instantiate another instance of this class with said input key.
+    """
+
+    def __init__(
+        self,
+        input_keys: List[str],
+        output_keys: List[str],
+        model_runner: ModelRunner,
+    ):
+        """GetModelResponse initializer.
+
+        :param input_keys: A single-element list containing the key corresponding to the ModelRunner's input.
+        :param output_keys: The keys corresponding to the data in the model response payload. Note that
+            this parameter is dependent on the behavior of model_runner's `predict` method. For example,
+            for ModelRunners that do not return log probabilities, `output_keys` should not contain a key
+            for log probabilities.
+        :param model_runner: The ModelRunner instance whose responses will be obtained.
+        """
+        assert_condition(len(input_keys) == 1, "GetModelResponse takes a single input key.")
+        super().__init__(input_keys, output_keys, model_runner)
+        self.model_runner = model_runner
+
+    def __call__(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        """Augments the input record with model responses and returns said record.
+
+        :param record: The input record.
+        :returns: The input record with model response data added in.
+        """
+        validate_existing_keys(record, self.input_keys)
+        original_keys = set(record.keys())
+
+        input_key = self.input_keys[0]
+        model_output, log_prob = self.model_runner.predict(record[input_key])
+        model_response = ((model_output,) if model_output is not None else ()) + (
+            (log_prob,) if log_prob is not None else ()
+        )
+        assert_condition(
+            len(model_response) == len(self.output_keys),
+            f"The number of elements in model response {model_response} "
+            f"does not match number of output keys in {self.output_keys}.",
+        )
+
+        for model_response_item, model_output_key in zip(model_response, self.output_keys):
+            record[model_output_key] = model_response_item
+
+        # A defensive sanity check; self.output_keys should never be mutated.
+        validate_key_uniqueness(self.output_keys)
+        validate_added_keys(
+            current_keys=set(record.keys()), original_keys=original_keys, keys_to_add=set(self.output_keys)
+        )
+        return record

--- a/src/fmeval/transforms/transform.py
+++ b/src/fmeval/transforms/transform.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from typing import Any, Dict, List
+
+from fmeval.transforms.util import validate_key_uniqueness
 from fmeval.util import assert_condition
 
 
@@ -46,6 +48,7 @@ class Transform(ABC):
             all(isinstance(input_key, str) for input_key in input_keys),
             "All keys in the input_keys argument for Transform.__init__ should be strings.",
         )
+        validate_key_uniqueness(input_keys)
         assert_condition(
             isinstance(output_keys, List), "The output_keys argument for Transform.__init__ should be a list."
         )
@@ -53,6 +56,7 @@ class Transform(ABC):
             all(isinstance(output_key, str) for output_key in output_keys),
             "All keys in the output_keys argument for Transform.__init__ should be strings.",
         )
+        validate_key_uniqueness(output_keys)
         self.input_keys = deepcopy(input_keys)
         self.output_keys = deepcopy(output_keys)
         self.args = (self.input_keys, self.output_keys) + deepcopy(args)

--- a/src/fmeval/transforms/util.py
+++ b/src/fmeval/transforms/util.py
@@ -1,8 +1,24 @@
-from typing import Any, Dict, List
-from fmeval.model_runners.composers.composers import PromptComposer
-from fmeval.model_runners.model_runner import ModelRunner
-from fmeval.transforms.transform import Transform
+from typing import Any, Dict, List, Set
 from fmeval.util import assert_condition
+
+
+def validate_key_uniqueness(keys: List[str]) -> None:
+    """Validate that a list of keys contains unique values.
+
+    This function exists to capture the full list of duplicate keys
+    in the error message that is raised, for a better debugging experience.
+
+    :param keys: The keys to be validated.
+    :raises: EvalAlgorithmInternalError if the values in `keys` are not unique.
+    """
+    seen = set()
+    duplicates = []
+    for key in keys:
+        if key in seen:
+            duplicates.append(key)
+        else:
+            seen.add(key)
+    assert_condition(len(duplicates) == 0, f"Duplicate keys found: {duplicates}.")
 
 
 def validate_existing_keys(record: Dict[str, Any], keys: List[str]) -> None:
@@ -12,11 +28,17 @@ def validate_existing_keys(record: Dict[str, Any], keys: List[str]) -> None:
     :param keys: The keys that are expected to be present in the record.
     :raises: EvalAlgorithmInternalError if any validation fails.
     """
+    missing_keys = []
     for key in keys:
-        assert_condition(key in record, f"Record {record} is expected to contain key '{key}', but does not.")
+        if key not in record:
+            missing_keys.append(key)
+    assert_condition(
+        len(missing_keys) == 0,
+        f"Record {record} is expected to contain the following keys, " f"but they are missing: {missing_keys}.",
+    )
 
 
-def validate_added_keys(current_keys: List[str], original_keys: List[str], keys_to_add: List[str]) -> None:
+def validate_added_keys(current_keys: Set[str], original_keys: Set[str], keys_to_add: Set[str]) -> None:
     """Validate that the set difference between `current_keys` and `original_keys` is `keys_to_add`.
 
     Note: this function should only be used when by Transforms that mutate their input record.
@@ -32,111 +54,9 @@ def validate_added_keys(current_keys: List[str], original_keys: List[str], keys_
         `output_keys` attribute.
     :raises: EvalAlgorithmInternalError if any validation fails.
     """
-    current_keys_set = set(current_keys)
     assert_condition(
-        len(current_keys_set) == len(current_keys), f"current_keys list {current_keys} contains a duplicate key."
+        current_keys - original_keys == keys_to_add,
+        f"The set difference between the current keys: {current_keys} "
+        f"and the original keys: {original_keys} does not match "
+        f"the expected keys to be added: {keys_to_add}.",
     )
-    original_keys_set = set(original_keys)
-    assert_condition(
-        len(original_keys_set) == len(original_keys), f"original_keys list {original_keys} contains a duplicate key."
-    )
-    keys_to_add_set = set(keys_to_add)
-    assert_condition(
-        len(keys_to_add_set) == len(keys_to_add), f"keys_to_add list {keys_to_add} contains a duplicate key."
-    )
-    assert_condition(
-        current_keys_set - original_keys_set == keys_to_add_set,
-        f"The set difference between the current keys: {current_keys_set} "
-        f"and the original keys: {original_keys_set} does not match "
-        f"the expected keys to be added: {keys_to_add_set}.",
-    )
-
-
-class GeneratePrompt(Transform):
-    """This transform augments an input record with LLM prompts constructed according to a template.
-
-    If multiple input keys are provided, this transform creates prompts out of all of them,
-    applying the same prompt template to each input.
-    """
-
-    def __init__(self, input_keys: List[str], output_keys: List[str], prompt_template: str):
-        """GeneratePrompt initializer.
-
-        :param input_keys: The keys corresponding to the text that will be used to create prompts.
-            If multiple input keys are provided, a prompt will be constructed from each input, but
-            the created prompts will all utilize the same prompt template.
-        :param output_keys: The keys corresponding to the prompts that get added by this Transform.
-        :param prompt_template: The template used to construct the prompt.
-            Example: "Summarize the following text: $feature".
-        """
-        super().__init__(input_keys, output_keys, prompt_template)
-        self.prompt_composer = PromptComposer(prompt_template)
-
-    def __call__(self, record: Dict[str, Any]) -> Dict[str, Any]:
-        """Augments the input record with LLM prompts and returns said record.
-
-        :param record: The input record.
-        :returns: The input record with prompts added in.
-        """
-        validate_existing_keys(record, self.input_keys)
-        original_keys = list(record.keys())
-
-        for input_key, prompt_key in zip(self.input_keys, self.output_keys):
-            record[prompt_key] = self.prompt_composer.compose(record[input_key])
-
-        validate_added_keys(current_keys=list(record.keys()), original_keys=original_keys, keys_to_add=self.output_keys)
-        return record
-
-
-class GetModelResponse(Transform):
-    """This transform augments an input record with a ModelRunner's `predict` response.
-
-    At the moment, this transform only accepts a single input key, meaning that
-    if you wish to invoke the same ModelRunner on a different input, you should
-    instantiate another instance of this class with said input key.
-    """
-
-    def __init__(
-        self,
-        input_keys: List[str],
-        output_keys: List[str],
-        model_runner: ModelRunner,
-    ):
-        """GetModelResponse initializer.
-
-        :param input_keys: A single-element list containing the key corresponding to the ModelRunner's input.
-        :param output_keys: The keys corresponding to the data in the model response payload. Note that
-            this parameter is dependent on the behavior of model_runner's `predict` method. For example,
-            for ModelRunners that do not return log probabilities, `output_keys` should not contain a key
-            for log probabilities.
-        :param model_runner: The ModelRunner instance whose responses will be obtained.
-        """
-        assert_condition(len(input_keys) == 1, "GetModelResponse takes a single input key.")
-        super().__init__(input_keys, output_keys, model_runner)
-        self.model_runner = model_runner
-
-    def __call__(self, record: Dict[str, Any]) -> Dict[str, Any]:
-        """Augments the input record with model responses and returns said record.
-
-        :param record: The input record.
-        :returns: The input record with model response data added in.
-        """
-        validate_existing_keys(record, self.input_keys)
-        original_keys = list(record.keys())
-
-        input_key = self.input_keys[0]
-        model_output, log_prob = self.model_runner.predict(record[input_key])
-        model_response = ((model_output,) if model_output is not None else ()) + (
-            (log_prob,) if log_prob is not None else ()
-        )
-        assert_condition(
-            len(model_response) == len(self.output_keys),
-            f"The number of elements in model response {model_response} "
-            f"does not match number of output keys in {self.output_keys}.",
-        )
-
-        for model_response_item, model_output_key in zip(model_response, self.output_keys):
-            record[model_output_key] = model_response_item
-
-        validate_added_keys(current_keys=list(record.keys()), original_keys=original_keys, keys_to_add=self.output_keys)
-        return record

--- a/src/fmeval/transforms/util.py
+++ b/src/fmeval/transforms/util.py
@@ -1,0 +1,140 @@
+from typing import Any, Dict, List
+from fmeval.model_runners.composers.composers import PromptComposer
+from fmeval.model_runners.model_runner import ModelRunner
+from fmeval.transforms.transform import Transform
+from fmeval.util import assert_condition
+
+
+def validate_existing_keys(record: Dict[str, Any], keys: List[str]) -> None:
+    """Validate that all expected keys are present in a record.
+
+    :param record: The record to be validated.
+    :param keys: The keys that are expected to be present in the record.
+    :raises: EvalAlgorithmInternalError if any validation fails.
+    """
+    for key in keys:
+        assert_condition(key in record, f"Record {record} is expected to contain key '{key}', but does not.")
+
+
+def validate_added_keys(current_keys: List[str], original_keys: List[str], keys_to_add: List[str]) -> None:
+    """Validate that the set difference between `current_keys` and `original_keys` is `keys_to_add`.
+
+    Note: this function should only be used when by Transforms that mutate their input record.
+    It doesn't make sense to call this function if the Transform constructs a new record to
+    be used as output, since said output record need not contain all the keys in the input record.
+
+    :param current_keys: The keys that are currently present in a record.
+    :param original_keys: The keys that were originally present in a record
+        (prior to performing transform-specific logic, which adds new keys).
+    :param keys_to_add: The keys that a transform should have added to its input record.
+        When this function is called from within a Transform's __call__ method (which should
+        be the primary use case for this function), this parameter should be the transform's
+        `output_keys` attribute.
+    :raises: EvalAlgorithmInternalError if any validation fails.
+    """
+    current_keys_set = set(current_keys)
+    assert_condition(
+        len(current_keys_set) == len(current_keys), f"current_keys list {current_keys} contains a duplicate key."
+    )
+    original_keys_set = set(original_keys)
+    assert_condition(
+        len(original_keys_set) == len(original_keys), f"original_keys list {original_keys} contains a duplicate key."
+    )
+    keys_to_add_set = set(keys_to_add)
+    assert_condition(
+        len(keys_to_add_set) == len(keys_to_add), f"keys_to_add list {keys_to_add} contains a duplicate key."
+    )
+    assert_condition(
+        current_keys_set - original_keys_set == keys_to_add_set,
+        f"The set difference between the current keys: {current_keys_set} "
+        f"and the original keys: {original_keys_set} does not match "
+        f"the expected keys to be added: {keys_to_add_set}.",
+    )
+
+
+class GeneratePrompt(Transform):
+    """This transform augments an input record with LLM prompts constructed according to a template.
+
+    If multiple input keys are provided, this transform creates prompts out of all of them,
+    applying the same prompt template to each input.
+    """
+    def __init__(self, input_keys: List[str], output_keys: List[str], prompt_template: str):
+        """GeneratePrompt initializer.
+
+        :param input_keys: The keys corresponding to the text that will be used to create prompts.
+            If multiple input keys are provided, a prompt will be constructed from each input, but
+            the created prompts will all utilize the same prompt template.
+        :param output_keys: The keys corresponding to the prompts that get added by this Transform.
+        :param prompt_template: The template used to construct the prompt.
+            Example: "Summarize the following text: $feature".
+        """
+        super().__init__(input_keys, output_keys, prompt_template)
+        self.prompt_composer = PromptComposer(prompt_template)
+
+    def __call__(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        """Augments the input record with LLM prompts and returns said record.
+
+        :param record: The input record.
+        :returns: The input record with prompts added in.
+        """
+        validate_existing_keys(record, self.input_keys)
+        original_keys = list(record.keys())
+
+        for input_key, prompt_key in zip(self.input_keys, self.output_keys):
+            record[prompt_key] = self.prompt_composer.compose(record[input_key])
+
+        validate_added_keys(current_keys=list(record.keys()), original_keys=original_keys, keys_to_add=self.output_keys)
+        return record
+
+
+class GetModelResponse(Transform):
+    """This transform augments an input record with a ModelRunner's `predict` response.
+
+    At the moment, this transform only accepts a single input key, meaning that
+    if you wish to invoke the same ModelRunner on a different input, you should
+    instantiate another instance of this class with said input key.
+    """
+    def __init__(
+        self,
+        input_keys: List[str],
+        output_keys: List[str],
+        model_runner: ModelRunner,
+    ):
+        """GetModelResponse initializer.
+
+        :param input_keys: A single-element list containing the key corresponding to the ModelRunner's input.
+        :param output_keys: The keys corresponding to the data in the model response payload. Note that
+            this parameter is dependent on the behavior of model_runner's `predict` method. For example,
+            for ModelRunners that do not return log probabilities, `output_keys` should not contain a key
+            for log probabilities.
+        :param model_runner: The ModelRunner instance whose responses will be obtained.
+        """
+        assert_condition(len(input_keys) == 1, "GetModelResponse takes a single input key.")
+        super().__init__(input_keys, output_keys, model_runner)
+        self.model_runner = model_runner
+
+    def __call__(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        """Augments the input record with model responses and returns said record.
+
+        :param record: The input record.
+        :returns: The input record with model response data added in.
+        """
+        validate_existing_keys(record, self.input_keys)
+        original_keys = list(record.keys())
+
+        input_key = self.input_keys[0]
+        model_output, log_prob = self.model_runner.predict(record[input_key])
+        model_response = (
+            ((model_output,) if model_output is not None else ()) + ((log_prob,) if log_prob is not None else ())
+        )
+        assert_condition(
+            len(model_response) == len(self.output_keys),
+            f"The number of elements in model response {model_response} "
+            f"does not match number of output keys in {self.output_keys}.",
+        )
+
+        for model_response_item, model_output_key in zip(model_response, self.output_keys):
+            record[model_output_key] = model_response_item
+
+        validate_added_keys(current_keys=list(record.keys()), original_keys=original_keys, keys_to_add=self.output_keys)
+        return record

--- a/src/fmeval/transforms/util.py
+++ b/src/fmeval/transforms/util.py
@@ -58,6 +58,7 @@ class GeneratePrompt(Transform):
     If multiple input keys are provided, this transform creates prompts out of all of them,
     applying the same prompt template to each input.
     """
+
     def __init__(self, input_keys: List[str], output_keys: List[str], prompt_template: str):
         """GeneratePrompt initializer.
 
@@ -94,6 +95,7 @@ class GetModelResponse(Transform):
     if you wish to invoke the same ModelRunner on a different input, you should
     instantiate another instance of this class with said input key.
     """
+
     def __init__(
         self,
         input_keys: List[str],
@@ -124,8 +126,8 @@ class GetModelResponse(Transform):
 
         input_key = self.input_keys[0]
         model_output, log_prob = self.model_runner.predict(record[input_key])
-        model_response = (
-            ((model_output,) if model_output is not None else ()) + ((log_prob,) if log_prob is not None else ())
+        model_response = ((model_output,) if model_output is not None else ()) + (
+            (log_prob,) if log_prob is not None else ()
         )
         assert_condition(
             len(model_response) == len(self.output_keys),

--- a/test/unit/transforms/test_common.py
+++ b/test/unit/transforms/test_common.py
@@ -1,0 +1,144 @@
+import pytest
+from unittest.mock import patch
+from typing import NamedTuple, List, Optional, Dict, Any
+from fmeval.transforms.common import GeneratePrompt, GetModelResponse
+from fmeval.util import EvalAlgorithmInternalError
+
+
+def test_generate_prompt_init():
+    """
+    GIVEN valid initializer arguments.
+    WHEN a GeneratePrompt object is instantiated.
+    THEN the instance's attributes match what is expected.
+    """
+    with patch("fmeval.transforms.common.PromptComposer") as mock_prompt_composer:
+        gen_prompt = GeneratePrompt(["model_input"], ["prompt"], "Summarize the following: $feature")
+        assert gen_prompt.input_keys == ["model_input"]
+        assert gen_prompt.output_keys == ["prompt"]
+        mock_prompt_composer.assert_called_once_with("Summarize the following: $feature")
+
+
+def test_generate_prompt_call():
+    """
+    GIVEN a GeneratePrompt instance.
+    WHEN its __call__ method is called on a record.
+    THEN the correct output is returned.
+    """
+    gen_prompt = GeneratePrompt(["input_1", "input_2"], ["prompt_1", "prompt_2"], "Summarize the following: $feature")
+    sample = {"input_1": "Hello", "input_2": "world"}
+    result = gen_prompt(sample)
+    assert result == {
+        "input_1": "Hello",
+        "input_2": "world",
+        "prompt_1": "Summarize the following: Hello",
+        "prompt_2": "Summarize the following: world",
+    }
+
+
+def test_get_model_response_init_success():
+    """
+    GIVEN valid initializer arguments.
+    WHEN a GeneratePrompt object is instantiated.
+    THEN the instance's attributes match what is expected.
+    """
+    with patch("fmeval.transforms.common.ModelRunner") as mock_model_runner:
+        get_model_response = GetModelResponse(["prompt"], ["model_output"], mock_model_runner)
+        assert get_model_response.input_keys == ["prompt"]
+        assert get_model_response.output_keys == ["model_output"]
+        assert get_model_response.model_runner == mock_model_runner
+
+
+def test_get_model_response_init_failure():
+    """
+    GIVEN a list of input keys where the number of keys != 1.
+    WHEN a GeneratePrompt object is instantiated.
+    THEN an EvalAlgorithmInternalError is raised.
+    """
+    with pytest.raises(EvalAlgorithmInternalError, match="GetModelResponse takes a single input key."):
+        with patch("fmeval.transforms.common.ModelRunner") as mock_model_runner:
+            GetModelResponse(["prompt_1", "prompt_2"], ["model_output_1", "model_output_2"], mock_model_runner)
+
+
+class TestCaseGetModelResponseSuccess(NamedTuple):
+    model_output: Optional[str]
+    log_prob: Optional[float]
+    output_keys: List[str]
+    expected_result: Dict[str, Any]
+
+
+@pytest.mark.parametrize(
+    "model_output, log_prob, output_keys, expected_result",
+    [
+        TestCaseGetModelResponseSuccess(
+            model_output="some output",
+            log_prob=-0.162,
+            output_keys=["model_output", "log_prob"],
+            expected_result={"input": "Hello", "model_output": "some output", "log_prob": -0.162},
+        ),
+        TestCaseGetModelResponseSuccess(
+            model_output="some output",
+            log_prob=None,
+            output_keys=["model_output"],
+            expected_result={"input": "Hello", "model_output": "some output"},
+        ),
+        TestCaseGetModelResponseSuccess(
+            model_output=None,
+            log_prob=-0.162,
+            output_keys=["log_prob"],
+            expected_result={"input": "Hello", "log_prob": -0.162},
+        ),
+    ],
+)
+def test_get_model_response_call_success(model_output, log_prob, output_keys, expected_result):
+    """
+    GIVEN a GetModelResponse instance.
+    WHEN its __call__ method is called on a record.
+    THEN the correct output is returned.
+    """
+    with patch("fmeval.transforms.common.ModelRunner") as mock_model_runner:
+        mock_model_runner.predict.return_value = (model_output, log_prob)
+        get_model_response = GetModelResponse(["input"], output_keys, mock_model_runner)
+        sample = {"input": "Hello"}
+        result = get_model_response(sample)
+        assert result == expected_result
+
+
+class TestCaseGetModelResponseFailure(NamedTuple):
+    model_output: Optional[str]
+    log_prob: Optional[float]
+    output_keys: List[str]
+
+
+@pytest.mark.parametrize(
+    "model_output, log_prob, output_keys",
+    [
+        TestCaseGetModelResponseFailure(
+            model_output="some output",
+            log_prob=-0.162,
+            output_keys=["model_output"],
+        ),
+        TestCaseGetModelResponseFailure(
+            model_output="some output",
+            log_prob=None,
+            output_keys=["model_output", "log_prob"],
+        ),
+        TestCaseGetModelResponseFailure(
+            model_output=None,
+            log_prob=-0.162,
+            output_keys=["model_output", "log_prob"],
+        ),
+    ],
+)
+def test_get_model_response_call_failure(model_output, log_prob, output_keys):
+    """
+    GIVEN a GetModelResponse instance whose `output_keys` attribute has a different number of elements
+        than the number of non-null elements in its model runner's predict() response.
+    WHEN its __call__ method is called.
+    THEN an EvalAlgorithmInternalError is raised.
+    """
+    sample = {"input": "Hello"}
+    with patch("fmeval.transforms.common.ModelRunner") as mock_model_runner:
+        mock_model_runner.predict.return_value = (model_output, log_prob)
+        get_model_response = GetModelResponse(["input"], output_keys, mock_model_runner)
+        with pytest.raises(EvalAlgorithmInternalError, match="The number of elements in model response"):
+            get_model_response(sample)

--- a/test/unit/transforms/test_transform.py
+++ b/test/unit/transforms/test_transform.py
@@ -77,6 +77,11 @@ class TestCaseTransformInitFailure(NamedTuple):
             err_msg="All keys in the input_keys argument for Transform.__init__ should be strings.",
         ),
         TestCaseTransformInitFailure(
+            input_keys=["input_1", "input_2", "input_1", "input_1"],
+            output_keys=["output"],
+            err_msg="Duplicate keys found: ",
+        ),
+        TestCaseTransformInitFailure(
             input_keys=["input"],
             output_keys="output",
             err_msg="The output_keys argument for Transform.__init__ should be a list.",
@@ -85,6 +90,11 @@ class TestCaseTransformInitFailure(NamedTuple):
             input_keys=["input"],
             output_keys=["output", 123],
             err_msg="All keys in the output_keys argument for Transform.__init__ should be strings.",
+        ),
+        TestCaseTransformInitFailure(
+            input_keys=["input_1", "input_2"],
+            output_keys=["output_1", "output_2", "output_1", "output_1"],
+            err_msg="Duplicate keys found: ",
         ),
     ],
 )

--- a/test/unit/transforms/test_util.py
+++ b/test/unit/transforms/test_util.py
@@ -1,0 +1,224 @@
+import pytest
+from unittest.mock import patch
+from typing import NamedTuple, List, Optional, Dict, Any
+from fmeval.transforms.util import validate_added_keys, validate_existing_keys, GeneratePrompt, GetModelResponse
+from fmeval.util import EvalAlgorithmInternalError
+
+
+def test_validate_existing_keys_success():
+    """
+    GIVEN a record containing all expected keys.
+    WHEN validate_existing_keys is called.
+    THEN no exception is raised.
+    """
+    record = {"a": 1, "b": 2, "c": 3, "d": 4}
+    keys = ["a", "b", "c"]
+    validate_existing_keys(record, keys)
+
+
+def test_validate_existing_keys_failure():
+    """
+    GIVEN a record that is missing an expected key.
+    WHEN validate_existing_keys is called.
+    THEN an EvalAlgorithmInternalError is raised.
+    """
+    record = {"a": 1, "b": 2, "d": 4}
+    keys = ["a", "b", "c"]
+    with pytest.raises(
+        EvalAlgorithmInternalError, match=f"Record {record} is expected to contain key 'c', but does not."
+    ):
+        validate_existing_keys(record, keys)
+
+
+def test_validate_added_keys_success():
+    """
+    GIVEN arguments that should not raise an exception.
+    WHEN validate_added_keys is called.
+    THEN no exception is raised.
+    """
+    current_keys = ["a", "b", "c", "d"]
+    original_keys = ["a", "c"]
+    keys_to_add = ["b", "d"]
+    validate_added_keys(current_keys, original_keys, keys_to_add)
+
+
+class TestCaseValidateAddedKeys(NamedTuple):
+    current_keys: List[str]
+    original_keys: List[str]
+    keys_to_add: List[str]
+    err_msg: str
+
+
+@pytest.mark.parametrize(
+    "current_keys, original_keys, keys_to_add, err_msg",
+    [
+        TestCaseValidateAddedKeys(
+            current_keys=["a", "b", "b"], original_keys=["a"], keys_to_add=["b"], err_msg="current_keys list"
+        ),
+        TestCaseValidateAddedKeys(
+            current_keys=["a", "b"], original_keys=["a", "a"], keys_to_add=["b"], err_msg="original_keys list"
+        ),
+        TestCaseValidateAddedKeys(
+            current_keys=["a", "b"], original_keys=["a"], keys_to_add=["b", "b"], err_msg="keys_to_add list"
+        ),
+        TestCaseValidateAddedKeys(
+            current_keys=["a", "b", "c", "d"], original_keys=["a", "c"], keys_to_add=["b"], err_msg="The set difference"
+        ),
+        TestCaseValidateAddedKeys(
+            current_keys=["a", "b", "c"], original_keys=["a", "c"], keys_to_add=["b", "d"], err_msg="The set difference"
+        ),
+    ],
+)
+def test_validate_added_keys_failure(
+    current_keys: List[str], original_keys: List[str], keys_to_add: List[str], err_msg: str
+):
+    """
+    GIVEN arguments that should raise an exception.
+    WHEN validate_added_keys is called.
+    THEN an EvalAlgorithmInternalError is raised.
+    """
+    with pytest.raises(EvalAlgorithmInternalError, match=err_msg):
+        validate_added_keys(current_keys, original_keys, keys_to_add)
+
+
+def test_generate_prompt_init():
+    """
+    GIVEN valid initializer arguments.
+    WHEN a GeneratePrompt object is instantiated.
+    THEN the instance's attributes match what is expected.
+    """
+    with patch("fmeval.transforms.util.PromptComposer") as mock_prompt_composer:
+        gen_prompt = GeneratePrompt(["model_input"], ["prompt"], "Summarize the following: $feature")
+        assert gen_prompt.input_keys == ["model_input"]
+        assert gen_prompt.output_keys == ["prompt"]
+        mock_prompt_composer.assert_called_once_with("Summarize the following: $feature")
+
+
+def test_generate_prompt_call():
+    """
+    GIVEN a GeneratePrompt instance.
+    WHEN its __call__ method is called on a record.
+    THEN the correct output is returned.
+    """
+    gen_prompt = GeneratePrompt(["input_1", "input_2"], ["prompt_1", "prompt_2"], "Summarize the following: $feature")
+    sample = {"input_1": "Hello", "input_2": "world"}
+    result = gen_prompt(sample)
+    assert result == {
+        "input_1": "Hello",
+        "input_2": "world",
+        "prompt_1": "Summarize the following: Hello",
+        "prompt_2": "Summarize the following: world",
+    }
+
+
+def test_get_model_response_init_success():
+    """
+    GIVEN valid initializer arguments.
+    WHEN a GeneratePrompt object is instantiated.
+    THEN the instance's attributes match what is expected.
+    """
+    with patch("fmeval.transforms.util.ModelRunner") as mock_model_runner:
+        get_model_response = GetModelResponse(["prompt"], ["model_output"], mock_model_runner)
+        assert get_model_response.input_keys == ["prompt"]
+        assert get_model_response.output_keys == ["model_output"]
+        assert get_model_response.model_runner == mock_model_runner
+
+
+def test_get_model_response_init_failure():
+    """
+    GIVEN a list of input keys where the number of keys != 1.
+    WHEN a GeneratePrompt object is instantiated.
+    THEN an EvalAlgorithmInternalError is raised.
+    """
+    with pytest.raises(EvalAlgorithmInternalError, match="GetModelResponse takes a single input key."):
+        with patch("fmeval.transforms.util.ModelRunner") as mock_model_runner:
+            GetModelResponse(
+                ["prompt_1", "prompt_2"],
+                ["model_output_1", "model_output_2"],
+                mock_model_runner
+            )
+
+
+class TestCaseGetModelResponseSuccess(NamedTuple):
+    model_output: Optional[str]
+    log_prob: Optional[float]
+    output_keys: List[str]
+    expected_result: Dict[str, Any]
+
+
+@pytest.mark.parametrize(
+    "model_output, log_prob, output_keys, expected_result",
+    [
+        TestCaseGetModelResponseSuccess(
+            model_output="some output",
+            log_prob=-0.162,
+            output_keys=["model_output", "log_prob"],
+            expected_result={"input": "Hello", "model_output": "some output", "log_prob": -0.162}
+        ),
+        TestCaseGetModelResponseSuccess(
+            model_output="some output",
+            log_prob=None,
+            output_keys=["model_output"],
+            expected_result={"input": "Hello", "model_output": "some output"}
+        ),
+        TestCaseGetModelResponseSuccess(
+            model_output=None,
+            log_prob=-0.162,
+            output_keys=["log_prob"],
+            expected_result={"input": "Hello", "log_prob": -0.162}
+        ),
+    ]
+)
+def test_get_model_response_call_success(model_output, log_prob, output_keys, expected_result):
+    """
+    GIVEN a GetModelResponse instance.
+    WHEN its __call__ method is called on a record.
+    THEN the correct output is returned.
+    """
+    with patch("fmeval.transforms.util.ModelRunner") as mock_model_runner:
+        mock_model_runner.predict.return_value = (model_output, log_prob)
+        get_model_response = GetModelResponse(["input"], output_keys, mock_model_runner)
+        sample = {"input": "Hello"}
+        result = get_model_response(sample)
+        assert result == expected_result
+
+
+class TestCaseGetModelResponseFailure(NamedTuple):
+    model_output: Optional[str]
+    log_prob: Optional[float]
+    output_keys: List[str]
+
+
+@pytest.mark.parametrize(
+    "model_output, log_prob, output_keys",
+    [
+        TestCaseGetModelResponseFailure(
+            model_output="some output",
+            log_prob=-0.162,
+            output_keys=["model_output"],
+        ),
+        TestCaseGetModelResponseFailure(
+            model_output="some output",
+            log_prob=None,
+            output_keys=["model_output", "log_prob"],
+        ),
+        TestCaseGetModelResponseFailure(
+            model_output=None,
+            log_prob=-0.162,
+            output_keys=["model_output", "log_prob"],
+        ),
+    ]
+)
+def test_get_model_response_call_failure(model_output, log_prob, output_keys):
+    """
+    GIVEN a GetModelResponse instance whose `output_keys` attribute has a different number of elements
+        than the number of non-null elements in its model runner's predict() response.
+    WHEN its __call__ method is called.
+    THEN an EvalAlgorithmInternalError is raised.
+    """
+    sample = {"input": "Hello"}
+    with patch("fmeval.transforms.util.ModelRunner") as mock_model_runner:
+        mock_model_runner.predict.return_value = (model_output, log_prob)
+        get_model_response = GetModelResponse(["input"], output_keys, mock_model_runner)
+        with pytest.raises(EvalAlgorithmInternalError, match="The number of elements in model response"):
+            get_model_response(sample)

--- a/test/unit/transforms/test_util.py
+++ b/test/unit/transforms/test_util.py
@@ -1,8 +1,30 @@
+import re
 import pytest
-from unittest.mock import patch
-from typing import NamedTuple, List, Optional, Dict, Any
-from fmeval.transforms.util import validate_added_keys, validate_existing_keys, GeneratePrompt, GetModelResponse
+from typing import NamedTuple, Set
+from fmeval.transforms.util import validate_added_keys, validate_existing_keys, validate_key_uniqueness
 from fmeval.util import EvalAlgorithmInternalError
+
+
+def test_validate_key_uniqueness_success():
+    """
+    GIVEN a list of unique keys.
+    WHEN validate_key_uniqueness is called.
+    THEN no error is raised.
+    """
+    keys = ["a", "b", "c"]
+    validate_key_uniqueness(keys)
+
+
+def test_validate_key_uniqueness_failure():
+    """
+    GIVEN a list of non-unique keys.
+    WHEN validate_key_uniqueness is called.
+    THEN an EvalAlgorithmInternalError with the correct message is raised.
+    """
+    keys = ["a", "b", "c", "c", "b", "b"]
+    duplicates = ["c", "b", "b"]
+    with pytest.raises(EvalAlgorithmInternalError, match=re.escape(f"Duplicate keys found: {duplicates}.")):
+        validate_key_uniqueness(keys)
 
 
 def test_validate_existing_keys_success():
@@ -20,12 +42,16 @@ def test_validate_existing_keys_failure():
     """
     GIVEN a record that is missing an expected key.
     WHEN validate_existing_keys is called.
-    THEN an EvalAlgorithmInternalError is raised.
+    THEN an EvalAlgorithmInternalError with the correct message is raised.
     """
-    record = {"a": 1, "b": 2, "d": 4}
-    keys = ["a", "b", "c"]
+    record = {"a": 1, "b": 2, "e": 4}
+    keys = ["a", "b", "c", "d"]
+    missing_keys = ["c", "d"]
     with pytest.raises(
-        EvalAlgorithmInternalError, match=f"Record {record} is expected to contain key 'c', but does not."
+        EvalAlgorithmInternalError,
+        match=re.escape(
+            f"Record {record} is expected to contain the following keys, " f"but they are missing: {missing_keys}."
+        ),
     ):
         validate_existing_keys(record, keys)
 
@@ -36,185 +62,38 @@ def test_validate_added_keys_success():
     WHEN validate_added_keys is called.
     THEN no exception is raised.
     """
-    current_keys = ["a", "b", "c", "d"]
-    original_keys = ["a", "c"]
-    keys_to_add = ["b", "d"]
+    current_keys = {"a", "b", "c", "d"}
+    original_keys = {"a", "c"}
+    keys_to_add = {"b", "d"}
     validate_added_keys(current_keys, original_keys, keys_to_add)
 
 
 class TestCaseValidateAddedKeys(NamedTuple):
-    current_keys: List[str]
-    original_keys: List[str]
-    keys_to_add: List[str]
-    err_msg: str
+    current_keys: Set[str]
+    original_keys: Set[str]
+    keys_to_add: Set[str]
 
 
 @pytest.mark.parametrize(
-    "current_keys, original_keys, keys_to_add, err_msg",
+    "current_keys, original_keys, keys_to_add",
     [
         TestCaseValidateAddedKeys(
-            current_keys=["a", "b", "b"], original_keys=["a"], keys_to_add=["b"], err_msg="current_keys list"
+            current_keys={"a", "b", "c", "d"},
+            original_keys={"a", "c"},
+            keys_to_add={"b"},
         ),
         TestCaseValidateAddedKeys(
-            current_keys=["a", "b"], original_keys=["a", "a"], keys_to_add=["b"], err_msg="original_keys list"
-        ),
-        TestCaseValidateAddedKeys(
-            current_keys=["a", "b"], original_keys=["a"], keys_to_add=["b", "b"], err_msg="keys_to_add list"
-        ),
-        TestCaseValidateAddedKeys(
-            current_keys=["a", "b", "c", "d"], original_keys=["a", "c"], keys_to_add=["b"], err_msg="The set difference"
-        ),
-        TestCaseValidateAddedKeys(
-            current_keys=["a", "b", "c"], original_keys=["a", "c"], keys_to_add=["b", "d"], err_msg="The set difference"
+            current_keys={"a", "b", "c"},
+            original_keys={"a", "c"},
+            keys_to_add={"b", "d"},
         ),
     ],
 )
-def test_validate_added_keys_failure(
-    current_keys: List[str], original_keys: List[str], keys_to_add: List[str], err_msg: str
-):
+def test_validate_added_keys_failure(current_keys, original_keys, keys_to_add):
     """
     GIVEN arguments that should raise an exception.
     WHEN validate_added_keys is called.
     THEN an EvalAlgorithmInternalError is raised.
     """
-    with pytest.raises(EvalAlgorithmInternalError, match=err_msg):
+    with pytest.raises(EvalAlgorithmInternalError, match="The set difference"):
         validate_added_keys(current_keys, original_keys, keys_to_add)
-
-
-def test_generate_prompt_init():
-    """
-    GIVEN valid initializer arguments.
-    WHEN a GeneratePrompt object is instantiated.
-    THEN the instance's attributes match what is expected.
-    """
-    with patch("fmeval.transforms.util.PromptComposer") as mock_prompt_composer:
-        gen_prompt = GeneratePrompt(["model_input"], ["prompt"], "Summarize the following: $feature")
-        assert gen_prompt.input_keys == ["model_input"]
-        assert gen_prompt.output_keys == ["prompt"]
-        mock_prompt_composer.assert_called_once_with("Summarize the following: $feature")
-
-
-def test_generate_prompt_call():
-    """
-    GIVEN a GeneratePrompt instance.
-    WHEN its __call__ method is called on a record.
-    THEN the correct output is returned.
-    """
-    gen_prompt = GeneratePrompt(["input_1", "input_2"], ["prompt_1", "prompt_2"], "Summarize the following: $feature")
-    sample = {"input_1": "Hello", "input_2": "world"}
-    result = gen_prompt(sample)
-    assert result == {
-        "input_1": "Hello",
-        "input_2": "world",
-        "prompt_1": "Summarize the following: Hello",
-        "prompt_2": "Summarize the following: world",
-    }
-
-
-def test_get_model_response_init_success():
-    """
-    GIVEN valid initializer arguments.
-    WHEN a GeneratePrompt object is instantiated.
-    THEN the instance's attributes match what is expected.
-    """
-    with patch("fmeval.transforms.util.ModelRunner") as mock_model_runner:
-        get_model_response = GetModelResponse(["prompt"], ["model_output"], mock_model_runner)
-        assert get_model_response.input_keys == ["prompt"]
-        assert get_model_response.output_keys == ["model_output"]
-        assert get_model_response.model_runner == mock_model_runner
-
-
-def test_get_model_response_init_failure():
-    """
-    GIVEN a list of input keys where the number of keys != 1.
-    WHEN a GeneratePrompt object is instantiated.
-    THEN an EvalAlgorithmInternalError is raised.
-    """
-    with pytest.raises(EvalAlgorithmInternalError, match="GetModelResponse takes a single input key."):
-        with patch("fmeval.transforms.util.ModelRunner") as mock_model_runner:
-            GetModelResponse(["prompt_1", "prompt_2"], ["model_output_1", "model_output_2"], mock_model_runner)
-
-
-class TestCaseGetModelResponseSuccess(NamedTuple):
-    model_output: Optional[str]
-    log_prob: Optional[float]
-    output_keys: List[str]
-    expected_result: Dict[str, Any]
-
-
-@pytest.mark.parametrize(
-    "model_output, log_prob, output_keys, expected_result",
-    [
-        TestCaseGetModelResponseSuccess(
-            model_output="some output",
-            log_prob=-0.162,
-            output_keys=["model_output", "log_prob"],
-            expected_result={"input": "Hello", "model_output": "some output", "log_prob": -0.162},
-        ),
-        TestCaseGetModelResponseSuccess(
-            model_output="some output",
-            log_prob=None,
-            output_keys=["model_output"],
-            expected_result={"input": "Hello", "model_output": "some output"},
-        ),
-        TestCaseGetModelResponseSuccess(
-            model_output=None,
-            log_prob=-0.162,
-            output_keys=["log_prob"],
-            expected_result={"input": "Hello", "log_prob": -0.162},
-        ),
-    ],
-)
-def test_get_model_response_call_success(model_output, log_prob, output_keys, expected_result):
-    """
-    GIVEN a GetModelResponse instance.
-    WHEN its __call__ method is called on a record.
-    THEN the correct output is returned.
-    """
-    with patch("fmeval.transforms.util.ModelRunner") as mock_model_runner:
-        mock_model_runner.predict.return_value = (model_output, log_prob)
-        get_model_response = GetModelResponse(["input"], output_keys, mock_model_runner)
-        sample = {"input": "Hello"}
-        result = get_model_response(sample)
-        assert result == expected_result
-
-
-class TestCaseGetModelResponseFailure(NamedTuple):
-    model_output: Optional[str]
-    log_prob: Optional[float]
-    output_keys: List[str]
-
-
-@pytest.mark.parametrize(
-    "model_output, log_prob, output_keys",
-    [
-        TestCaseGetModelResponseFailure(
-            model_output="some output",
-            log_prob=-0.162,
-            output_keys=["model_output"],
-        ),
-        TestCaseGetModelResponseFailure(
-            model_output="some output",
-            log_prob=None,
-            output_keys=["model_output", "log_prob"],
-        ),
-        TestCaseGetModelResponseFailure(
-            model_output=None,
-            log_prob=-0.162,
-            output_keys=["model_output", "log_prob"],
-        ),
-    ],
-)
-def test_get_model_response_call_failure(model_output, log_prob, output_keys):
-    """
-    GIVEN a GetModelResponse instance whose `output_keys` attribute has a different number of elements
-        than the number of non-null elements in its model runner's predict() response.
-    WHEN its __call__ method is called.
-    THEN an EvalAlgorithmInternalError is raised.
-    """
-    sample = {"input": "Hello"}
-    with patch("fmeval.transforms.util.ModelRunner") as mock_model_runner:
-        mock_model_runner.predict.return_value = (model_output, log_prob)
-        get_model_response = GetModelResponse(["input"], output_keys, mock_model_runner)
-        with pytest.raises(EvalAlgorithmInternalError, match="The number of elements in model response"):
-            get_model_response(sample)

--- a/test/unit/transforms/test_util.py
+++ b/test/unit/transforms/test_util.py
@@ -132,11 +132,7 @@ def test_get_model_response_init_failure():
     """
     with pytest.raises(EvalAlgorithmInternalError, match="GetModelResponse takes a single input key."):
         with patch("fmeval.transforms.util.ModelRunner") as mock_model_runner:
-            GetModelResponse(
-                ["prompt_1", "prompt_2"],
-                ["model_output_1", "model_output_2"],
-                mock_model_runner
-            )
+            GetModelResponse(["prompt_1", "prompt_2"], ["model_output_1", "model_output_2"], mock_model_runner)
 
 
 class TestCaseGetModelResponseSuccess(NamedTuple):
@@ -153,21 +149,21 @@ class TestCaseGetModelResponseSuccess(NamedTuple):
             model_output="some output",
             log_prob=-0.162,
             output_keys=["model_output", "log_prob"],
-            expected_result={"input": "Hello", "model_output": "some output", "log_prob": -0.162}
+            expected_result={"input": "Hello", "model_output": "some output", "log_prob": -0.162},
         ),
         TestCaseGetModelResponseSuccess(
             model_output="some output",
             log_prob=None,
             output_keys=["model_output"],
-            expected_result={"input": "Hello", "model_output": "some output"}
+            expected_result={"input": "Hello", "model_output": "some output"},
         ),
         TestCaseGetModelResponseSuccess(
             model_output=None,
             log_prob=-0.162,
             output_keys=["log_prob"],
-            expected_result={"input": "Hello", "log_prob": -0.162}
+            expected_result={"input": "Hello", "log_prob": -0.162},
         ),
-    ]
+    ],
 )
 def test_get_model_response_call_success(model_output, log_prob, output_keys, expected_result):
     """
@@ -207,7 +203,7 @@ class TestCaseGetModelResponseFailure(NamedTuple):
             log_prob=-0.162,
             output_keys=["model_output", "log_prob"],
         ),
-    ]
+    ],
 )
 def test_get_model_response_call_failure(model_output, log_prob, output_keys):
     """


### PR DESCRIPTION
*Description of changes:*
This PR implements two utility transforms: one for generating prompts from raw text input, and another for invoking model runners. It also implements a few validation utility functions that will be used across all `Transform`s that we implement.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
