### PR TITLE
feat: implement helper models used by evaluation algorithms

### DIFF
--- a/src/fmeval/helper_models.py
+++ b/src/fmeval/helper_models.py
@@ -1,0 +1,169 @@
+import torch
+import transformers
+import evaluate as hf_evaluate
+
+from enum import Enum
+from typing import Dict, List
+from transformers import pipeline, AutoConfig
+
+
+class ToxigenModel:
+    """Toxigen helper model.
+
+    See https://huggingface.co/tomh/toxigen_roberta/tree/main
+    """
+
+    MODEL_NAME = "tomh/toxigen_roberta"
+    SCORE_NAME = "toxicity"
+
+    def __init__(self):
+        """Load the helper model into memory."""
+        self._model = pipeline("text-classification", model=ToxigenModel.MODEL_NAME)
+
+    def invoke_model(self, text_inputs: List[str]) -> Dict[str, List[float]]:
+        """Get Toxigen scores by invoking self._model on a list of text inputs.
+
+        Note: Toxigen scores are for the label "LABEL_1".
+
+        :param text_inputs: A list of text inputs for the model.
+        :returns: A dict mapping score name to a list of scores for each of the text inputs.
+        """
+        inference_output = self._model(text_inputs)
+        return {
+            ToxigenModel.SCORE_NAME: [
+                x["score"] if x["label"] == "LABEL_1" else 1.0 - x["score"] for x in inference_output
+            ]
+        }
+
+    def __reduce__(self):
+        """Serializer method."""
+        return self.__class__, ()
+
+
+class DetoxifyModel:
+    """Detoxify helper model.
+
+    See https://github.com/unitaryai/detoxify
+
+    Note: we load the unbiased model directly from the state dict due to dependency conflicts between detoxify and
+    transformers libraries.
+
+    TODO: To be switched to consuming HF model once consistency issue is resolved:
+    https://huggingface.co/unitary/unbiased-toxic-roberta. This will allow removing detoxify PyPI as a dependency,
+    update transformers version we are consuming.
+    """
+
+    UNBIASED_MODEL_URL = (
+        "https://github.com/unitaryai/detoxify/releases/download/v0.3-alpha/toxic_debiased-c7548aa0.ckpt"
+    )
+    TOXICITY_SCORE = "toxicity"
+    SEVERE_TOXICITY_SCORE = "severe_toxicity"
+    OBSCENE_SCORE = "obscene"
+    IDENTITY_ATTACK_SCORE = "identity_attack"
+    INSULT_SCORE = "insult"
+    THREAT_SCORE = "threat"
+    SEXUAL_EXPLICIT_SCORE = "sexual_explicit"
+    SCORE_NAMES = [
+        TOXICITY_SCORE,
+        SEVERE_TOXICITY_SCORE,
+        OBSCENE_SCORE,
+        IDENTITY_ATTACK_SCORE,
+        INSULT_SCORE,
+        THREAT_SCORE,
+        SEXUAL_EXPLICIT_SCORE,
+    ]
+
+    def __init__(self):
+        """Load the helper model into memory."""
+        state_dict = torch.hub.load_state_dict_from_url(DetoxifyModel.UNBIASED_MODEL_URL, map_location="cpu")
+        config = state_dict["config"]["arch"]["args"]
+        self._model = (
+            getattr(transformers, config["model_name"])
+            .from_pretrained(
+                pretrained_model_name_or_path=None,
+                config=AutoConfig.from_pretrained(config["model_type"], num_labels=config["num_classes"]),
+                state_dict=state_dict["state_dict"],
+                local_files_only=False,
+            )
+            .to("cpu")
+        )
+        self._tokenizer = getattr(transformers, config["tokenizer_name"]).from_pretrained(config["model_type"])
+
+    def invoke_model(self, text_inputs: List[str]) -> Dict[str, List[float]]:
+        """Get Detoxify scores by invoking self._model on a list of text inputs.
+
+        :param text_inputs: A list of text inputs for the model.
+        :returns: A dict mapping score name to a list of scores for each of the text inputs.
+        """
+        inputs = self._tokenizer(text_inputs, return_tensors="pt", truncation=True, padding=True).to(self._model.device)
+        scores = torch.sigmoid(self._model(**inputs)[0]).cpu().detach().numpy()
+        return {
+            score_name: [score[i].tolist() for score in scores]
+            for i, score_name in enumerate(DetoxifyModel.SCORE_NAMES)
+        }
+
+    def __reduce__(self):
+        """Serializer method."""
+        return self.__class__, ()
+
+
+class BertscoreModel:
+    """
+    BERTscore is a similarity-based metric that compares the embedding of the prediction and target sentences
+    under a (learned) model, typically, from the BERT family.
+    This score may lead to increased flexibility compared to rouge and METEOR in terms of rephrasing since
+    semantically similar sentences are (typically) embedded similarly.
+
+    https://huggingface.co/spaces/evaluate-metric/bertscore
+
+    Note: we specify that this Ray actor requires num_cpus=1 in order to limit the number of concurrently
+    running tasks or actors to avoid out of memory issues.
+    See https://docs.ray.io/en/latest/ray-core/patterns/limit-running-tasks.html#core-patterns-limit-running-tasks
+    for a detailed explanation.
+    """
+
+    def __init__(self, model_type: str):
+        """Load the HuggingFace bertscore metric.
+
+        :param model_type: Model type to be used for bertscore
+        """
+        self._bertscore = hf_evaluate.load("bertscore")
+        self._model_type = model_type
+
+    def invoke_model(self, target_output: str, model_output: str) -> float:
+        """Invoke the helper model to obtain a BERT score.
+
+        :param target_output: Reference text.
+        :param model_output: Model output text.
+        :returns: The computed BERT score.
+        """
+        return self._bertscore.compute(
+            predictions=[model_output],
+            references=[target_output],
+            model_type=self._model_type,
+        )["f1"][0]
+
+    def __reduce__(self):
+        """Serializer method."""
+        return self.__class__, (self._model_type,)
+
+
+class BertscoreModelTypes(Enum):
+    """This class holds the names of all the allowed models for computing the BERTScore."""
+
+    MICROSOFT_DEBERTA_MODEL = "microsoft/deberta-xlarge-mnli"
+    ROBERTA_MODEL = "roberta-large-mnli"
+
+    @classmethod
+    def model_is_allowed(cls, model_name: str) -> bool:
+        """
+        Given a model name like 'roberta-large-mnli', check if this is an allowed model for computing BERTScore.
+        """
+        return any(elem.value == model_name for elem in iter(cls))
+
+    @classmethod
+    def model_list(cls) -> List[str]:
+        """
+        Return a list of all the allowed models for computing BERTScore.
+        """
+        return [elem.value for elem in iter(cls)]

--- a/test/integration/test_util.py
+++ b/test/integration/test_util.py
@@ -1,0 +1,24 @@
+import pytest
+import ray
+
+from fmeval.helper_models import BertscoreModel, BertscoreModelTypes
+from fmeval.util import create_shared_resource
+
+
+class TestUtil:
+    def test_create_shared_resource(self):
+        """
+        GIVEN a BertscoreModel instance.
+        WHEN create_shared_resource is called on this instance.
+        THEN a Ray actor handle for the BertscoreModel is returned,
+            and this actor handle can be used just like a regular
+            BertscoreModel object (with the addition of needing to call
+            `remote` and `get`).
+
+        Note that the input payload and expected result are copied from
+        the BertscoreModel.invoke_model unit test.
+        """
+        bertscore_model = BertscoreModel(BertscoreModelTypes.ROBERTA_MODEL.value)
+        actor_handle = create_shared_resource(bertscore_model)
+        result = ray.get(actor_handle.invoke_model.remote("sample text reference", "sample text prediction"))
+        assert result == pytest.approx(0.8580247163772583)

--- a/test/unit/test_helper_models.py
+++ b/test/unit/test_helper_models.py
@@ -1,0 +1,149 @@
+import pytest
+from typing import NamedTuple
+from unittest.mock import patch, PropertyMock
+
+from fmeval.helper_models import (
+    ToxigenModel,
+    DetoxifyModel,
+    BertscoreModel,
+    BertscoreModelTypes,
+)
+
+
+class TestHelperModel:
+    @patch.object(ToxigenModel, "MODEL_NAME", new_callable=PropertyMock)
+    def test_toxigen_invoke_model(self, mock_model_name):
+        """
+        GIVEN valid inputs.
+        WHEN invoke_model method of ToxigenModel is called.
+        THEN the correct output is returned.
+
+        Note: using lightweight test model: https://huggingface.co/hf-internal-testing/tiny-random-roberta
+        """
+        mock_model_name.return_value = "hf-internal-testing/tiny-random-roberta"
+        toxigen_model = ToxigenModel()
+        actual_response = toxigen_model.invoke_model(["My toxic text", "My good text"])
+        assert ToxigenModel.SCORE_NAME in actual_response
+        assert actual_response[ToxigenModel.SCORE_NAME] == pytest.approx(
+            [0.5005707144737244, 0.5005643963813782], rel=1e-5
+        )
+
+    @patch.object(ToxigenModel, "MODEL_NAME", new_callable=PropertyMock)
+    def test_toxigen_reduce(self, mock_model_name):
+        """
+        GIVEN a ToxigenModel instance.
+        WHEN __reduce__ is called.
+        THEN the correct output is returned.
+        """
+        mock_model_name.return_value = "hf-internal-testing/tiny-random-roberta"
+        toxigen_model = ToxigenModel()
+        assert toxigen_model.__reduce__() == (ToxigenModel, ())
+
+    def test_detoxify_model_invoke_model(self):
+        """
+        GIVEN valid inputs.
+        WHEN invoke_model method of DetoxifyModel is called.
+        THEN the correct output is returned.
+        """
+        detoxify_model = DetoxifyModel()
+        actual_response = detoxify_model.invoke_model(["My toxic text", "My good text"])
+        expected_response = {
+            DetoxifyModel.TOXICITY_SCORE: [0.06483059376478195, 0.00045518550905399024],
+            DetoxifyModel.SEVERE_TOXICITY_SCORE: [1.26147870105342e-05, 1.6480657905049156e-06],
+            DetoxifyModel.OBSCENE_SCORE: [0.0009980567265301943, 3.1544899684377015e-05],
+            DetoxifyModel.IDENTITY_ATTACK_SCORE: [0.0012085289927199483, 6.863904854981229e-05],
+            DetoxifyModel.INSULT_SCORE: [0.00813359022140503, 8.761371282162145e-05],
+            DetoxifyModel.THREAT_SCORE: [0.0004742506134789437, 2.826379204634577e-05],
+            DetoxifyModel.SEXUAL_EXPLICIT_SCORE: [0.00044487009290605783, 1.9261064153397456e-05],
+        }
+        assert list(actual_response.keys()) == DetoxifyModel.SCORE_NAMES
+        assert actual_response[DetoxifyModel.TOXICITY_SCORE] == pytest.approx(
+            expected_response[DetoxifyModel.TOXICITY_SCORE], rel=1e-5
+        )
+        assert actual_response[DetoxifyModel.SEVERE_TOXICITY_SCORE] == pytest.approx(
+            expected_response[DetoxifyModel.SEVERE_TOXICITY_SCORE], rel=1e-5
+        )
+        assert actual_response[DetoxifyModel.OBSCENE_SCORE] == pytest.approx(
+            expected_response[DetoxifyModel.OBSCENE_SCORE], rel=1e-5
+        )
+        assert actual_response[DetoxifyModel.IDENTITY_ATTACK_SCORE] == pytest.approx(
+            expected_response[DetoxifyModel.IDENTITY_ATTACK_SCORE], rel=1e-5
+        )
+        assert actual_response[DetoxifyModel.INSULT_SCORE] == pytest.approx(
+            expected_response[DetoxifyModel.INSULT_SCORE], rel=1e-5
+        )
+        assert actual_response[DetoxifyModel.THREAT_SCORE] == pytest.approx(
+            expected_response[DetoxifyModel.THREAT_SCORE], rel=1e-5
+        )
+        assert actual_response[DetoxifyModel.SEXUAL_EXPLICIT_SCORE] == pytest.approx(
+            expected_response[DetoxifyModel.SEXUAL_EXPLICIT_SCORE], rel=1e-5
+        )
+
+    def test_detoxify_reduce(self):
+        """
+        GIVEN a DetoxifyModel instance.
+        WHEN __reduce__ is called.
+        THEN the correct output is returned.
+        """
+        detoxify_model = DetoxifyModel()
+        assert detoxify_model.__reduce__() == (DetoxifyModel, ())
+
+    def test_bertscore_model_invoke_model(self):
+        """
+        GIVEN valid inputs.
+        WHEN invoke_model method of BertscoreModel is called.
+        THEN the correct output is returned.
+        """
+        bertscore = BertscoreModel(BertscoreModelTypes.ROBERTA_MODEL.value)
+        result = bertscore.invoke_model("sample text reference", "sample text prediction")
+        assert result == pytest.approx(0.8580247163772583)
+
+    def test_bertscore_reduce(self):
+        """
+        GIVEN a BertscoreModel instance.
+        WHEN __reduce__ is called.
+        THEN the correct output is returned.
+        """
+        bertscore_model = BertscoreModel(BertscoreModelTypes.ROBERTA_MODEL.value)
+        assert bertscore_model.__reduce__() == (BertscoreModel, (BertscoreModelTypes.ROBERTA_MODEL.value,))
+
+    class TestCaseBertscoreModelTypes(NamedTuple):
+        model_type: str
+        allowed: bool
+
+    @pytest.mark.parametrize(
+        "model_type, allowed",
+        [
+            TestCaseBertscoreModelTypes(
+                model_type=BertscoreModelTypes.MICROSOFT_DEBERTA_MODEL.value,
+                allowed=True,
+            ),
+            TestCaseBertscoreModelTypes(
+                model_type=BertscoreModelTypes.ROBERTA_MODEL.value,
+                allowed=True,
+            ),
+            TestCaseBertscoreModelTypes(
+                model_type="distilbert-base-uncased",
+                allowed=False,
+            ),
+        ],
+    )
+    def test_bertscore_model_types_model_is_allowed(self, model_type, allowed):
+        """
+        GIVEN a model type string.
+        WHEN BertscoreModelTypes.model_is_allowed is called.
+        THEN the correct output is returned.
+        """
+        assert BertscoreModelTypes.model_is_allowed(model_type) == allowed
+
+    def test_bertscore_model_types_model_list(self):
+        """
+        GIVEN N/A.
+        WHEN BertscoreModelTypes.model_list is called.
+        THEN the correct output is returned.
+
+        Note: I'm just including this to meet the 100% unit test coverage requirement.
+        Once I implement the code that actually calls these methods, we can remove this
+        trivial test.
+        """
+        assert BertscoreModelTypes.model_list() == ["microsoft/deberta-xlarge-mnli", "roberta-large-mnli"]

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -1,9 +1,8 @@
-import os
-
 import pytest
-
+import os
+from unittest.mock import patch, Mock
 from fmeval.exceptions import EvalAlgorithmClientError
-from fmeval.util import require, project_root, singleton
+from fmeval.util import require, project_root, singleton, create_shared_resource
 
 
 def test_require():
@@ -39,3 +38,41 @@ def test_singleton_instance():
     singleton2 = TestSingletonClass()
 
     assert singleton1 is singleton2
+
+
+def test_create_shared_resource():
+    """
+    GIVEN an object.
+    WHEN create_shared_resource is called on this object.
+    THEN the relevant Ray functions are called with the correct arguments.
+
+    Note: this unit test is included primarily for 100% unit test
+    coverage purposes. It is critical that this function be
+    tested without mocking anything, to ensure that the function
+    works with Ray as intended.
+    """
+
+    class Dummy:
+        def __init__(self, name: str, age: int):
+            self.name = name
+            self.age = age
+
+        def __reduce__(self):
+            return Dummy, (self.name, self.age)
+
+    with patch("src.fmeval.util.ray.remote") as mock_ray_remote:
+        mock_actor_class = Mock()
+        mock_actor_class.remote = Mock()
+
+        mock_wrapped_resource_class = Mock()
+        mock_wrapped_resource_class.remote = Mock()
+
+        mock_actor_class.return_value = mock_wrapped_resource_class
+        mock_ray_remote.return_value = mock_actor_class
+
+        num_cpus = 3
+        create_shared_resource(Dummy("C", 2), num_cpus=num_cpus)
+
+        mock_ray_remote.assert_called_once_with(num_cpus=num_cpus)
+        mock_actor_class.assert_called_once_with(Dummy)
+        mock_wrapped_resource_class.remote.assert_called_once_with("C", 2)


### PR DESCRIPTION
*Description of changes:*
This PR ports over a copy of the helper models from `fmeval.eval_algorithms.helper_models.helper_model` into `fmeval.helper_models`. The reason behind keeping the old code is that I don't to make half-baked changes that will break the existing evaluation algorithm implementations. Eventually, when all evaluation algorithms use the new Transform-based design, I will obviously get rid of `fmeval.eval_algorithms.helper_models.helper_model`.

Note that the new helper model code isn't _exactly_ the same as the original code, but the changes are mainly minor cleanup.

This PR also implements the `create_shared_resource` utility function, which is used to create a Ray actor out of a "shared resource" (which is typically an object that consumes lots of memory, like a helper model). This utility function allows us to decouple the helper models from Ray, which is one problem that the current implementation of `BertscoreHelperModel` faces (notice how there is the `@ray.remote` decorator on top of the class in our current implementation).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
