### PR TITLE
feature: implement TransformPipeline

### DIFF
--- a/src/fmeval/constants.py
+++ b/src/fmeval/constants.py
@@ -126,8 +126,10 @@ GENERATED_TEXT_JMESPATH_EXPRESSION = "*.output_keys.generated_text"
 BERTSCORE_DEFAULT_MODEL = "microsoft/deberta-xlarge-mnli"
 
 # Configures the maximum number of Transforms a TransformPipeline can contain.
-# All builtin eval algorithms use on the order of just a few dozen Transforms;
-# setting the limit to 100 to support more complicated, user-implemented algorithms.
-# Any evaluation algorithm where the pipeline has an order of magnitude more transforms
-# than this should likely be redesigned.
+# All built-in evaluation algorithms use on the order of a few dozen Transforms;
+# we set the limit to 100 to support more complicated, user-implemented algorithms.
+# An evaluation algorithm that contains a pipeline with significantly more transforms
+# than this should likely be redesigned. It is worth noting that for optimal performance,
+# the computation that an individual Transform performs should not be too small.
+# See https://docs.ray.io/en/latest/ray-core/patterns/too-fine-grained-tasks.html
 TRANSFORM_PIPELINE_MAX_SIZE = 100

--- a/src/fmeval/constants.py
+++ b/src/fmeval/constants.py
@@ -124,3 +124,10 @@ GENERATED_TEXT_JMESPATH_EXPRESSION = "*.output_keys.generated_text"
 
 # BERTScore
 BERTSCORE_DEFAULT_MODEL = "microsoft/deberta-xlarge-mnli"
+
+# Configures the maximum number of Transforms a TransformPipeline can contain.
+# All builtin eval algorithms use on the order of just a few dozen Transforms;
+# setting the limit to 100 to support more complicated, user-implemented algorithms.
+# Any evaluation algorithm where the pipeline has an order of magnitude more transforms
+# than this should likely be redesigned.
+TRANSFORM_PIPELINE_MAX_SIZE = 100

--- a/src/fmeval/transforms/transform.py
+++ b/src/fmeval/transforms/transform.py
@@ -41,20 +41,14 @@ class Transform(ABC):
         :param *args: Variable length argument list.
         :param **kwargs: Arbitrary keyword arguments.
         """
-        assert_condition(
-            isinstance(input_keys, List), "input_keys should be a list."
-        )
+        assert_condition(isinstance(input_keys, List), "input_keys should be a list.")
         assert_condition(
             all(isinstance(input_key, str) for input_key in input_keys),
             "All keys in input_keys should be strings.",
         )
         validate_key_uniqueness(input_keys)
-        assert_condition(
-            isinstance(output_keys, List), "output_keys should be a list."
-        )
-        assert_condition(
-            len(output_keys) > 0, "output_keys should be a non-empty list."
-        )
+        assert_condition(isinstance(output_keys, List), "output_keys should be a list.")
+        assert_condition(len(output_keys) > 0, "output_keys should be a non-empty list.")
         assert_condition(
             all(isinstance(output_key, str) for output_key in output_keys),
             "All keys in output_keys should be strings.",

--- a/src/fmeval/transforms/transform.py
+++ b/src/fmeval/transforms/transform.py
@@ -68,3 +68,9 @@ class Transform(ABC):
             This record can be the same object as the input record. In this case,
             the logic in this method should mutate the input record directly.
         """
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}(input_keys={self.input_keys}, output_keys={self.output_keys}, "
+            f"args={list(self.args[2:])}, kwargs={self.kwargs})"
+        )

--- a/src/fmeval/transforms/transform.py
+++ b/src/fmeval/transforms/transform.py
@@ -42,19 +42,22 @@ class Transform(ABC):
         :param **kwargs: Arbitrary keyword arguments.
         """
         assert_condition(
-            isinstance(input_keys, List), "The input_keys argument for Transform.__init__ should be a list."
+            isinstance(input_keys, List), "input_keys should be a list."
         )
         assert_condition(
             all(isinstance(input_key, str) for input_key in input_keys),
-            "All keys in the input_keys argument for Transform.__init__ should be strings.",
+            "All keys in input_keys should be strings.",
         )
         validate_key_uniqueness(input_keys)
         assert_condition(
-            isinstance(output_keys, List), "The output_keys argument for Transform.__init__ should be a list."
+            isinstance(output_keys, List), "output_keys should be a list."
+        )
+        assert_condition(
+            len(output_keys) > 0, "output_keys should be a non-empty list."
         )
         assert_condition(
             all(isinstance(output_key, str) for output_key in output_keys),
-            "All keys in the output_keys argument for Transform.__init__ should be strings.",
+            "All keys in output_keys should be strings.",
         )
         validate_key_uniqueness(output_keys)
         self.input_keys = deepcopy(input_keys)

--- a/src/fmeval/transforms/transform_pipeline.py
+++ b/src/fmeval/transforms/transform_pipeline.py
@@ -1,0 +1,67 @@
+import ray.data
+from typing import List, Union
+
+from fmeval.constants import TRANSFORM_PIPELINE_MAX_SIZE
+from fmeval.exceptions import EvalAlgorithmClientError
+from fmeval.transforms.transform import Transform
+from fmeval.util import require
+
+NestedTransform = Union[Transform, "TransformPipeline"]
+
+
+class TransformPipeline:
+    def __init__(self, nested_transforms: List[NestedTransform]):
+        require(
+            isinstance(nested_transforms, List),
+            "TransformPipeline initializer accepts a list containing Transforms or TransformPipelines.",
+        )
+        seen_keys = set()
+        duplicate_keys = []
+        self.transforms: List[Transform] = []
+        for nested_transform in nested_transforms:
+            if isinstance(nested_transform, Transform):
+                for key in nested_transform.output_keys:
+                    if key in seen_keys:
+                        duplicate_keys.append(key)
+                    else:
+                        seen_keys.add(key)
+                self.transforms.append(nested_transform)
+            elif isinstance(nested_transform, TransformPipeline):
+                self.transforms += nested_transform.transforms
+            else:
+                raise EvalAlgorithmClientError(
+                    f"nested_transform has type {type(nested_transform)}, "
+                    "but either Transform or TransformPipeline is expected."
+                )
+        require(
+            len(duplicate_keys) == 0,
+            "TransformPipeline contains Transforms with the same output keys as other Transforms. "
+            f"Duplicate keys: {duplicate_keys}."
+        )
+        require(
+            len(self.transforms) <= TRANSFORM_PIPELINE_MAX_SIZE,
+            f"TransformPipeline initialized with {len(self.transforms)} Transforms. "
+            f"Currently, the max pipeline size is {TRANSFORM_PIPELINE_MAX_SIZE}."
+        )
+
+    def execute(self, dataset: ray.data.Dataset):
+        for transform in self.transforms:
+            dataset = dataset.map(
+                transform.__class__,
+                fn_constructor_args=transform.args,
+                fn_constructor_kwargs=transform.kwargs,
+                # num_cpus configures how many logical CPUs
+                # (see https://docs.ray.io/en/latest/ray-core/scheduling/resources.html)
+                # each map worker requires.
+                # To prevent the case where an actor cannot be created due to
+                # insufficient logical CPUs, we set num_cpus to a small fractional value.
+                # The default value for num_cpus is 1 and the default number of logical CPUs
+                # is the number of cores on the machine, meaning that if we don't
+                # override num_cpus, any pipeline with more Transforms than cores will
+                # fail to execute.
+                num_cpus=(1 / TRANSFORM_PIPELINE_MAX_SIZE),
+                # Set concurrency to 1 for now. Even with a concurrency parameter of 1,
+                # the code runs significantly faster (by roughly 4x) compared to fmeval v1.
+                concurrency=1,
+            )
+        return dataset

--- a/src/fmeval/transforms/transform_pipeline.py
+++ b/src/fmeval/transforms/transform_pipeline.py
@@ -36,12 +36,12 @@ class TransformPipeline:
         require(
             len(duplicate_keys) == 0,
             "TransformPipeline contains Transforms with the same output keys as other Transforms. "
-            f"Duplicate keys: {duplicate_keys}."
+            f"Duplicate keys: {duplicate_keys}.",
         )
         require(
             len(self.transforms) <= TRANSFORM_PIPELINE_MAX_SIZE,
             f"TransformPipeline initialized with {len(self.transforms)} Transforms. "
-            f"Currently, the max pipeline size is {TRANSFORM_PIPELINE_MAX_SIZE}."
+            f"Currently, the max pipeline size is {TRANSFORM_PIPELINE_MAX_SIZE}.",
         )
 
     def execute(self, dataset: ray.data.Dataset):

--- a/test/integration/transforms/test_transform_pipeline.py
+++ b/test/integration/transforms/test_transform_pipeline.py
@@ -1,0 +1,34 @@
+from fmeval.data_loaders.util import get_dataset
+from fmeval.transforms.common import GeneratePrompt, GetModelResponse
+from fmeval.transforms.transform_pipeline import TransformPipeline
+from fmeval.eval_algorithms import DATASET_CONFIGS, TREX
+from test.integration.models.model_runners import sm_model_runner
+
+
+def test_pipeline_execution():
+    """
+    GIVEN a dataset and a TransformPipeline.
+    WHEN the pipeline's execute() method is called on the dataset.
+    THEN Ray successfully applies the transforms to the dataset.
+    """
+    data_config = DATASET_CONFIGS[TREX]
+    ds = get_dataset(data_config, 20)
+    original_columns = set(ds.columns())
+
+    gen_prompt = GeneratePrompt(
+        input_keys=["model_input"],
+        output_keys=["prompt"],
+        prompt_template="Summarize the following text in one sentence: $feature",
+    )
+
+    get_model_response = GetModelResponse(
+        input_keys=gen_prompt.output_keys,
+        output_keys=["model_output"],
+        model_runner=sm_model_runner,
+    )
+
+    pipeline = TransformPipeline([gen_prompt, get_model_response])
+    ds = pipeline.execute(ds)
+
+    new_columns = set(ds.columns())
+    assert new_columns - original_columns == {"prompt", "model_output"}

--- a/test/unit/transforms/test_transform.py
+++ b/test/unit/transforms/test_transform.py
@@ -111,3 +111,19 @@ def test_transform_init_failure(input_keys, output_keys, err_msg):
     """
     with pytest.raises(EvalAlgorithmInternalError, match=err_msg):
         DummyTransform(input_keys, output_keys, [123], {"k": "v"})
+
+
+def test_repr():
+    input_keys = ["input"]
+    output_keys = ["output"]
+    pos_arg_a = [162, 189]
+    pos_arg_b = {"k1": ["v1"], "k2": ["v2"]}
+    kw_arg_a = 123
+    kw_arg_b = "Hi"
+    dummy = DummyTransform(input_keys, output_keys, pos_arg_a, pos_arg_b, kw_arg_a=kw_arg_a, kw_arg_b=kw_arg_b)
+    expected = (
+        "DummyTransform(input_keys=['input'], output_keys=['output'], "
+        "args=[[162, 189], {'k1': ['v1'], 'k2': ['v2']}], "
+        "kwargs={'kw_arg_a': 123, 'kw_arg_b': 'Hi'})"
+    )
+    assert str(dummy) == expected

--- a/test/unit/transforms/test_transform.py
+++ b/test/unit/transforms/test_transform.py
@@ -69,12 +69,12 @@ class TestCaseTransformInitFailure(NamedTuple):
         TestCaseTransformInitFailure(
             input_keys="input",
             output_keys=["output"],
-            err_msg="The input_keys argument for Transform.__init__ should be a list.",
+            err_msg="input_keys should be a list.",
         ),
         TestCaseTransformInitFailure(
             input_keys=["input", 123],
             output_keys=["output"],
-            err_msg="All keys in the input_keys argument for Transform.__init__ should be strings.",
+            err_msg="All keys in input_keys should be strings.",
         ),
         TestCaseTransformInitFailure(
             input_keys=["input_1", "input_2", "input_1", "input_1"],
@@ -84,12 +84,17 @@ class TestCaseTransformInitFailure(NamedTuple):
         TestCaseTransformInitFailure(
             input_keys=["input"],
             output_keys="output",
-            err_msg="The output_keys argument for Transform.__init__ should be a list.",
+            err_msg="output_keys should be a list.",
+        ),
+        TestCaseTransformInitFailure(
+            input_keys=["input"],
+            output_keys=[],
+            err_msg="output_keys should be a non-empty list.",
         ),
         TestCaseTransformInitFailure(
             input_keys=["input"],
             output_keys=["output", 123],
-            err_msg="All keys in the output_keys argument for Transform.__init__ should be strings.",
+            err_msg="All keys in output_keys should be strings.",
         ),
         TestCaseTransformInitFailure(
             input_keys=["input_1", "input_2"],

--- a/test/unit/transforms/test_transform_pipeline.py
+++ b/test/unit/transforms/test_transform_pipeline.py
@@ -1,0 +1,105 @@
+from unittest.mock import Mock
+
+import pytest
+from typing import Any, List, NamedTuple, Dict
+
+from fmeval.constants import TRANSFORM_PIPELINE_MAX_SIZE
+from fmeval.exceptions import EvalAlgorithmClientError
+from fmeval.transforms.common import GeneratePrompt
+from fmeval.transforms.transform import Transform
+from fmeval.transforms.transform_pipeline import TransformPipeline, NestedTransform
+
+
+TRANSFORM_1 = GeneratePrompt(["input_1"], ["output_1"], "1")
+TRANSFORM_2 = GeneratePrompt(["input_2"], ["output_2"], "2")
+TRANSFORM_3 = GeneratePrompt(["input_3"], ["output_3"], "3")
+
+
+class TestCaseInit(NamedTuple):
+    transforms: List[NestedTransform]
+    expected: List[Transform]
+
+
+@pytest.mark.parametrize(
+    "transforms, expected",
+    [
+        TestCaseInit(transforms=[TRANSFORM_1, TRANSFORM_2], expected=[TRANSFORM_1, TRANSFORM_2]),
+        TestCaseInit(transforms=[TransformPipeline([TRANSFORM_1]), TRANSFORM_2], expected=[TRANSFORM_1, TRANSFORM_2]),
+        TestCaseInit(
+            transforms=[TransformPipeline([TRANSFORM_1]), TransformPipeline([TRANSFORM_2])],
+            expected=[TRANSFORM_1, TRANSFORM_2],
+        ),
+        TestCaseInit(
+            transforms=[
+                TransformPipeline([TRANSFORM_1, TransformPipeline([TRANSFORM_2, TransformPipeline([TRANSFORM_3])])])
+            ],
+            expected=[TRANSFORM_1, TRANSFORM_2, TRANSFORM_3],
+        ),
+    ],
+)
+def test_init_success(transforms, expected):
+    pipeline = TransformPipeline(transforms)
+    assert pipeline.transforms == expected
+
+
+class TestCaseInitFailure(NamedTuple):
+    transforms: Any
+    err_msg: str
+
+
+@pytest.mark.parametrize(
+    "transforms, err_msg",
+    [
+        TestCaseInitFailure(
+            transforms=TRANSFORM_1,
+            err_msg="TransformPipeline initializer accepts a list containing Transforms or TransformPipelines.",
+        ),
+        TestCaseInitFailure(
+            transforms=[TRANSFORM_1, TRANSFORM_2, 123], err_msg="nested_transform has type <class 'int'>"
+        ),
+        TestCaseInitFailure(
+            transforms=[TRANSFORM_1, TRANSFORM_1],
+            err_msg="TransformPipeline contains Transforms with the same output keys as other Transforms."
+        ),
+        TestCaseInitFailure(
+            transforms=[GeneratePrompt([f"input_{i}"], [f"output_{i}"], str(i)) for i in range(TRANSFORM_PIPELINE_MAX_SIZE + 1)],
+            err_msg=f"TransformPipeline initialized with {TRANSFORM_PIPELINE_MAX_SIZE + 1} Transforms."
+        )
+    ],
+)
+def test_init_failure(transforms, err_msg):
+    with pytest.raises(EvalAlgorithmClientError, match=err_msg):
+        TransformPipeline(transforms)
+
+
+class DummyTransform(Transform):
+    def __init__(
+        self,
+        input_keys: List[str],
+        output_keys: List[str],
+        pos_arg: int,
+        kw_arg: str = "Hi",
+    ):
+        super().__init__(input_keys, output_keys, pos_arg, kw_arg=kw_arg)
+
+    def __call__(self, record: Dict[str, Any]):
+        return record
+
+
+def test_execute():
+    """
+    GIVEN a valid TransformPipeline.
+    WHEN its execute method is called on a dataset.
+    THEN the Ray Dataset `map` method is called with the correct arguments.
+    """
+    pipeline = TransformPipeline([DummyTransform(["input"], ["output"], 42, "Hello there")])
+    dataset = Mock()
+    dataset.map = Mock()
+    pipeline.execute(dataset)
+    dataset.map.assert_called_once_with(
+        DummyTransform,
+        fn_constructor_args=(["input"], ["output"], 42,),
+        fn_constructor_kwargs={"kw_arg": "Hello there"},
+        num_cpus=(1 / TRANSFORM_PIPELINE_MAX_SIZE),
+        concurrency=1.
+    )

--- a/test/unit/transforms/test_transform_pipeline.py
+++ b/test/unit/transforms/test_transform_pipeline.py
@@ -59,12 +59,14 @@ class TestCaseInitFailure(NamedTuple):
         ),
         TestCaseInitFailure(
             transforms=[TRANSFORM_1, TRANSFORM_1],
-            err_msg="TransformPipeline contains Transforms with the same output keys as other Transforms."
+            err_msg="TransformPipeline contains Transforms with the same output keys as other Transforms.",
         ),
         TestCaseInitFailure(
-            transforms=[GeneratePrompt([f"input_{i}"], [f"output_{i}"], str(i)) for i in range(TRANSFORM_PIPELINE_MAX_SIZE + 1)],
-            err_msg=f"TransformPipeline initialized with {TRANSFORM_PIPELINE_MAX_SIZE + 1} Transforms."
-        )
+            transforms=[
+                GeneratePrompt([f"input_{i}"], [f"output_{i}"], str(i)) for i in range(TRANSFORM_PIPELINE_MAX_SIZE + 1)
+            ],
+            err_msg=f"TransformPipeline initialized with {TRANSFORM_PIPELINE_MAX_SIZE + 1} Transforms.",
+        ),
     ],
 )
 def test_init_failure(transforms, err_msg):
@@ -98,8 +100,12 @@ def test_execute():
     pipeline.execute(dataset)
     dataset.map.assert_called_once_with(
         DummyTransform,
-        fn_constructor_args=(["input"], ["output"], 42,),
+        fn_constructor_args=(
+            ["input"],
+            ["output"],
+            42,
+        ),
         fn_constructor_kwargs={"kw_arg": "Hello there"},
         num_cpus=(1 / TRANSFORM_PIPELINE_MAX_SIZE),
-        concurrency=1.
+        concurrency=1.0,
     )


### PR DESCRIPTION
*Description of changes:*
This PR implements the `TransformPipeline` class, which is used to apply `Transform`s to a Ray `Dataset`. The PR additionally adds some new validations to the `Transform` initializer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
