### PR TITLE
feat: implement transforms for summarization accuracy metrics

### DIFF
--- a/src/fmeval/transforms/summarization_accuracy_metrics.py
+++ b/src/fmeval/transforms/summarization_accuracy_metrics.py
@@ -1,0 +1,221 @@
+import ray
+import nltk
+import evaluate as hf_evaluate
+
+from typing import List, Dict, Any, Union
+from ray import ObjectRef
+from nltk import word_tokenize
+from nltk.translate import meteor_score
+
+from fmeval.util import require
+from fmeval.transforms.transform import Transform
+from fmeval.transforms.util import validate_call
+from fmeval.helper_models import BertscoreModel
+
+
+METEOR_SCORE = "meteor"
+ROUGE_SCORE = "rouge"
+BERT_SCORE = "bertscore"
+
+# rouge constants
+ROUGE_1 = "rouge1"
+ROUGE_2 = "rouge2"
+ROUGE_L = "rougeL"
+
+ROUGE_TYPES = [ROUGE_1, ROUGE_2, ROUGE_L]
+
+
+def _load_meteor_modules() -> None:  # pragma: no cover
+    """Load helper modules required by meteor metric.
+
+    :returns: None
+    """
+    nltk.download("wordnet")
+    nltk.download("punkt")
+    nltk.download("omw-1.4")
+
+
+class MeteorScore(Transform):
+    """This Transform augments an input record with the METEOR metric, computed from target and model outputs.
+
+    METEOR is a metric for text similarity between the machine-produced summary
+    and human-produced reference summaries.
+    Unigrams can be matched based on their surface forms, stemmed forms,
+    and meanings; furthermore, METEOR can be easily extended to include more
+    advanced matching strategies. Once all generalized unigram matches
+    between the two strings have been found, METEOR computes a score for
+    this matching using a combination of unigram-precision, unigram-recall, and
+    a measure of fragmentation that is designed to directly capture how
+    well-ordered the matched words in the machine translation are in relation
+    to the reference.
+    """
+
+    def __init__(
+        self,
+        input_keys: List[str],
+        output_keys: List[str],
+        target_output_key: str,
+        model_output_key: str,
+        load_meteor_modules: bool = True,
+    ):
+        """MeteorScore initializer.
+
+        :param input_keys: A two-element list containing the keys corresponding to the target output and LLM output.
+        :param output_keys: A single-element list containing the output key for this Transform,
+            which corresponds to the METEOR metric that gets computed.
+        :param target_output_key: The key corresponding to the target output.
+        :param model_output_key: The key corresponding to the model (LLM) output.
+        :param load_meteor_modules: Whether to load the meteor helper modules. This needs to be performed only once.
+        """
+        require(
+            set(input_keys) == {target_output_key, model_output_key},
+            f"input_keys to MeteorScore should be {target_output_key, model_output_key}.",
+        )
+        require(len(output_keys) == 1, "MeteorScore should only have a single output key.")
+        super().__init__(
+            input_keys,
+            output_keys,
+            target_output_key,
+            model_output_key,
+            # The first instance of this class that gets created will
+            # load the helper modules, so copies of this instance
+            # need not load them again.
+            load_meteor_modules=False,
+        )
+        self.target_output_key = target_output_key
+        self.model_output_key = model_output_key
+        if load_meteor_modules:
+            _load_meteor_modules()
+
+    @validate_call
+    def __call__(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        """Augments the input record with the computed METEOR metric.
+
+        :param record: The input record.
+        :returns: The input record with the METEOR metric added in.
+        """
+        output_key = self.output_keys[0]
+        record[output_key] = meteor_score.single_meteor_score(
+            reference=word_tokenize(record[self.target_output_key]),
+            hypothesis=word_tokenize(record[self.model_output_key]),
+        )
+        return record
+
+
+class RougeScore(Transform):
+    """This transform augments an input record with the ROUGE score, computed from target and model outputs.
+
+    The ROUGE-N, where N=[1,2,L], score is a standard metric for summarization quality.
+    It computes the word overlap between the reference and model summary. Given that this metric is based on simple
+    word overlap statistics, it works best for extractive summaries.
+    Note that if we rephrase the summary without changing its meaning the ROUGE-N score will drop.
+
+    Reference: https://huggingface.co/spaces/evaluate-metric/rouge
+    """
+
+    def __init__(
+        self,
+        input_keys: List[str],
+        output_keys: List[str],
+        target_output_key: str,
+        model_output_key: str,
+        rouge_type: str = ROUGE_2,
+        use_stemmer: bool = True,
+    ):
+        """RougeScore initializer.
+
+        :param input_keys: A two-element list containing the keys corresponding to the target output and LLM output.
+        :param output_keys: A single-element list containing the output key for this Transform,
+            which corresponds to the ROUGE score that gets computed.
+        :param target_output_key: The key corresponding to the target output.
+        :param model_output_key: The key corresponding to the model (LLM) output.
+        :param rouge_type: Which ROUGE type to use (1, 2, L).
+        :param use_stemmer: Whether to use a stemmer for ROUGE.
+        """
+        require(
+            set(input_keys) == {target_output_key, model_output_key},
+            f"input_keys to RougeScore should be {target_output_key, model_output_key}.",
+        )
+        require(len(output_keys) == 1, "RougeScore should only have a single output key.")
+        super().__init__(
+            input_keys, output_keys, target_output_key, model_output_key, rouge_type=rouge_type, use_stemmer=use_stemmer
+        )
+        self.target_output_key = target_output_key
+        self.model_output_key = model_output_key
+        self.rouge_type = rouge_type
+        self.use_stemmer = use_stemmer
+        self.rouge_metric = hf_evaluate.load("rouge")
+
+    @validate_call
+    def __call__(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        """Augments the input record with the computed ROUGE score.
+
+        :param record: The input record.
+        :returns: The input record with the ROUGE score added in.
+        """
+        output_key = self.output_keys[0]
+        record[output_key] = self.rouge_metric.compute(
+            predictions=[record[self.model_output_key]],
+            references=[record[self.target_output_key]],
+            use_stemmer=self.use_stemmer,
+            rouge_types=[self.rouge_type],
+        )[self.rouge_type]
+        return record
+
+
+class BertScore(Transform):
+    """This transform augments an input record with the BERT score, computed from target and model outputs.
+
+    BERTscore is a similarity-based metric that compares the embedding of the prediction and target sentences
+    under a learned model, typically, from the BERT family.
+    This score may lead to increased flexibility compared to ROUGE and METEOR in terms of rephrasing since
+    semantically similar sentences are (typically) embedded similarly.
+
+    See https://huggingface.co/spaces/evaluate-metric/bertscore
+    """
+
+    def __init__(
+        self,
+        input_keys: List[str],
+        output_keys: List[str],
+        target_output_key: str,
+        model_output_key: str,
+        bertscore_model: Union[BertscoreModel, ObjectRef],
+    ):
+        """BertScore initializer.
+
+        :param input_keys: A two-element list containing the keys corresponding to the target output and LLM output.
+        :param output_keys: A single-element list containing the output key for this Transform,
+            which corresponds to the ROUGE score that gets computed.
+        :param target_output_key: The key corresponding to the target output.
+        :param model_output_key: The key corresponding to the model (LLM) output.
+        :param bertscore_model: A BertscoreModel instance or a Ray actor handle for a BertscoreModel.
+        """
+        require(
+            set(input_keys) == {target_output_key, model_output_key},
+            f"input_keys to BertScore should be {target_output_key, model_output_key}.",
+        )
+        require(len(output_keys) == 1, "BertScore should only have a single output key.")
+        super().__init__(input_keys, output_keys, target_output_key, model_output_key, bertscore_model)
+        self.target_output_key = target_output_key
+        self.model_output_key = model_output_key
+        self.bertscore_model = bertscore_model
+
+    def __call__(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        """Augments the input record with the computed BERT score.
+
+        :param record: The input record.
+        :returns: The input record with the BERT score added in.
+        """
+        score = (
+            self.bertscore_model.invoke_model(record[self.target_output_key], record[self.model_output_key])
+            if isinstance(self.bertscore_model, BertscoreModel)
+            else ray.get(
+                self.bertscore_model.invoke_model.remote(  # type: ignore[union-attr]
+                    record[self.target_output_key], record[self.model_output_key]
+                )
+            )
+        )
+        output_key = self.output_keys[0]
+        record[output_key] = score
+        return record

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -60,7 +60,7 @@ def test_create_shared_resource():
         def __reduce__(self):
             return Dummy, (self.name, self.age)
 
-    with patch("src.fmeval.util.ray.remote") as mock_ray_remote:
+    with patch("fmeval.util.ray.remote") as mock_ray_remote:
         mock_actor_class = Mock()
         mock_actor_class.remote = Mock()
 

--- a/test/unit/transforms/test_summarization_accuracy_metrics.py
+++ b/test/unit/transforms/test_summarization_accuracy_metrics.py
@@ -1,0 +1,250 @@
+import pytest
+from unittest.mock import patch, call, Mock
+from typing import List, NamedTuple
+
+from ray import ObjectRef
+
+from fmeval.exceptions import EvalAlgorithmClientError
+from fmeval.helper_models import BertscoreModel
+from fmeval.transforms.summarization_accuracy_metrics import MeteorScore, RougeScore, BertScore, ROUGE_2
+
+
+def test_meteor_score_init_load_modules():
+    """
+    GIVEN valid arguments to __init__.
+    WHEN a MeteorScore is instantiated with load_meteor_modules=True.
+    THEN the instance is created without errors, and _load_meteor_modules is called.
+    """
+    with patch("fmeval.transforms.summarization_accuracy_metrics._load_meteor_modules") as mock_load_modules:
+        MeteorScore(
+            input_keys=["target_output", "model_output"],
+            output_keys=["meteor"],
+            target_output_key="target_output",
+            model_output_key="model_output",
+            load_meteor_modules=True,
+        )
+        mock_load_modules.assert_called_once()
+
+
+class TestCaseInitFailure(NamedTuple):
+    input_keys: List[str]
+    output_keys: List[str]
+    err_msg: str
+
+
+@pytest.mark.parametrize(
+    "input_keys, output_keys, err_msg",
+    [
+        TestCaseInitFailure(
+            input_keys=["not_target_output", "model_output"],
+            output_keys=["meteor"],
+            err_msg="input_keys to MeteorScore should be",
+        ),
+        TestCaseInitFailure(
+            input_keys=["target_output", "not_model_output"],
+            output_keys=["meteor"],
+            err_msg="input_keys to MeteorScore should be",
+        ),
+        TestCaseInitFailure(
+            input_keys=["target_output", "model_output"],
+            output_keys=["key1", "key2"],
+            err_msg="MeteorScore should only have a single output key.",
+        ),
+    ],
+)
+def test_meteor_score_init_failure(input_keys, output_keys, err_msg):
+    """
+    GIVEN invalid initializer arguments.
+    WHEN a MeteorScore object is instantiated.
+    THEN an EvalAlgorithmClientError with the correct error message is raised.
+    """
+    with pytest.raises(EvalAlgorithmClientError, match=err_msg):
+        MeteorScore(
+            input_keys=input_keys,
+            output_keys=output_keys,
+            target_output_key="target_output",
+            model_output_key="model_output",
+        )
+
+
+def test_meteor_score_call():
+    """
+    GIVEN a MeteorScore instance.
+    WHEN its __call__ method is invoked.
+    THEN nltk.translate.meteor_score.single_meteor_score and
+     nltk.word_tokenize are called with the correct arguments.
+
+    Note: we don't validate the structure of the __call__ output since
+    we already have @validate_call to handle that.
+    """
+    with patch(
+        "fmeval.transforms.summarization_accuracy_metrics.meteor_score.single_meteor_score"
+    ) as mock_meteor, patch("fmeval.transforms.summarization_accuracy_metrics.word_tokenize") as mock_word_tokenize:
+
+        mock_word_tokenize.side_effect = ["tokenized_target_output", "tokenized_model_output"]
+        ms = MeteorScore(
+            input_keys=["target_output", "model_output"],
+            output_keys=["meteor"],
+            target_output_key="target_output",
+            model_output_key="model_output",
+            load_meteor_modules=False,
+        )
+        sample = {"target_output": "Hello there!", "model_output": "Hi"}
+        ms(sample)
+        mock_word_tokenize.assert_has_calls([call("Hello there!"), call("Hi")])
+        mock_meteor.assert_called_once_with(reference="tokenized_target_output", hypothesis="tokenized_model_output")
+
+
+@pytest.mark.parametrize(
+    "input_keys, output_keys, err_msg",
+    [
+        TestCaseInitFailure(
+            input_keys=["not_target_output", "model_output"],
+            output_keys=["rouge"],
+            err_msg="input_keys to RougeScore should be",
+        ),
+        TestCaseInitFailure(
+            input_keys=["target_output", "not_model_output"],
+            output_keys=["rouge"],
+            err_msg="input_keys to RougeScore should be",
+        ),
+        TestCaseInitFailure(
+            input_keys=["target_output", "model_output"],
+            output_keys=["key1", "key2"],
+            err_msg="RougeScore should only have a single output key.",
+        ),
+    ],
+)
+def test_rouge_score_init_failure(input_keys, output_keys, err_msg):
+    """
+    GIVEN invalid initializer arguments.
+    WHEN a RougeScore object is instantiated.
+    THEN an EvalAlgorithmClientError with the correct error message is raised.
+    """
+    with pytest.raises(EvalAlgorithmClientError, match=err_msg):
+        RougeScore(
+            input_keys=input_keys,
+            output_keys=output_keys,
+            target_output_key="target_output",
+            model_output_key="model_output",
+        )
+
+
+def test_rouge_score_call():
+    """
+    GIVEN a RougeScore instance.
+    WHEN its __call__ method is invoked.
+    THEN self.rouge_metric.compute is called with the correct arguments.
+
+    Note: we don't validate the structure of the __call__ output since
+    we already have @validate_call to handle that.
+    """
+    with patch("fmeval.transforms.summarization_accuracy_metrics.hf_evaluate.load") as mock_hf_load:
+        rouge_type = ROUGE_2
+        mock_rouge_metric = Mock()
+        mock_rouge_metric.compute = Mock()
+        mock_rouge_metric.compute.return_value = {rouge_type: "blah"}
+        mock_hf_load.return_value = mock_rouge_metric
+
+        rs = RougeScore(
+            input_keys=["target_output", "model_output"],
+            output_keys=["rouge"],
+            target_output_key="target_output",
+            model_output_key="model_output",
+            rouge_type=rouge_type,
+        )
+        sample = {"target_output": "Hello there!", "model_output": "Hi"}
+        rs(sample)
+        mock_rouge_metric.compute.assert_called_once_with(
+            predictions=["Hi"],
+            references=["Hello there!"],
+            use_stemmer=rs.use_stemmer,
+            rouge_types=[rs.rouge_type],
+        )
+
+
+@pytest.mark.parametrize(
+    "input_keys, output_keys, err_msg",
+    [
+        TestCaseInitFailure(
+            input_keys=["not_target_output", "model_output"],
+            output_keys=["rouge"],
+            err_msg="input_keys to BertScore should be",
+        ),
+        TestCaseInitFailure(
+            input_keys=["target_output", "not_model_output"],
+            output_keys=["rouge"],
+            err_msg="input_keys to BertScore should be",
+        ),
+        TestCaseInitFailure(
+            input_keys=["target_output", "model_output"],
+            output_keys=["key1", "key2"],
+            err_msg="BertScore should only have a single output key.",
+        ),
+    ],
+)
+def test_bert_score_init_failure(input_keys, output_keys, err_msg):
+    """
+    GIVEN invalid initializer arguments.
+    WHEN a BertScore object is instantiated.
+    THEN an EvalAlgorithmClientError with the correct error message is raised.
+    """
+    with pytest.raises(EvalAlgorithmClientError, match=err_msg):
+        BertScore(
+            input_keys=input_keys,
+            output_keys=output_keys,
+            target_output_key="target_output",
+            model_output_key="model_output",
+            bertscore_model=Mock(),
+        )
+
+
+def test_bert_score_call_with_bertscore_model_object():
+    """
+    GIVEN a BertScore instance, where its `bertscore_model` is a BertscoreModel object.
+    WHEN its __call__ method is invoked.
+    THEN self.bertscore_model is invoked with the correct arguments.
+
+    Note: we don't validate the structure of the __call__ output since
+    we already have @validate_call to handle that.
+    """
+    mock_bertscore_model = Mock(spec=BertscoreModel)
+    mock_bertscore_model.invoke_model = Mock()
+
+    bs = BertScore(
+        input_keys=["target_output", "model_output"],
+        output_keys=["rouge"],
+        target_output_key="target_output",
+        model_output_key="model_output",
+        bertscore_model=mock_bertscore_model,
+    )
+    sample = {"target_output": "Hello there!", "model_output": "Hi"}
+    bs(sample)
+    mock_bertscore_model.invoke_model.assert_called_once_with("Hello there!", "Hi")
+
+
+def test_bert_score_call_with_ray_actor_handle():
+    """
+    GIVEN a BertScore instance, where its `bertscore_model` is a Ray actor handle.
+    WHEN its __call__ method is invoked.
+    THEN the correct Ray APIs are called.
+
+    Note: we don't validate the structure of the __call__ output since
+    we already have @validate_call to handle that.
+    """
+    mock_bertscore_model = Mock(spec=ObjectRef)
+    mock_bertscore_model.invoke_model = Mock()
+    mock_bertscore_model.invoke_model.remote = Mock(return_value="remote invocation result")
+
+    with patch("fmeval.transforms.summarization_accuracy_metrics.ray.get") as mock_ray_get:
+        bs = BertScore(
+            input_keys=["target_output", "model_output"],
+            output_keys=["rouge"],
+            target_output_key="target_output",
+            model_output_key="model_output",
+            bertscore_model=mock_bertscore_model,
+        )
+        sample = {"target_output": "Hello there!", "model_output": "Hi"}
+        bs(sample)
+        mock_bertscore_model.invoke_model.remote.assert_called_once_with("Hello there!", "Hi")
+        mock_ray_get.assert_called_once_with("remote invocation result")


### PR DESCRIPTION
*Description of changes:*
This PR implements `Transform`s for the three existing summarization accuracy metrics supported by `fmeval`: Meteor, Rouge, and Bert.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
