### PR TITLE
feat: update GetModelResponse transform to support multiple model invocations on the same input

### DIFF
--- a/src/fmeval/eval_algorithms/summarization_accuracy.py
+++ b/src/fmeval/eval_algorithms/summarization_accuracy.py
@@ -185,7 +185,9 @@ class SummarizationAccuracy(EvalAlgorithmInterface):
                     prompt_template=dataset_prompt_template,
                 )
                 get_model_response = GetModelResponse(
-                    input_to_output_keys={DatasetColumns.PROMPT.value.name: [DatasetColumns.MODEL_OUTPUT.value.name]},
+                    input_key_to_response_keys={
+                        DatasetColumns.PROMPT.value.name: [(DatasetColumns.MODEL_OUTPUT.value.name,)]
+                    },
                     model_runner=model,
                 )
                 pipeline = TransformPipeline([gen_prompt, get_model_response, pipeline])

--- a/test/integration/transforms/test_transform_pipeline.py
+++ b/test/integration/transforms/test_transform_pipeline.py
@@ -22,7 +22,7 @@ def test_pipeline_execution():
     )
 
     get_model_response = GetModelResponse(
-        input_to_output_keys={gen_prompt.output_keys[0]: ["model_output"]},
+        input_key_to_response_keys={gen_prompt.output_keys[0]: [("model_output",)]},
         model_runner=sm_model_runner,
     )
 

--- a/test/unit/eval_algorithms/test_summarization_accuracy.py
+++ b/test/unit/eval_algorithms/test_summarization_accuracy.py
@@ -16,18 +16,10 @@ from fmeval.eval_algorithms import (
     CategoryScore,
     EvalOutput,
     EvalScore,
-    BUILT_IN_DATASET_DEFAULT_PROMPT_TEMPLATES,
-    DEFAULT_PROMPT_TEMPLATE,
-    GIGAWORD,
-    GOV_REPORT,
 )
 from fmeval.helper_models import BertscoreModel
 from fmeval.transforms.common import GetModelResponse, GeneratePrompt
-from fmeval.transforms.summarization_accuracy_metrics import (
-    ROUGE_1,
-    ROUGE_2,
-    ROUGE_L,
-)
+from fmeval.transforms.summarization_accuracy_metrics import ROUGE_L
 from fmeval.eval_algorithms.summarization_accuracy import (
     SummarizationAccuracyConfig,
     SummarizationAccuracy,
@@ -350,7 +342,7 @@ class TestSummarizationAccuracy:
             prompt_template=test_case.eval_output_prompt_template,
         )
         get_model_response.assert_called_with(
-            input_to_output_keys={DatasetColumns.PROMPT.value.name: [DatasetColumns.MODEL_OUTPUT.value.name]},
+            input_key_to_response_keys={DatasetColumns.PROMPT.value.name: [(DatasetColumns.MODEL_OUTPUT.value.name,)]},
             model_runner=model_runner,
         )
         save_dataset.assert_called_once()

--- a/test/unit/transforms/test_common.py
+++ b/test/unit/transforms/test_common.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import patch
-from typing import NamedTuple, List, Optional, Dict, Any
+from typing import NamedTuple, List, Optional, Dict, Any, Tuple
 
 from fmeval.transforms.common import GeneratePrompt, GetModelResponse
 from fmeval.util import EvalAlgorithmInternalError
@@ -44,7 +44,7 @@ def test_get_model_response_init_success():
     """
     with patch("fmeval.transforms.common.ModelRunner") as mock_model_runner:
         get_model_response = GetModelResponse(
-            input_to_output_keys={"prompt": ["model_output"]}, model_runner=mock_model_runner
+            input_key_to_response_keys={"prompt": [("model_output",)]}, model_runner=mock_model_runner
         )
         assert get_model_response.input_keys == ["prompt"]
         assert get_model_response.output_keys == ["model_output"]
@@ -54,34 +54,34 @@ def test_get_model_response_init_success():
 class TestCaseGetModelResponseSuccess(NamedTuple):
     model_output: Optional[str]
     log_prob: Optional[float]
-    output_keys: List[str]
+    response_keys: List[Tuple[str]]
     expected_result: Dict[str, Any]
 
 
 @pytest.mark.parametrize(
-    "model_output, log_prob, output_keys, expected_result",
+    "model_output, log_prob, response_keys, expected_result",
     [
         TestCaseGetModelResponseSuccess(
             model_output="some output",
             log_prob=-0.162,
-            output_keys=["model_output", "log_prob"],
+            response_keys=[("model_output", "log_prob")],
             expected_result={"input": "Hello", "model_output": "some output", "log_prob": -0.162},
         ),
         TestCaseGetModelResponseSuccess(
             model_output="some output",
             log_prob=None,
-            output_keys=["model_output"],
+            response_keys=[("model_output",)],
             expected_result={"input": "Hello", "model_output": "some output"},
         ),
         TestCaseGetModelResponseSuccess(
             model_output=None,
             log_prob=-0.162,
-            output_keys=["log_prob"],
+            response_keys=[("log_prob",)],
             expected_result={"input": "Hello", "log_prob": -0.162},
         ),
     ],
 )
-def test_get_model_response_call_success(model_output, log_prob, output_keys, expected_result):
+def test_get_model_response_call_success(model_output, log_prob, response_keys, expected_result):
     """
     GIVEN a GetModelResponse instance.
     WHEN its __call__ method is called on a record.
@@ -90,7 +90,7 @@ def test_get_model_response_call_success(model_output, log_prob, output_keys, ex
     with patch("fmeval.transforms.common.ModelRunner") as mock_model_runner:
         mock_model_runner.predict.return_value = (model_output, log_prob)
         get_model_response = GetModelResponse(
-            input_to_output_keys={"input": output_keys}, model_runner=mock_model_runner
+            input_key_to_response_keys={"input": response_keys}, model_runner=mock_model_runner
         )
         sample = {"input": "Hello"}
         result = get_model_response(sample)
@@ -104,11 +104,11 @@ def test_get_model_response_call_multiple_inputs():
     THEN the correct output is returned.
     """
     with patch("fmeval.transforms.common.ModelRunner") as mock_model_runner:
-        mock_model_runner.predict.side_effect = [("output 1", -0.162), ("output 2", -0.189)]
+        mock_model_runner.predict.side_effect = [("output 1", -0.162), ("output 2", -0.189), ("output 3", -0.126)]
         get_model_response = GetModelResponse(
-            input_to_output_keys={
-                "input_1": ["output_key_1", "log_prob_key_1"],
-                "input_2": ["output_key_2", "log_prob_key_2"],
+            input_key_to_response_keys={
+                "input_1": [("output_key_1", "log_prob_key_1"), ("output_key_2", "log_prob_key_2")],
+                "input_2": [("output_key_3", "log_prob_key_3")],
             },
             model_runner=mock_model_runner,
         )
@@ -120,6 +120,8 @@ def test_get_model_response_call_multiple_inputs():
             "input_2": "input 2",
             "output_key_2": "output 2",
             "log_prob_key_2": -0.189,
+            "output_key_3": "output 3",
+            "log_prob_key_3": -0.126,
         }
         result = get_model_response(sample)
         assert result == expected_result
@@ -128,30 +130,30 @@ def test_get_model_response_call_multiple_inputs():
 class TestCaseGetModelResponseFailure(NamedTuple):
     model_output: Optional[str]
     log_prob: Optional[float]
-    output_keys: List[str]
+    response_keys: List[Tuple[str]]
 
 
 @pytest.mark.parametrize(
-    "model_output, log_prob, output_keys",
+    "model_output, log_prob, response_keys",
     [
         TestCaseGetModelResponseFailure(
             model_output="some output",
             log_prob=-0.162,
-            output_keys=["model_output"],
+            response_keys=[("model_output",)],
         ),
         TestCaseGetModelResponseFailure(
             model_output="some output",
             log_prob=None,
-            output_keys=["model_output", "log_prob"],
+            response_keys=[("model_output", "log_prob")],
         ),
         TestCaseGetModelResponseFailure(
             model_output=None,
             log_prob=-0.162,
-            output_keys=["model_output", "log_prob"],
+            response_keys=[("model_output", "log_prob")],
         ),
     ],
 )
-def test_get_model_response_call_failure(model_output, log_prob, output_keys):
+def test_get_model_response_call_failure(model_output, log_prob, response_keys):
     """
     GIVEN a GetModelResponse instance where the number of output keys corresponding to
         a particular input key does not match the number of non-null elements in its model runner's
@@ -163,7 +165,7 @@ def test_get_model_response_call_failure(model_output, log_prob, output_keys):
     with patch("fmeval.transforms.common.ModelRunner") as mock_model_runner:
         mock_model_runner.predict.return_value = (model_output, log_prob)
         get_model_response = GetModelResponse(
-            input_to_output_keys={"input": output_keys},
+            input_key_to_response_keys={"input": response_keys},
             model_runner=mock_model_runner,
         )
         with pytest.raises(EvalAlgorithmInternalError, match="The number of elements in model response"):


### PR DESCRIPTION
*Description of changes:*
This PR updates `GetModelResponse` so that it supports the semantic robustness use case where a model is invoked on the same input multiple times.

Currently, the instance attribute `input_to_output_keys` maps a model input key to a list representing the model response keys (where a response is of the form `(model_output, log_probability)` where both `model_output` and `log_probability` are optional).

This PR changes `input_to_output_keys` such that a model input key is mapped to a list of tuples, where each tuple is of the form `(model_output, log_probability)`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
