### PR TITLE
feat: update various transforms to accept multiple input keys

### DIFF
--- a/src/fmeval/transforms/semantic_perturbations.py
+++ b/src/fmeval/transforms/semantic_perturbations.py
@@ -31,7 +31,7 @@ class SemanticPerturbation(Transform):
             len(output_keys) == num_perturbations,
             f"len(output_keys) is {len(output_keys)} while num_perturbations is {num_perturbations}. They should match.",
         )
-        super().__init__(input_key, output_keys, num_perturbations, seed, args, kwargs)
+        super().__init__(input_key, output_keys, num_perturbations, seed, *args, **kwargs)
         self.register_input_output_keys([input_key], output_keys)
         self.input_key = input_key
         self.num_perturbations = num_perturbations

--- a/src/fmeval/transforms/transform.py
+++ b/src/fmeval/transforms/transform.py
@@ -60,7 +60,7 @@ class Transform(ABC):
             f"args={list(self.args)}, kwargs={self.kwargs})"
         )
 
-    def register_input_output_keys(self, input_keys: List[str], output_keys: List[str]):
+    def register_input_output_keys(self, input_keys: List[str], output_keys: List[str], allow_duplicates: bool = False):
         """Assign self.input_keys and self.output_keys attributes.
 
         Concrete subclasses of Transform should call this method in their __init__
@@ -71,13 +71,15 @@ class Transform(ABC):
         :param output_keys: The keys introduced by this Transform's __call__ logic
             that will be present in the output record. If this Transform mutates its
             input, then these keys should be added by __call__ to the input record.
+        :param allow_duplicates: Whether to allow duplicate values in `input_keys`.
         """
         assert_condition(isinstance(input_keys, List), "input_keys should be a list.")
         assert_condition(
             all(isinstance(input_key, str) for input_key in input_keys),
             "All keys in input_keys should be strings.",
         )
-        validate_key_uniqueness(input_keys)
+        if not allow_duplicates:
+            validate_key_uniqueness(input_keys)
         assert_condition(isinstance(output_keys, List), "output_keys should be a list.")
         assert_condition(len(output_keys) > 0, "output_keys should be a non-empty list.")
         assert_condition(

--- a/test/integration/transforms/test_transform_pipeline.py
+++ b/test/integration/transforms/test_transform_pipeline.py
@@ -22,8 +22,7 @@ def test_pipeline_execution():
     )
 
     get_model_response = GetModelResponse(
-        input_keys=gen_prompt.output_keys,
-        output_keys=["model_output"],
+        input_to_output_keys={gen_prompt.output_keys[0]: ["model_output"]},
         model_runner=sm_model_runner,
     )
 

--- a/test/unit/eval_algorithms/test_summarization_accuracy.py
+++ b/test/unit/eval_algorithms/test_summarization_accuracy.py
@@ -350,8 +350,7 @@ class TestSummarizationAccuracy:
             prompt_template=test_case.eval_output_prompt_template,
         )
         get_model_response.assert_called_with(
-            input_keys=[DatasetColumns.PROMPT.value.name],
-            output_keys=[DatasetColumns.MODEL_OUTPUT.value.name],
+            input_to_output_keys={DatasetColumns.PROMPT.value.name: [DatasetColumns.MODEL_OUTPUT.value.name]},
             model_runner=model_runner,
         )
         save_dataset.assert_called_once()

--- a/test/unit/transforms/test_semantic_perturbations.py
+++ b/test/unit/transforms/test_semantic_perturbations.py
@@ -32,14 +32,20 @@ def test_semantic_perturbation_init_success():
     """
     GIVEN valid arguments to __init__.
     WHEN a concrete subclass of SemanticPerturbation is initialized.
-    THEN the instance's attributes match what is expected
-        and np.random.default_rng is called with the correct argument.
+    THEN Transform.__init__ is called with the correct arguments,
+        np.random.default_rng is called with the correct argument, and
+        the instance's attributes match what is expected.
     """
 
-    with patch("numpy.random.default_rng") as mock_rng:
+    with patch("numpy.random.default_rng") as mock_rng, patch(
+        "fmeval.transforms.transform.Transform.__init__"
+    ) as mock_transform_init:
         num_perturbations = 3
         seed = 42
         dummy = Dummy("input", ["output_1", "output_2", "output_3"], num_perturbations, seed, "asdf", kw_arg="qwerty")
+        mock_transform_init.assert_called_once_with(
+            "input", ["output_1", "output_2", "output_3"], num_perturbations, seed, "asdf", kw_arg="qwerty"
+        )
         assert dummy.num_perturbations == num_perturbations
         mock_rng.assert_called_once_with(seed)
 

--- a/test/unit/transforms/test_summarization_accuracy_metrics.py
+++ b/test/unit/transforms/test_summarization_accuracy_metrics.py
@@ -13,13 +13,14 @@ def test_meteor_score_init(load_modules):
     """
     GIVEN valid arguments to __init__.
     WHEN a MeteorScore is instantiated.
-    THEN the instance is created without errors, and _load_meteor_modules is called.
+    THEN _load_meteor_modules is called if applicable.
     """
-    with patch("fmeval.transforms.summarization_accuracy_metrics._load_meteor_modules") as mock_load_modules:
+    with patch("fmeval.transforms.summarization_accuracy_metrics.MeteorScore._load_modules") as mock_load_modules:
         MeteorScore(
-            output_key="meteor",
-            target_output_key="target_output",
-            model_output_key="model_output",
+            target_output_keys=["target_output"],
+            model_output_keys=["model_output"],
+            output_keys=["meteor"],
+            allow_duplicate_input_keys=False,
             load_meteor_modules=load_modules,
         )
         if load_modules:
@@ -44,10 +45,10 @@ def test_meteor_score_call():
 
         mock_word_tokenize.side_effect = ["tokenized_target_output", "tokenized_model_output"]
         ms = MeteorScore(
-            output_key="meteor",
-            target_output_key="target_output",
-            model_output_key="model_output",
-            load_meteor_modules=False,
+            target_output_keys=["target_output"],
+            model_output_keys=["model_output"],
+            output_keys=["meteor"],
+            allow_duplicate_input_keys=False,
         )
         sample = {"target_output": "Hello there!", "model_output": "Hi"}
         ms(sample)
@@ -63,9 +64,10 @@ def test_rouge_score_init():
     """
     with patch("fmeval.transforms.summarization_accuracy_metrics.hf_evaluate.load") as mock_load:
         RougeScore(
-            output_key="rouge",
-            target_output_key="target_output",
-            model_output_key="model_output",
+            target_output_keys=["target_output"],
+            model_output_keys=["model_output"],
+            output_keys=["rouge"],
+            allow_duplicate_input_keys=False,
         )
         mock_load.assert_called_once_with("rouge")
 
@@ -87,9 +89,10 @@ def test_rouge_score_call():
         mock_hf_load.return_value = mock_rouge_metric
 
         rs = RougeScore(
-            output_key="rouge",
-            target_output_key="target_output",
-            model_output_key="model_output",
+            target_output_keys=["target_output"],
+            model_output_keys=["model_output"],
+            output_keys=["rouge"],
+            allow_duplicate_input_keys=False,
             rouge_type=rouge_type,
         )
         sample = {"target_output": "Hello there!", "model_output": "Hi"}
@@ -115,9 +118,10 @@ def test_bert_score_call_with_bertscore_model_object():
     mock_bertscore_model.invoke_model = Mock()
 
     bs = BertScore(
-        output_key="bertscore",
-        target_output_key="target_output",
-        model_output_key="model_output",
+        target_output_keys=["target_output"],
+        model_output_keys=["model_output"],
+        output_keys=["bertscore"],
+        allow_duplicate_input_keys=False,
         bertscore_model=mock_bertscore_model,
     )
     sample = {"target_output": "Hello there!", "model_output": "Hi"}
@@ -140,9 +144,10 @@ def test_bert_score_call_with_ray_actor_handle():
 
     with patch("fmeval.transforms.summarization_accuracy_metrics.ray.get") as mock_ray_get:
         bs = BertScore(
-            output_key="bertscore",
-            target_output_key="target_output",
-            model_output_key="model_output",
+            target_output_keys=["target_output"],
+            model_output_keys=["model_output"],
+            output_keys=["bertscore"],
+            allow_duplicate_input_keys=False,
             bertscore_model=mock_bertscore_model,
         )
         sample = {"target_output": "Hello there!", "model_output": "Hi"}
@@ -175,10 +180,10 @@ class TestCaseMetricNumericalValues(NamedTuple):
 )
 def test_meteor_numerical_values(test_case):
     ms = MeteorScore(
-        output_key="meteor",
-        target_output_key="target_output",
-        model_output_key="model_output",
-        load_meteor_modules=False,
+        target_output_keys=["target_output"],
+        model_output_keys=["model_output"],
+        output_keys=["meteor"],
+        allow_duplicate_input_keys=False,
     )
     sample = {"target_output": test_case.target_output, "model_output": test_case.model_output}
     output = ms(sample)
@@ -219,9 +224,10 @@ def test_meteor_numerical_values(test_case):
 )
 def test_get_rouge_score(test_case):
     rs = RougeScore(
-        output_key="rouge",
-        target_output_key="target_output",
-        model_output_key="model_output",
+        target_output_keys=["target_output"],
+        model_output_keys=["model_output"],
+        output_keys=["rouge"],
+        allow_duplicate_input_keys=False,
         rouge_type=test_case.rouge_type,
     )
     sample = {"target_output": test_case.target_output, "model_output": test_case.model_output}

--- a/test/unit/transforms/test_summarization_accuracy_metrics.py
+++ b/test/unit/transforms/test_summarization_accuracy_metrics.py
@@ -13,7 +13,7 @@ def test_meteor_score_init(load_modules):
     """
     GIVEN valid arguments to __init__.
     WHEN a MeteorScore is instantiated.
-    THEN _load_meteor_modules is called if applicable.
+    THEN _load_modules is called if applicable.
     """
     with patch("fmeval.transforms.summarization_accuracy_metrics.MeteorScore._load_modules") as mock_load_modules:
         MeteorScore(
@@ -21,7 +21,7 @@ def test_meteor_score_init(load_modules):
             model_output_keys=["model_output"],
             output_keys=["meteor"],
             allow_duplicate_input_keys=False,
-            load_meteor_modules=load_modules,
+            load_modules=load_modules,
         )
         if load_modules:
             mock_load_modules.assert_called_once()

--- a/test/unit/transforms/test_transform.py
+++ b/test/unit/transforms/test_transform.py
@@ -99,6 +99,16 @@ def test_register_input_output_keys_failure(input_keys, output_keys, err_msg):
         d.register_input_output_keys(input_keys, output_keys)
 
 
+def test_register_input_output_keys_duplicate_keys_allowed():
+    """
+    GIVEN a list of input keys with duplicate values.
+    WHEN register_input_output_keys is called with `allow_duplicates` = True.
+    THEN no exceptions are raised due to duplicate keys being found.
+    """
+    d = DummyTransform([123], {"k": "v"})
+    d.register_input_output_keys(["a", "a"], ["b"], allow_duplicates=True)
+
+
 def test_repr():
     """
     GIVEN a valid Transform instance.

--- a/test/unit/transforms/test_transform_pipeline.py
+++ b/test/unit/transforms/test_transform_pipeline.py
@@ -1,7 +1,8 @@
 import re
-from unittest.mock import Mock
-
+import os
 import pytest
+
+from unittest.mock import Mock
 from typing import Any, List, NamedTuple, Dict
 
 from fmeval.constants import TRANSFORM_PIPELINE_MAX_SIZE
@@ -13,6 +14,8 @@ from fmeval.transforms.transform_pipeline import TransformPipeline, NestedTransf
 TRANSFORM_1 = GeneratePrompt(["input_1"], ["output_1"], "1")
 TRANSFORM_2 = GeneratePrompt(["input_2"], ["output_2"], "2")
 TRANSFORM_3 = GeneratePrompt(["input_3"], ["output_3"], "3")
+
+os.environ["PARALLELIZATION_FACTOR"] = "2"
 
 
 class TestCaseInit(NamedTuple):
@@ -155,8 +158,7 @@ def test_execute():
             42,
         ),
         fn_constructor_kwargs={"kw_arg": "Hello there"},
-        num_cpus=(1 / TRANSFORM_PIPELINE_MAX_SIZE),
-        concurrency=1.0,
+        concurrency=(1, 2),
     )
 
 


### PR DESCRIPTION
*Description of changes:*
This PR makes the following changes:
1. Update `GetModelResponse` and all three summarization accuracy metric transforms to support multiple input keys
2. Update `TransformPipeline.execute` to materialize intermediate datasets (as I've observed that not materializing the dataset leads to a performance degradation in `SummarizationAccuracy` evaluations). This change causes the performance of `SummarizationAccuracy` to match the performance of the old code.
3. Refactor the summarization accuracy metrics to use a parent ABC, mimicking the approach taken with the semantic perturbation transforms.
4. Fix bug in `semantic_perturbations.py` where I didn't unpack `*args` and `**kwargs`. Updated the unit test to catch this bug.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
