### PR TITLE
feat: update implementation of GeneralSemanticRobustness to use Transform-based approach

### DIFF
--- a/src/fmeval/constants.py
+++ b/src/fmeval/constants.py
@@ -97,8 +97,8 @@ SEED = 1234
 
 # Semantic robustness perturbation types
 BUTTER_FINGER = "butter_finger"
-RANDOM_UPPER_CASE = "random_upper_case"
-WHITESPACE_ADD_REMOVE = "whitespace_add_remove"
+RANDOM_UPPERCASE = "random_uppercase"
+ADD_REMOVE_WHITESPACE = "add_remove_whitespace"
 
 PREFIX_FOR_DELTA_SCORES = "delta_"
 
@@ -124,12 +124,3 @@ GENERATED_TEXT_JMESPATH_EXPRESSION = "*.output_keys.generated_text"
 
 # BERTScore
 BERTSCORE_DEFAULT_MODEL = "microsoft/deberta-xlarge-mnli"
-
-# Configures the maximum number of Transforms a TransformPipeline can contain.
-# All built-in evaluation algorithms use on the order of a few dozen Transforms;
-# we set the limit to 100 to support more complicated, user-implemented algorithms.
-# An evaluation algorithm that contains a pipeline with significantly more transforms
-# than this should likely be redesigned. It is worth noting that for optimal performance,
-# the computation that an individual Transform performs should not be too small.
-# See https://docs.ray.io/en/latest/ray-core/patterns/too-fine-grained-tasks.html
-TRANSFORM_PIPELINE_MAX_SIZE = 100

--- a/src/fmeval/eval_algorithms/classification_accuracy_semantic_robustness.py
+++ b/src/fmeval/eval_algorithms/classification_accuracy_semantic_robustness.py
@@ -11,8 +11,8 @@ from fmeval.constants import (
     DatasetColumns,
     MEAN,
     BUTTER_FINGER,
-    RANDOM_UPPER_CASE,
-    WHITESPACE_ADD_REMOVE,
+    RANDOM_UPPERCASE,
+    ADD_REMOVE_WHITESPACE,
     PREFIX_FOR_DELTA_SCORES,
 )
 from fmeval.data_loaders.util import get_dataset
@@ -55,13 +55,13 @@ from fmeval.eval_algorithms.classification_accuracy import (
     CLASSIFICATION_ACCURACY_SCORE,
     UNIQUENESS_FACTOR,
 )
-from fmeval.eval_algorithms.general_semantic_robustness import ButterFinger, RandomUpperCase, WhitespaceAddRemove
+from fmeval.eval_algorithms.semantic_perturbation_utils import ButterFinger, RandomUpperCase, WhitespaceAddRemove
 
 # All the perturbation types supported by this eval algo
 PERTURBATION_TYPE_TO_HELPER_CLASS = {
     BUTTER_FINGER: ButterFinger,
-    RANDOM_UPPER_CASE: RandomUpperCase,
-    WHITESPACE_ADD_REMOVE: WhitespaceAddRemove,
+    RANDOM_UPPERCASE: RandomUpperCase,
+    ADD_REMOVE_WHITESPACE: WhitespaceAddRemove,
 }
 
 PREFIX_FOR_DELTA_SCORES = "delta_"
@@ -82,11 +82,11 @@ class ClassificationAccuracySemanticRobustnessConfig(EvalAlgorithmConfig):
     :param butter_finger_perturbation_prob: The probability that a given character will be perturbed. Used for
         butter_finger perturbation_type
     :param random_uppercase_corrupt_proportion: Fraction of characters to be changed to uppercase. Used for
-        random_upper_case perturbation_type
+        random_uppercase perturbation_type
     :param whitespace_remove_prob: Given a whitespace, remove it with this much probability. Used for
-        whitespace_add_remove perturbation_type
+        add_remove_whitespace perturbation_type
     :param whitespace_add_prob: Given a non-whitespace, add a whitespace before it with this probability. Used for
-        whitespace_add_remove perturbation_type
+        add_remove_whitespace perturbation_type
     """
 
     valid_labels: Optional[List[str]] = None
@@ -141,7 +141,7 @@ class ClassificationAccuracySemanticRobustness(EvalAlgorithmInterface):
 
         if self._eval_algorithm_config.perturbation_type == BUTTER_FINGER:
             self._perturbation_config = ButterFingerConfig(self._eval_algorithm_config.butter_finger_perturbation_prob)
-        elif self._eval_algorithm_config.perturbation_type == RANDOM_UPPER_CASE:
+        elif self._eval_algorithm_config.perturbation_type == RANDOM_UPPERCASE:
             self._perturbation_config = RandomUpperCaseConfig(
                 self._eval_algorithm_config.random_uppercase_corrupt_proportion
             )

--- a/src/fmeval/eval_algorithms/general_semantic_robustness.py
+++ b/src/fmeval/eval_algorithms/general_semantic_robustness.py
@@ -1,20 +1,14 @@
-import functools
 import itertools
 import logging
-
-import evaluate as hf_evaluate
 from dataclasses import dataclass
 from typing import Optional, List, Dict, Any
-import numpy as np
-from ray.data import Dataset
 
-from fmeval import util
 from fmeval.constants import (
     DatasetColumns,
     MEAN,
     BUTTER_FINGER,
-    RANDOM_UPPER_CASE,
-    WHITESPACE_ADD_REMOVE,
+    RANDOM_UPPERCASE,
+    ADD_REMOVE_WHITESPACE,
 )
 from fmeval.data_loaders.data_config import DataConfig
 from fmeval.data_loaders.util import get_dataset
@@ -22,78 +16,82 @@ from fmeval.eval_algorithms import (
     EvalAlgorithm,
     EvalScore,
     EvalOutput,
-    DATASET_CONFIGS,
-    EVAL_DATASETS,
     DEFAULT_PROMPT_TEMPLATE,
     get_default_prompt_template,
 )
 from fmeval.eval_algorithms.eval_algorithm import EvalAlgorithmConfig, EvalAlgorithmInterface
-from fmeval.eval_algorithms.semantic_perturbation_utils import (
+from fmeval.helper_models import BertscoreModelTypes, BertscoreModel
+from fmeval.transforms.common import GeneratePrompt, GetModelResponse
+from fmeval.transforms.semantic_perturbations import (
     ButterFinger,
-    RandomUpperCase,
-    WhitespaceAddRemove,
-    ButterFingerConfig,
-    RandomUpperCaseConfig,
-    WhitespaceAddRemoveConfig,
+    RandomUppercase,
+    AddRemoveWhitespace,
 )
 from fmeval.eval_algorithms.util import (
     validate_dataset,
     save_dataset,
     aggregate_evaluation_scores,
     generate_output_dataset_path,
-    generate_prompt_column_for_dataset,
-    generate_model_predict_response_for_dataset,
     verify_model_determinism,
+    get_dataset_configs,
 )
 from fmeval.exceptions import EvalAlgorithmClientError
 from fmeval.model_runners.composers.composers import PromptComposer
 from fmeval.model_runners.model_runner import ModelRunner
 from fmeval.perf_util import timed_block
-from fmeval.eval_algorithms.util import get_bert_score
 from fmeval.constants import BERTSCORE_DEFAULT_MODEL
-from fmeval.eval_algorithms.helper_models.helper_model import BertscoreHelperModel, BertscoreHelperModelTypes
+from fmeval.eval_algorithms.helper_models.helper_model import BertscoreHelperModelTypes
+from fmeval.transforms.summarization_accuracy_metrics import BertScore
+from fmeval.transforms.semantic_robustness_metrics import BertScoreDissimilarity, WER
+from fmeval.transforms.transform import Transform
+from fmeval.transforms.transform_pipeline import TransformPipeline
+from fmeval.transforms.util import create_output_key
+from fmeval.util import create_shared_resource
 
 logger = logging.getLogger(__name__)
 
 # All the perturbation types supported by this eval algo
 PERTURBATION_TYPE_TO_HELPER_CLASS = {
     BUTTER_FINGER: ButterFinger,
-    RANDOM_UPPER_CASE: RandomUpperCase,
-    WHITESPACE_ADD_REMOVE: WhitespaceAddRemove,
+    RANDOM_UPPERCASE: RandomUppercase,
+    ADD_REMOVE_WHITESPACE: AddRemoveWhitespace,
 }
 
 WER_SCORE = "word_error_rate"
 BERT_SCORE_DISSIMILARITY = "bertscore_dissimilarity"
+BASELINE_SUFFIX = "baseline"
+BASELINE_WER_SCORE = f"{WER_SCORE}_{BASELINE_SUFFIX}"
+BASELINE_BERT_SCORE_DISSIMILARITY = f"{BERT_SCORE_DISSIMILARITY}_{BASELINE_SUFFIX}"
 
 
 @dataclass(frozen=True)
 class GeneralSemanticRobustnessConfig(EvalAlgorithmConfig):
-    """
-    Configuration for the general semantic robustness eval algorithm.
+    """Configures the general semantic robustness evaluation algorithm.
 
-    :param perturbation_type: perturbation type for generating perturbed inputs
-    :param num_perturbations: Number of perturbed inputs to be generated for robustness evaluation
+    :param perturbation_type: Perturbation type for generating perturbed inputs.
+        Either BUTTER_FINGER, RANDOM_UPPERCASE, or ADD_REMOVE_WHITESPACE.
+    :param num_perturbations: Number of perturbed outputs to be generated for robustness evaluation.
     :param num_baseline_samples: Only used for non-deterministic models. Number of times we generate
         the model output with the same input to compute the "baseline" change in model output. We
         compute differences between all pairs of outputs, i.e. between comb(num_baseline_samples, 2) pairs.
-    :param butter_finger_perturbation_prob: The probability that a given character will be perturbed. Used for
-        butter_finger perturbation_type
-    :param random_uppercase_corrupt_proportion: Fraction of characters to be changed to uppercase. Used for
-        random_upper_case perturbation_type
-    :param whitespace_remove_prob: Given a whitespace, remove it with this much probability. Used for
-        whitespace_add_remove perturbation_type
-    :param whitespace_add_prob: Given a non-whitespace, add a whitespace before it with this probability. Used for
-        whitespace_add_remove perturbation_type
-    :param model_type_for_bertscore: model to use for bert score
+    :param butter_finger_perturbation_prob: The probability that a given character will be perturbed.
+        Used when perturbation_type is BUTTER_FINGER.
+    :param random_uppercase_fraction: Fraction of characters to be changed to uppercase.
+        Used when perturbation_type is RANDOM_UPPERCASE.
+    :param whitespace_remove_prob: The probability of removing a whitespace character.
+        Used when perturbation_type is ADD_REMOVE_WHITESPACE.
+    :param whitespace_add_prob: The probability of adding a whitespace character after a non-whitespace character.
+        Used when perturbation_type is ADD_REMOVE_WHITESPACE.
+    :param model_type_for_bertscore: Model type to use for BERT score.
     """
 
     perturbation_type: str = BUTTER_FINGER
     num_perturbations: int = 5
     num_baseline_samples: int = 4
     butter_finger_perturbation_prob: float = 0.1
-    random_uppercase_corrupt_proportion: float = 0.1
-    whitespace_remove_prob: float = 0.1
+    random_uppercase_fraction: float = 0.1
     whitespace_add_prob: float = 0.05
+    whitespace_remove_prob: float = 0.1
     model_type_for_bertscore: str = BERTSCORE_DEFAULT_MODEL
 
     def __post_init__(self):
@@ -105,18 +103,17 @@ class GeneralSemanticRobustnessConfig(EvalAlgorithmConfig):
         if not BertscoreHelperModelTypes.model_is_allowed(self.model_type_for_bertscore):
             raise EvalAlgorithmClientError(
                 f"Invalid model_type_for_bertscore: {self.model_type_for_bertscore} requested in "
-                f"GeneralSemanticRobustnessConfig, please choose from acceptable values: {BertscoreHelperModelTypes.model_list()}."
+                f"GeneralSemanticRobustnessConfig, please choose from acceptable values: {BertscoreModelTypes.model_list()}."
             )
         if self.num_baseline_samples < 2:
             raise EvalAlgorithmClientError(
-                f"Invalid num_baseline_samples: {self.num_baseline_samples} in GeneralSemanticRobusntessConfig. "
+                f"Invalid num_baseline_samples: {self.num_baseline_samples} in GeneralSemanticRobustnessConfig. "
                 f"The value should be at least 2."
             )
 
 
 class GeneralSemanticRobustness(EvalAlgorithmInterface):
-    """
-    Semantic Robustness Eval algorithm for General task LLMs.
+    """Semantic Robustness evaluation algorithm for general task LLMs.
 
     This evaluation measures how much the model output changes as a result of semantic preserving
     perturbations. Given the input, e.g., "A quick brown fox jumps over the lazy dog", the
@@ -126,7 +123,7 @@ class GeneralSemanticRobustness(EvalAlgorithmInterface):
     original vs. perturbed input.
 
     The output difference is measured using two metrics: the Word Error Rate
-    (https://huggingface.co/spaces/evaluate-metric/wer) and the BERTScore Dissimilarity, which  is
+    (https://huggingface.co/spaces/evaluate-metric/wer) and the BERTScore Dissimilarity, which is
     1 - BERTScore (https://huggingface.co/spaces/evaluate-metric/bertscore), between the original
     and the perturbed outputs. Word Error Rate measures syntactic differences, that is, changes in
     the words, whereas BERTScore Dissimilarity measures semantic differences. Semantic differences
@@ -143,129 +140,237 @@ class GeneralSemanticRobustness(EvalAlgorithmInterface):
     differences between the model output on the same input.
     """
 
-    def __init__(self, eval_algorithm_config: GeneralSemanticRobustnessConfig = GeneralSemanticRobustnessConfig()):
-        """Default constructor
+    eval_name = EvalAlgorithm.GENERAL_SEMANTIC_ROBUSTNESS.value
 
-        :param eval_algorithm_config: General Semantic Robustness eval algorithm config.
+    def __init__(
+        self,
+        eval_algorithm_config: GeneralSemanticRobustnessConfig = GeneralSemanticRobustnessConfig(),
+        use_ray: bool = True,
+    ):
+        """GeneralSemanticRobustness initializer.
+
+        :param eval_algorithm_config: General semantic robustness evaluation algorithm config.
+        :param use_ray: Whether to create a Ray actor for the BertscoreModel used by this evaluation
+            algorithm instance. Currently, `evaluate` will only work if `use_ray` is set to True,
+            as the execution of the transform pipeline relies on the BertscoreModel existing
+            in shared memory. This flag can be set to False if you only plan on invoking the
+            `evaluate_sample` method, which is a computationally cheap operation that does not
+            require utilizing Ray for parallel execution.
         """
         super().__init__(eval_algorithm_config)
-        self.eval_name = EvalAlgorithm.GENERAL_SEMANTIC_ROBUSTNESS.value
-        self._eval_algorithm_config = eval_algorithm_config
-        self._is_model_deterministic: Optional[bool] = None
+        self.num_perturbations = eval_algorithm_config.num_perturbations
+        self.num_baseline_samples = eval_algorithm_config.num_baseline_samples
 
-        if self._eval_algorithm_config.perturbation_type == BUTTER_FINGER:
-            self._perturbation_config = ButterFingerConfig(self._eval_algorithm_config.butter_finger_perturbation_prob)
-        elif self._eval_algorithm_config.perturbation_type == RANDOM_UPPER_CASE:
-            self._perturbation_config = RandomUpperCaseConfig(
-                self._eval_algorithm_config.random_uppercase_corrupt_proportion
+        if eval_algorithm_config.perturbation_type == BUTTER_FINGER:
+            self.perturbation_transform = ButterFinger(
+                input_key=DatasetColumns.MODEL_INPUT.value.name,
+                output_keys=[
+                    create_output_key(ButterFinger.__name__, DatasetColumns.MODEL_INPUT.value.name, i)
+                    for i in range(self.num_perturbations)
+                ],
+                num_perturbations=self.num_perturbations,
+                perturbation_prob=eval_algorithm_config.butter_finger_perturbation_prob,
+            )
+        elif eval_algorithm_config.perturbation_type == RANDOM_UPPERCASE:
+            self.perturbation_transform = RandomUppercase(
+                input_key=DatasetColumns.MODEL_INPUT.value.name,
+                output_keys=[
+                    create_output_key(RandomUppercase.__name__, DatasetColumns.MODEL_INPUT.value.name, i)
+                    for i in range(self.num_perturbations)
+                ],
+                num_perturbations=self.num_perturbations,
+                uppercase_fraction=eval_algorithm_config.random_uppercase_fraction,
             )
         else:
-            self._perturbation_config = WhitespaceAddRemoveConfig(
-                self._eval_algorithm_config.whitespace_remove_prob, self._eval_algorithm_config.whitespace_add_prob
+            self.perturbation_transform = AddRemoveWhitespace(
+                input_key=DatasetColumns.MODEL_INPUT.value.name,
+                output_keys=[
+                    create_output_key(AddRemoveWhitespace.__name__, DatasetColumns.MODEL_INPUT.value.name, i)
+                    for i in range(self.num_perturbations)
+                ],
+                num_perturbations=self.num_perturbations,
+                add_prob=eval_algorithm_config.whitespace_add_prob,
+                remove_prob=eval_algorithm_config.whitespace_remove_prob,
             )
 
-        self._bertscore_helper_model = BertscoreHelperModel.remote(
-            model_type=self._eval_algorithm_config.model_type_for_bertscore
+        self.bertscore_model = BertscoreModel(eval_algorithm_config.model_type_for_bertscore)
+        if use_ray:
+            self.bertscore_model = create_shared_resource(self.bertscore_model)
+
+    def build_pipeline(
+        self,
+        model: ModelRunner,
+        prompt_template: str,
+        is_deterministic: bool,
+    ) -> TransformPipeline:
+        """Build the TransformPipeline to be used by `evaluate` and `evaluate_sample`.
+
+        While other evaluation algorithms (e.g. Summarization Accuracy) can configure
+        their TransformPipeline at algorithm initialization, because the General
+        Semantic Robustness algorithm's evaluation logic depends on the ModelRunner
+        and prompt template that are evaluation-specific (i.e. these parameters aren't
+        configured at the algorithm level), the pipeline used by the GSR algorithm is built
+        when `evaluate` or `evaluate_sample` is called.
+
+        :param model: The ModelRunner representing the model under evaluation.
+        :param prompt_template: A template that is used to construct the prompt fed to the model.
+        :param is_deterministic: Whether `model` produces deterministic results.
+            In `evaluate_sample`, this is computed by invoking the model with the
+            same input twice, and checking if the model output is the same.
+            In `evaluate`, similar logic is used, but instead of using just a single input,
+            multiple inputs from the dataset are used.
+        :returns: A TransformPipeline that can be used by either `evaluate_sample` or `evaluate`.
+        """
+        get_perturbed_inputs = self.perturbation_transform
+
+        # Generate prompts from perturbed inputs
+        gen_perturbed_prompts = GeneratePrompt(
+            input_keys=get_perturbed_inputs.output_keys,
+            output_keys=[
+                create_output_key(GeneratePrompt.__name__, perturbed_input_key)
+                for perturbed_input_key in get_perturbed_inputs.output_keys
+            ],
+            prompt_template=prompt_template,
         )
 
-    def _compute_baseline_scores(
-        self, model: ModelRunner, original_prompt: str, original_model_output
-    ) -> Dict[str, float]:
-        """
-        Private method for computing baseline scores. The baseline scores are required when the model
-        output is non-deterministic and measure the change in the model output with the same input.
-        See the class documentation for how the baseline scores are computed and used.
+        # Invoke model with prompts generated above
+        get_perturbed_responses = GetModelResponse(
+            input_key_to_response_keys={
+                perturbed_prompt_key: [(create_output_key(GetModelResponse.__name__, perturbed_prompt_key),)]
+                for perturbed_prompt_key in gen_perturbed_prompts.output_keys
+            },
+            model_runner=model,
+        )
 
-        :param model: An instance of ModelRunner which is the model under evaluation
-        :param original_prompt: The input prompt to the model. Assumes that the input is already
-            embedded into the prompt template.
-        :param original_model_output: The output of the model on the original input prompt.
+        original_model_output_key = DatasetColumns.MODEL_OUTPUT.value.name
+        # Compute BERTScores with target_output = the original model output
+        # and model_output = the output from invoking the model with the perturbed prompt.
+        get_bert_scores = BertScore(
+            target_output_keys=[original_model_output_key for _ in range(self.num_perturbations)],
+            model_output_keys=get_perturbed_responses.output_keys,
+            output_keys=[create_output_key(BertScore.__name__, i) for i in range(self.num_perturbations)],
+            allow_duplicate_input_keys=True,
+            bertscore_model=self.bertscore_model,
+        )
 
-        :return: A dict containing the score name to baseline score value mapping.
-        """
-        model_outputs = [
-            model.predict(original_prompt)[0] for _ in range(self._eval_algorithm_config.num_baseline_samples - 1)
+        compute_bertscore_dissimilarity = BertScoreDissimilarity(
+            bert_score_keys=get_bert_scores.output_keys,
+            output_key=BERT_SCORE_DISSIMILARITY,
+        )
+
+        compute_wer_metric = WER(
+            prediction_keys=get_perturbed_responses.output_keys,
+            reference_keys=[original_model_output_key for _ in range(self.num_perturbations)],
+            output_key=WER_SCORE,
+        )
+
+        transforms = [
+            get_perturbed_inputs,
+            gen_perturbed_prompts,
+            get_perturbed_responses,
+            get_bert_scores,
+            compute_bertscore_dissimilarity,
+            compute_wer_metric,
         ]
-        model_outputs.append(original_model_output)
-        all_pairs = itertools.combinations(model_outputs, 2)
-        first_output, second_output = zip(*all_pairs)
-        baselines = dict()
 
-        baselines[BERT_SCORE_DISSIMILARITY] = 1 - np.mean(
-            list(
-                map(
-                    functools.partial(get_bert_score, helper_model=self._bertscore_helper_model),
-                    first_output,
-                    second_output,
-                )
+        pipeline = TransformPipeline(transforms)
+
+        # If the model is not deterministic, we execute additional steps
+        # to compute baseline scores for both BERTScore and WER.
+        if not is_deterministic:
+            # Invoke the model with the original (i.e. unperturbed) prompt
+            # self.num_baseline_samples - 1 times.
+            baseline_response_keys = [
+                create_output_key(GeneratePrompt.__name__, BASELINE_SUFFIX, i)
+                for i in range(self.num_baseline_samples - 1)
+            ]
+            get_baseline_responses = GetModelResponse(
+                input_key_to_response_keys={
+                    DatasetColumns.PROMPT.value.name: [
+                        (baseline_response_key,) for baseline_response_key in baseline_response_keys
+                    ]
+                },
+                model_runner=model,
             )
-        )
 
-        wer = hf_evaluate.load("wer")
-        baselines[WER_SCORE] = wer.compute(predictions=first_output, references=second_output)
+            # Get every possible pair of model outputs.
+            # The first output in the pair is treated as the target output
+            # and the second output is treated as the model output
+            # when computing the BERTScore.
+            baseline_keys = baseline_response_keys + [DatasetColumns.MODEL_OUTPUT.value.name]
+            all_pairs = itertools.combinations(baseline_keys, 2)
+            first_output_keys, second_output_keys = zip(*all_pairs)
 
-        return baselines
+            # Compute baseline BERTScores and then compute BERTScore Dissimilarity using these BERTScores.
+            get_baseline_bert_scores = BertScore(
+                target_output_keys=list(first_output_keys),
+                model_output_keys=list(second_output_keys),
+                output_keys=[
+                    create_output_key(BertScore.__name__, BASELINE_SUFFIX, i) for i in range(len(first_output_keys))
+                ],
+                allow_duplicate_input_keys=True,
+                bertscore_model=self.bertscore_model,
+            )
+            compute_baseline_bertscore_dissimilarity = BertScoreDissimilarity(
+                bert_score_keys=get_baseline_bert_scores.output_keys,
+                output_key=BASELINE_BERT_SCORE_DISSIMILARITY,
+            )
+
+            # Compute WER metric using the baseline model outputs.
+            compute_baseline_wer_metric = WER(
+                prediction_keys=list(first_output_keys),
+                reference_keys=list(second_output_keys),
+                output_key=BASELINE_WER_SCORE,
+            )
+            # Update BERTScore Dissimilarity and WER metrics
+            # given the new baseline scores that have been computed.
+            update_scores = UpdateRobustnessScores()
+
+            # Extend the pipeline with these additional steps.
+            additional_steps = TransformPipeline(
+                [
+                    get_baseline_responses,
+                    get_baseline_bert_scores,
+                    compute_baseline_bertscore_dissimilarity,
+                    compute_baseline_wer_metric,
+                    update_scores,
+                ]
+            )
+            pipeline = TransformPipeline([pipeline, additional_steps])
+
+        return pipeline
 
     def evaluate_sample(
         self,
         model_input: str,
         model: ModelRunner,
-        model_output: Optional[str] = None,
         prompt_template: str = DEFAULT_PROMPT_TEMPLATE,
     ) -> List[EvalScore]:  # type: ignore[override]
-        """
-        Semantic Robustness evaluate sample.
+        """Compute general semantic robustness metrics for a single sample.
 
-        :param model_input: text input for model
-        :param model: An instance of ModelRunner which is the model under evaluation
-        :param model_output: The output of a model that we want to evaluate.
-        :param prompt_template: A template which can be used to compose prompt using model_input
-        :return: list of EvalScore object
+        :param model_input: Text input for model.
+        :param model: An instance of ModelRunner representing the model under evaluation.
+        :param prompt_template: A template that is used in conjunction with `model_input`
+            to construct the prompt that is fed to the model.
+        :returns: A list of EvalScore objects, one for each of the robustness metrics.
         """
-        util.require(model_input, "Missing required input: model_input, for GeneralSemanticRobustness evaluate_sample")
-        util.require(
-            model, "Missing required input: model i.e. ModelRunner, for GeneralSemanticRobustness " "evaluate_sample"
-        )
-
+        # Determine whether model produces deterministic outputs, as this affects
+        # what steps will be included in the TransformPipeline.
         prompt_composer = PromptComposer(prompt_template)
-        original_prompt = prompt_composer.compose(model_input)
-        original_model_output = model_output if model_output else model.predict(original_prompt)[0]
+        prompt = prompt_composer.compose(model_input)
+        model_output = model.predict(prompt)[0]
+        is_deterministic = model_output == model.predict(prompt)[0]
 
-        is_model_deterministic = self._is_model_deterministic
-        if is_model_deterministic is None:
-            is_model_deterministic = model.predict(original_prompt)[0] == original_model_output
+        sample = {
+            DatasetColumns.MODEL_INPUT.value.name: model_input,
+            DatasetColumns.PROMPT.value.name: prompt,
+            DatasetColumns.MODEL_OUTPUT.value.name: model_output,
+        }
+        pipeline = self.build_pipeline(model, prompt_template, is_deterministic=is_deterministic)
+        output_record = pipeline.execute_record(sample)
 
-        perturbation = PERTURBATION_TYPE_TO_HELPER_CLASS[self._eval_algorithm_config.perturbation_type]()
-        perturbed_inputs = perturbation.perturb(
-            text=model_input,
-            config=self._perturbation_config,
-            num_perturbations=self._eval_algorithm_config.num_perturbations,
-        )
-        perturbed_input_prompts = [prompt_composer.compose(perturbed_input) for perturbed_input in perturbed_inputs]
-        perturbed_input_outputs = [model.predict(prompt)[0] for prompt in perturbed_input_prompts]
-
-        bert_score_dissimilarity_value = 1 - np.mean(
-            list(
-                map(
-                    functools.partial(get_bert_score, helper_model=self._bertscore_helper_model),
-                    itertools.repeat(original_model_output, len(perturbed_input_outputs)),
-                    perturbed_input_outputs,
-                )
-            )
-        )
-        wer = hf_evaluate.load("wer")
-        wer_value = wer.compute(
-            predictions=perturbed_input_outputs,
-            references=list(itertools.repeat(original_model_output, self._eval_algorithm_config.num_perturbations)),
-        )
-
-        if not is_model_deterministic:  # Compute the baseline differences in the model outputs for the same input
-            baselines = self._compute_baseline_scores(model, original_prompt, original_model_output)
-            bert_score_dissimilarity_value = max(
-                0, bert_score_dissimilarity_value - baselines[BERT_SCORE_DISSIMILARITY]
-            )
-            wer_value = max(0, wer_value - baselines[WER_SCORE])
-
+        bert_score_dissimilarity_value = output_record[BERT_SCORE_DISSIMILARITY]
+        wer_value = output_record[WER_SCORE]
         return [
             EvalScore(name=BERT_SCORE_DISSIMILARITY, value=bert_score_dissimilarity_value),
             EvalScore(name=WER_SCORE, value=wer_value),
@@ -279,28 +384,20 @@ class GeneralSemanticRobustness(EvalAlgorithmInterface):
         save: bool = False,
         num_records=100,
     ) -> List[EvalOutput]:
-        """
-        Semantic Robustness evaluate.
+        """Perform general semantic robustness evaluation on a dataset.
 
-        :param model: An instance of ModelRunner which is the model under evaluation
-        :param dataset_config: Configures the single dataset used for evaluation. If not provided,
-            evaluation will use all of it's supported built-in datasets
-        :param prompt_template: A template which can be used to generate prompts, optional, if not provided defaults
-            will be used.
-        :param save: If set to true, prompt responses and scores will be saved to file. The output is written to
-                     EvalAlgorithmInterface.EVAL_RESULTS_PATH
-        :param num_records: The number of records to be sampled randomly from the input dataset to perform the
-                            evaluation
-        :return: List of EvalOutput objects.
+        :param model: An instance of ModelRunner representing the model under evaluation.
+        :param dataset_config: Configures the single dataset used for evaluation.
+            If not provided, evaluation will use all of its supported built-in datasets.
+        :param prompt_template: A template used to generate prompts.
+            If not provided, defaults will be used.
+        :param save: If set to true, prompt responses and scores will be saved to a file.
+            The output is written to EvalAlgorithmInterface.EVAL_RESULTS_PATH.
+        :param num_records: The number of records to be sampled randomly from the input dataset
+            to perform the evaluation
+        :return: A list of EvalOutput objects.
         """
-        util.require(
-            model, "Missing required input: model i.e. ModelRunner, for GeneralSemanticRobustness evaluate method"
-        )
-        if dataset_config:
-            dataset_configs = [dataset_config]
-        else:
-            dataset_configs = [DATASET_CONFIGS[dataset_name] for dataset_name in EVAL_DATASETS[self.eval_name]]
-
+        dataset_configs = get_dataset_configs(dataset_config, self.eval_name)
         eval_outputs = []
         for dataset_config in dataset_configs:
             dataset = get_dataset(dataset_config, num_records)
@@ -308,23 +405,24 @@ class GeneralSemanticRobustness(EvalAlgorithmInterface):
             dataset_prompt_template = (
                 get_default_prompt_template(dataset_config.dataset_name) if not prompt_template else prompt_template
             )
-            dataset = generate_prompt_column_for_dataset(
-                dataset_prompt_template,
-                dataset,
-                DatasetColumns.MODEL_INPUT.value.name,
-                DatasetColumns.PROMPT.value.name,
+            gen_prompt = GeneratePrompt(
+                input_keys=[DatasetColumns.MODEL_INPUT.value.name],
+                output_keys=[DatasetColumns.PROMPT.value.name],
+                prompt_template=dataset_prompt_template,
             )
+            get_model_response = GetModelResponse(
+                input_key_to_response_keys={
+                    DatasetColumns.PROMPT.value.name: [(DatasetColumns.MODEL_OUTPUT.value.name,)]
+                },
+                model_runner=model,
+            )
+            model_invocation_pipeline = TransformPipeline([gen_prompt, get_model_response])
+            dataset = model_invocation_pipeline.execute(dataset)
+            is_deterministic = verify_model_determinism(model, dataset, DatasetColumns.PROMPT.value.name)
+            pipeline = self.build_pipeline(model, dataset_prompt_template, is_deterministic=is_deterministic)
 
-            self._is_model_deterministic = verify_model_determinism(model, dataset, DatasetColumns.PROMPT.value.name)
-            dataset = generate_model_predict_response_for_dataset(
-                model=model,
-                data=dataset,
-                model_input_column_name=DatasetColumns.PROMPT.value.name,
-                model_output_column_name=DatasetColumns.MODEL_OUTPUT.value.name,
-            )
             with (timed_block(f"Computing score and aggregation on dataset {dataset_config.dataset_name}", logger)):
-
-                dataset = self.__add_scores_to_dataset(dataset, model, dataset_prompt_template)
+                dataset = pipeline.execute(dataset)
                 dataset_scores, category_scores = aggregate_evaluation_scores(
                     dataset, [BERT_SCORE_DISSIMILARITY, WER_SCORE], agg_method=MEAN
                 )
@@ -342,8 +440,7 @@ class GeneralSemanticRobustness(EvalAlgorithmInterface):
                         ),
                     )
                 )
-            self._is_model_deterministic = None
-            if save:
+            if save:  # pragma: no branch
                 save_dataset(
                     dataset=dataset,
                     score_names=[BERT_SCORE_DISSIMILARITY, WER_SCORE],
@@ -353,32 +450,40 @@ class GeneralSemanticRobustness(EvalAlgorithmInterface):
                         dataset_name=dataset_config.dataset_name,
                     ),
                 )
-
         return eval_outputs
 
-    def __add_scores_to_dataset(self, dataset: Dataset, model: ModelRunner, prompt_template: str):
+
+class UpdateRobustnessScores(Transform):
+    """Used by General Semantic Robustness when the model under evaluation is not deterministic.
+
+    See the class documentation for GeneralSemanticRobustness for details on how baseline scores
+    are computed and used. This transform simply updates the data corresponding to the
+    WER_SCORE and BERT_SCORE_DISSIMILARITY keys after baseline scores have been computed.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.register_input_output_keys(
+            input_keys=[WER_SCORE, BERT_SCORE_DISSIMILARITY, BASELINE_WER_SCORE, BASELINE_BERT_SCORE_DISSIMILARITY],
+            output_keys=[WER_SCORE, BERT_SCORE_DISSIMILARITY],
+        )
+
+    def __call__(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        """Update the values corresponding to the keys WER_SCORE and BERT_SCORE_DISSIMILARITY.
+
+        This method does not add new keys, but rather mutates the data corresponding to existing
+        keys (WER_SCORE and BERT_SCORE_DISSIMILARITY) in the input record.
+
+        :param record: The input record.
+        :returns: The input record with updated WER_SCORE and BERT_SCORE_DISSIMILARITY values.
         """
-        Private method to encapsulate logic around getting scores for every row in the dataset.
+        bert_score_dissimilarity_value = record[BERT_SCORE_DISSIMILARITY]
+        wer_value = record[WER_SCORE]
+        baseline_bert_score_dissimilarity_value = record[BASELINE_BERT_SCORE_DISSIMILARITY]
+        baseline_wer_value = record[BASELINE_WER_SCORE]
 
-        :param dataset: ray Dataset to be used for eval scores generation
-        :param model: An instance of ModelRunner which is the model under evaluation
-        :param prompt_template: Eval algo config
-        :returns: ray Dataset with score columns
-        """
-
-        def _generate_general_semantic_robustness_score(row: Dict[str, Any]) -> Dict[str, Any]:  # pragma: no cover
-            """
-            Map function generating the scores for every input record in input dataset
-            """
-            scores = self.evaluate_sample(
-                model_input=row[DatasetColumns.MODEL_INPUT.value.name],
-                model=model,
-                model_output=row[DatasetColumns.MODEL_OUTPUT.value.name],
-                prompt_template=prompt_template,
-            )
-            row[BERT_SCORE_DISSIMILARITY] = scores[0].value
-            row[WER_SCORE] = scores[1].value
-
-            return row
-
-        return dataset.map(_generate_general_semantic_robustness_score).materialize()  # pragma: no cover
+        record[BERT_SCORE_DISSIMILARITY] = max(
+            0, bert_score_dissimilarity_value - baseline_bert_score_dissimilarity_value
+        )
+        record[WER_SCORE] = max(0, wer_value - baseline_wer_value)
+        return record

--- a/src/fmeval/eval_algorithms/general_semantic_robustness.py
+++ b/src/fmeval/eval_algorithms/general_semantic_robustness.py
@@ -76,7 +76,7 @@ class GeneralSemanticRobustnessConfig(EvalAlgorithmConfig):
         compute differences between all pairs of outputs, i.e. between comb(num_baseline_samples, 2) pairs.
     :param butter_finger_perturbation_prob: The probability that a given character will be perturbed.
         Used when perturbation_type is BUTTER_FINGER.
-    :param random_uppercase_fraction: Fraction of characters to be changed to uppercase.
+    :param random_uppercase_corrupt_proportion: Fraction of characters to be changed to uppercase.
         Used when perturbation_type is RANDOM_UPPERCASE.
     :param whitespace_remove_prob: The probability of removing a whitespace character.
         Used when perturbation_type is ADD_REMOVE_WHITESPACE.
@@ -89,7 +89,7 @@ class GeneralSemanticRobustnessConfig(EvalAlgorithmConfig):
     num_perturbations: int = 5
     num_baseline_samples: int = 4
     butter_finger_perturbation_prob: float = 0.1
-    random_uppercase_fraction: float = 0.1
+    random_uppercase_corrupt_proportion: float = 0.1
     whitespace_add_prob: float = 0.05
     whitespace_remove_prob: float = 0.1
     model_type_for_bertscore: str = BERTSCORE_DEFAULT_MODEL
@@ -179,7 +179,7 @@ class GeneralSemanticRobustness(EvalAlgorithmInterface):
                     for i in range(self.num_perturbations)
                 ],
                 num_perturbations=self.num_perturbations,
-                uppercase_fraction=eval_algorithm_config.random_uppercase_fraction,
+                uppercase_fraction=eval_algorithm_config.random_uppercase_corrupt_proportion,
             )
         else:
             self.perturbation_transform = AddRemoveWhitespace(

--- a/src/fmeval/eval_algorithms/qa_accuracy_semantic_robustness.py
+++ b/src/fmeval/eval_algorithms/qa_accuracy_semantic_robustness.py
@@ -12,8 +12,8 @@ from fmeval.constants import (
     DatasetColumns,
     MEAN,
     BUTTER_FINGER,
-    RANDOM_UPPER_CASE,
-    WHITESPACE_ADD_REMOVE,
+    RANDOM_UPPERCASE,
+    ADD_REMOVE_WHITESPACE,
     PREFIX_FOR_DELTA_SCORES,
 )
 from fmeval.data_loaders.util import get_dataset
@@ -65,8 +65,8 @@ from fmeval.eval_algorithms.qa_accuracy import (
 # All the perturbation types supported by this eval algo
 PERTURBATION_TYPE_TO_HELPER_CLASS = {
     BUTTER_FINGER: ButterFinger,
-    RANDOM_UPPER_CASE: RandomUpperCase,
-    WHITESPACE_ADD_REMOVE: WhitespaceAddRemove,
+    RANDOM_UPPERCASE: RandomUpperCase,
+    ADD_REMOVE_WHITESPACE: WhitespaceAddRemove,
 }
 
 DELTA_F1_SCORE = PREFIX_FOR_DELTA_SCORES + F1_SCORE
@@ -91,11 +91,11 @@ class QAAccuracySemanticRobustnessConfig(EvalAlgorithmConfig):
     :param butter_finger_perturbation_prob: The probability that a given character will be perturbed. Used for
         butter_finger perturbation_type
     :param random_uppercase_corrupt_proportion: Fraction of characters to be changed to uppercase. Used for
-        random_upper_case perturbation_type
+        random_uppercase perturbation_type
     :param whitespace_remove_prob: Given a whitespace, remove it with this much probability. Used for
-        whitespace_add_remove perturbation_type
+        add_remove_whitespace perturbation_type
     :param whitespace_add_prob: Given a non-whitespace, add a whitespace before it with this probability. Used for
-        whitespace_add_remove perturbation_type
+        add_remove_whitespace perturbation_type
     """
 
     target_output_delimiter: Optional[str] = "<OR>"
@@ -139,7 +139,7 @@ class QAAccuracySemanticRobustness(EvalAlgorithmInterface):
 
         if self._eval_algorithm_config.perturbation_type == BUTTER_FINGER:
             self._perturbation_config = ButterFingerConfig(self._eval_algorithm_config.butter_finger_perturbation_prob)
-        elif self._eval_algorithm_config.perturbation_type == RANDOM_UPPER_CASE:
+        elif self._eval_algorithm_config.perturbation_type == RANDOM_UPPERCASE:
             self._perturbation_config = RandomUpperCaseConfig(
                 self._eval_algorithm_config.random_uppercase_corrupt_proportion
             )

--- a/src/fmeval/eval_algorithms/summarization_accuracy_semantic_robustness.py
+++ b/src/fmeval/eval_algorithms/summarization_accuracy_semantic_robustness.py
@@ -12,8 +12,8 @@ from fmeval.constants import (
     DatasetColumns,
     MEAN,
     BUTTER_FINGER,
-    RANDOM_UPPER_CASE,
-    WHITESPACE_ADD_REMOVE,
+    RANDOM_UPPERCASE,
+    ADD_REMOVE_WHITESPACE,
     PREFIX_FOR_DELTA_SCORES,
 )
 from fmeval.data_loaders.data_config import DataConfig
@@ -67,8 +67,8 @@ logger = logging.getLogger(__name__)
 # All the perturbation types supported by this eval algo
 PERTURBATION_TYPE_TO_HELPER_CLASS = {
     BUTTER_FINGER: ButterFinger,
-    RANDOM_UPPER_CASE: RandomUpperCase,
-    WHITESPACE_ADD_REMOVE: WhitespaceAddRemove,
+    RANDOM_UPPERCASE: RandomUpperCase,
+    ADD_REMOVE_WHITESPACE: WhitespaceAddRemove,
 }
 
 DELTA_ROUGE_SCORE = PREFIX_FOR_DELTA_SCORES + ROUGE_SCORE
@@ -124,11 +124,11 @@ class SummarizationAccuracySemanticRobustnessConfig(EvalAlgorithmConfig):
     :param butter_finger_perturbation_prob: The probability that a given character will be perturbed. Used for
         butter_finger perturbation_type
     :param random_uppercase_corrupt_proportion: Fraction of characters to be changed to uppercase. Used for
-        random_upper_case perturbation_type
+        random_uppercase perturbation_type
     :param whitespace_remove_prob: Given a whitespace, remove it with this much probability. Used for
-        whitespace_add_remove perturbation_type
+        add_remove_whitespace perturbation_type
     :param whitespace_add_prob: Given a non-whitespace, add a whitespace before it with this probability. Used for
-        whitespace_add_remove perturbation_type
+        add_remove_whitespace perturbation_type
     :param rouge_type: Type of rouge metric in eval results
     :param use_stemmer_for_rouge: bool value to set using stemmer for rouge metric
     :param model_type_for_bertscore: model to use for bert score
@@ -193,7 +193,7 @@ class SummarizationAccuracySemanticRobustness(EvalAlgorithmInterface):
 
         if self._eval_algorithm_config.perturbation_type == BUTTER_FINGER:
             self._perturbation_config = ButterFingerConfig(self._eval_algorithm_config.butter_finger_perturbation_prob)
-        elif self._eval_algorithm_config.perturbation_type == RANDOM_UPPER_CASE:
+        elif self._eval_algorithm_config.perturbation_type == RANDOM_UPPERCASE:
             self._perturbation_config = RandomUpperCaseConfig(
                 self._eval_algorithm_config.random_uppercase_corrupt_proportion
             )

--- a/src/fmeval/transforms/common.py
+++ b/src/fmeval/transforms/common.py
@@ -1,3 +1,4 @@
+import numpy as np
 from typing import Any, Dict, List, Tuple
 
 from fmeval.model_runners.composers.composers import PromptComposer
@@ -116,4 +117,28 @@ class GetModelResponse(Transform):
                 )
                 for model_response_key, model_response_item in zip(response_key_tuple, model_response):
                     record[model_response_key] = model_response_item
+        return record
+
+
+class Mean(Transform):
+    """This transform computes the arithmetic mean of specified values in a record and augments said record."""
+
+    def __init__(self, input_keys: List[str], output_key: str):
+        """Mean initializer.
+        :param input_keys: The keys corresponding to the values to take the mean of.
+        :param output_key: The key corresponding to the mean value, which gets
+            added to the record.
+        """
+        super().__init__(input_keys, output_key)
+        self.register_input_output_keys(input_keys, [output_key])
+        self.output_key = output_key
+
+    @validate_call
+    def __call__(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        """Augment the input record with the computed mean.
+        :param record: The input record.
+        :returns: The input record with the mean added in.
+        """
+        avg = np.mean([record[input_key] for input_key in self.input_keys])
+        record[self.output_key] = avg
         return record

--- a/src/fmeval/transforms/semantic_robustness_metrics.py
+++ b/src/fmeval/transforms/semantic_robustness_metrics.py
@@ -1,0 +1,93 @@
+import evaluate as hf_evaluate
+from typing import List, Dict, Any
+
+from fmeval.util import require
+from fmeval.transforms.common import Mean
+from fmeval.transforms.transform import Transform
+from fmeval.transforms.util import validate_call
+
+
+class BertScoreDissimilarity(Transform):
+    """This Transform augments its input record with the BERTScore Dissimilarity metric.
+
+    BERTScore Dissimilarity is simply 1 - BERTScore
+    (https://huggingface.co/spaces/evaluate-metric/bertscore).
+    This Transform uses the mean of a list of BERTScore values as the BERTScore
+    in the formula above.
+    """
+
+    def __init__(self, bert_score_keys: List[str], output_key: str):
+        """BertScoreDissimilarity initializer.
+
+        :param bert_score_keys: The keys corresponding to the BERTScore values.
+        :param output_key: The key corresponding to the output of this transform.
+        """
+        super().__init__(bert_score_keys, output_key)
+        self.register_input_output_keys(bert_score_keys, [output_key])
+        self.bert_score_keys = bert_score_keys
+        self.output_key = output_key
+
+    @validate_call
+    def __call__(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        """Augment the input record with the computed BERTScore Dissimilarity metric.
+
+        :param record: The input record.
+        :returns: The input record with the BERTScore Dissimilarity metric added in.
+        """
+        add_mean_bert_score = Mean(
+            self.bert_score_keys,
+            self.output_key,
+        )
+        record = add_mean_bert_score(record)
+        # Override the intermediate value corresponding to self.output_key
+        # (i.e. the mean bert score) to 1 - mean.
+        record[self.output_key] = 1 - record[self.output_key]
+        return record
+
+
+class WER(Transform):
+    """This Transform computes the Word Error Rate metric and augments its input record with the computed value.
+
+    Word Error Rate measures syntactic differences, that is, changes in the words, whereas BERTScore Dissimilarity
+    measures semantic differences. Semantic differences account for cases when the precise words in the output
+    change but the meaning is the same. For example, consider the outputs "it is pouring down today" vs.
+    "it is very rainy today".
+    """
+
+    def __init__(self, prediction_keys: List[str], reference_keys: List[str], output_key: str):
+        """WER initializer.
+
+        Note that the order of elements in `prediction_keys` and `reference_keys` matters;
+        the kth element of `prediction_keys` should correspond to the kth element of
+        `reference_keys`.
+
+        :param prediction_keys: The record keys corresponding to model predictions.
+        :param reference_keys: The record keys corresponding ot reference, aka target, values.
+        :param output_key: The output key to assign the computed WER value.
+        """
+        require(
+            len(prediction_keys) == len(reference_keys),
+            "prediction_keys and reference_keys should have the same number of elements. "
+            f"prediction_keys has {len(prediction_keys)} elements while reference_keys has "
+            f"{len(reference_keys)} elements.",
+        )
+        super().__init__(prediction_keys, reference_keys, output_key)
+        self.register_input_output_keys(prediction_keys + reference_keys, [output_key], allow_duplicates=True)
+        self.prediction_keys = prediction_keys
+        self.reference_keys = reference_keys
+        self.output_key = output_key
+        self.wer = hf_evaluate.load("wer")
+
+    @validate_call
+    def __call__(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        """Augment the input record with the computed WER metric.
+
+        :param record: The input record.
+        :returns: The input record with the WER metric added in.
+        """
+        wer_metric = self.wer.compute(
+            predictions=[record[prediction_key] for prediction_key in self.prediction_keys],
+            references=[record[reference_key] for reference_key in self.reference_keys],
+        )
+        record[self.output_key] = wer_metric
+        return record

--- a/src/fmeval/transforms/transform_pipeline.py
+++ b/src/fmeval/transforms/transform_pipeline.py
@@ -2,7 +2,6 @@ import ray.data
 from typing import List, Union, Dict, Any
 from collections import defaultdict
 
-from fmeval.constants import TRANSFORM_PIPELINE_MAX_SIZE
 from fmeval.exceptions import EvalAlgorithmClientError
 from fmeval.transforms.transform import Transform
 from fmeval.util import require, get_num_actors
@@ -60,15 +59,6 @@ class TransformPipeline:
             "TransformPipeline contains Transforms with the same output keys as other Transforms. "
             "Here are the problematic Transforms, paired with their offending keys: "
             f"{str(dict(transform_to_duplicate_keys))}",
-        )
-        require(
-            len(self.transforms) <= TRANSFORM_PIPELINE_MAX_SIZE,
-            f"TransformPipeline initialized with {len(self.transforms)} Transforms. "
-            f"Currently, the max pipeline size is {TRANSFORM_PIPELINE_MAX_SIZE}. "
-            "An overly-large pipeline is typically an indication that your Transforms "
-            "are performing tasks that are too fine-grained. See how this negatively "
-            "affects performance here: "
-            "https://docs.ray.io/en/latest/ray-core/patterns/too-fine-grained-tasks.html",
         )
 
     def execute(self, dataset: ray.data.Dataset) -> ray.data.Dataset:

--- a/test/integration/test_classification_accuracy_semantic_robustness.py
+++ b/test/integration/test_classification_accuracy_semantic_robustness.py
@@ -13,8 +13,8 @@ from fmeval.eval_algorithms.classification_accuracy_semantic_robustness import (
     ClassificationAccuracySemanticRobustness,
     ClassificationAccuracySemanticRobustnessConfig,
     DELTA_CLASSIFICATION_ACCURACY_SCORE,
-    RANDOM_UPPER_CASE,
-    WHITESPACE_ADD_REMOVE,
+    RANDOM_UPPERCASE,
+    ADD_REMOVE_WHITESPACE,
 )
 
 from test.integration.models.model_runners import (
@@ -53,7 +53,7 @@ class TestClassificationAccuracySemanticRobustness:
             CASRTestCase(
                 config=ClassificationAccuracySemanticRobustnessConfig(
                     valid_labels=SAMPLE_VALID_LABELS,
-                    perturbation_type=RANDOM_UPPER_CASE,
+                    perturbation_type=RANDOM_UPPERCASE,
                     num_perturbations=5,
                     random_uppercase_corrupt_proportion=0.1,
                 ),
@@ -66,7 +66,7 @@ class TestClassificationAccuracySemanticRobustness:
             CASRTestCase(
                 config=ClassificationAccuracySemanticRobustnessConfig(
                     valid_labels=SAMPLE_VALID_LABELS,
-                    perturbation_type=WHITESPACE_ADD_REMOVE,
+                    perturbation_type=ADD_REMOVE_WHITESPACE,
                     num_perturbations=5,
                     whitespace_remove_prob=0.1,
                     whitespace_add_prob=0.05,
@@ -169,7 +169,7 @@ class TestClassificationAccuracySemanticRobustness:
             CASRTestCase(
                 config=ClassificationAccuracySemanticRobustnessConfig(
                     valid_labels=SAMPLE_VALID_LABELS,
-                    perturbation_type=RANDOM_UPPER_CASE,
+                    perturbation_type=RANDOM_UPPERCASE,
                     num_perturbations=5,
                     random_uppercase_corrupt_proportion=0.1,
                 ),
@@ -239,7 +239,7 @@ class TestClassificationAccuracySemanticRobustness:
             CASRTestCase(
                 config=ClassificationAccuracySemanticRobustnessConfig(
                     valid_labels=SAMPLE_VALID_LABELS,
-                    perturbation_type=WHITESPACE_ADD_REMOVE,
+                    perturbation_type=ADD_REMOVE_WHITESPACE,
                     num_perturbations=5,
                     whitespace_remove_prob=0.1,
                     whitespace_add_prob=0.05,

--- a/test/integration/test_general_semantic_robustness.py
+++ b/test/integration/test_general_semantic_robustness.py
@@ -46,29 +46,6 @@ class TestGeneralSemanticRobustness:
                     BERT_SCORE_DISSIMILARITY: 0.19456744194030762,
                 },
             ),
-            GSRTestCase(
-                config=GeneralSemanticRobustnessConfig(
-                    perturbation_type=RANDOM_UPPERCASE,
-                    num_perturbations=3,
-                    random_uppercase_fraction=0.1,
-                ),
-                expected_scores={
-                    WER_SCORE: 0.7777777777777778,
-                    BERT_SCORE_DISSIMILARITY: 0.18904542922973633,
-                },
-            ),
-            GSRTestCase(
-                config=GeneralSemanticRobustnessConfig(
-                    perturbation_type=ADD_REMOVE_WHITESPACE,
-                    num_perturbations=2,
-                    whitespace_add_prob=0.05,
-                    whitespace_remove_prob=0.1,
-                ),
-                expected_scores={
-                    WER_SCORE: 0.3333333333333333,
-                    BERT_SCORE_DISSIMILARITY: 0.14486145973205566,
-                },
-            ),
         ],
     )
     def test_evaluate_sample(self, gsr_test_case):

--- a/test/integration/test_general_semantic_robustness.py
+++ b/test/integration/test_general_semantic_robustness.py
@@ -1,9 +1,8 @@
 import os
-from copy import deepcopy
-from typing import NamedTuple, Dict
-
 import pytest
+
 from pytest import approx
+from typing import NamedTuple, Dict
 
 from fmeval.eval_algorithms import (
     DATASET_CONFIGS,
@@ -11,11 +10,12 @@ from fmeval.eval_algorithms import (
 )
 from fmeval.eval_algorithms.general_semantic_robustness import (
     BUTTER_FINGER,
+    RANDOM_UPPERCASE,
+    ADD_REMOVE_WHITESPACE,
     GeneralSemanticRobustness,
     GeneralSemanticRobustnessConfig,
     WER_SCORE,
     BERT_SCORE_DISSIMILARITY,
-    WHITESPACE_ADD_REMOVE,
 )
 
 from test.integration.models.model_runners import (
@@ -42,14 +42,37 @@ class TestGeneralSemanticRobustness:
                     butter_finger_perturbation_prob=0.1,
                 ),
                 expected_scores={
-                    WER_SCORE: 1.1,
-                    BERT_SCORE_DISSIMILARITY: 0.4326739013195038,
+                    WER_SCORE: 0.5666666666666667,
+                    BERT_SCORE_DISSIMILARITY: 0.19456744194030762,
                 },
-            )
+            ),
+            GSRTestCase(
+                config=GeneralSemanticRobustnessConfig(
+                    perturbation_type=RANDOM_UPPERCASE,
+                    num_perturbations=3,
+                    random_uppercase_fraction=0.1,
+                ),
+                expected_scores={
+                    WER_SCORE: 0.7777777777777778,
+                    BERT_SCORE_DISSIMILARITY: 0.18904542922973633,
+                },
+            ),
+            GSRTestCase(
+                config=GeneralSemanticRobustnessConfig(
+                    perturbation_type=ADD_REMOVE_WHITESPACE,
+                    num_perturbations=2,
+                    whitespace_add_prob=0.05,
+                    whitespace_remove_prob=0.1,
+                ),
+                expected_scores={
+                    WER_SCORE: 0.3333333333333333,
+                    BERT_SCORE_DISSIMILARITY: 0.14486145973205566,
+                },
+            ),
         ],
     )
     def test_evaluate_sample(self, gsr_test_case):
-        gen_semantic_robustness = GeneralSemanticRobustness(gsr_test_case.config)
+        gen_semantic_robustness = GeneralSemanticRobustness(gsr_test_case.config, use_ray=False)
         model_input = "London is the capital of "
         eval_scores = gen_semantic_robustness.evaluate_sample(
             model_input=model_input,
@@ -63,21 +86,21 @@ class TestGeneralSemanticRobustness:
         [
             GSRTestCase(
                 config=GeneralSemanticRobustnessConfig(
-                    perturbation_type=WHITESPACE_ADD_REMOVE,
+                    perturbation_type=ADD_REMOVE_WHITESPACE,
                     num_perturbations=5,
                     whitespace_remove_prob=0.1,
                     whitespace_add_prob=0.05,
                 ),
                 expected_scores={
-                    WER_SCORE: 0.6135412698412699,
-                    BERT_SCORE_DISSIMILARITY: 0.2815050273537636,
+                    WER_SCORE: 0.4727531746031748,
+                    BERT_SCORE_DISSIMILARITY: 0.2137835907936097,
                 },
             ),
         ],
     )
     def test_evaluate(self, gsr_test_case):
         gen_semantic_robustness = GeneralSemanticRobustness(gsr_test_case.config)
-        dataset_config = deepcopy(DATASET_CONFIGS[WIKITEXT2])
+        dataset_config = DATASET_CONFIGS[WIKITEXT2]
         eval_output = gen_semantic_robustness.evaluate(
             model=sm_model_runner,
             dataset_config=dataset_config,

--- a/test/integration/test_qa_accuracy_semantic_robustness.py
+++ b/test/integration/test_qa_accuracy_semantic_robustness.py
@@ -7,8 +7,8 @@ from fmeval.eval_algorithms.qa_accuracy_semantic_robustness import (
     QAAccuracySemanticRobustness,
     QAAccuracySemanticRobustnessConfig,
     BUTTER_FINGER,
-    RANDOM_UPPER_CASE,
-    WHITESPACE_ADD_REMOVE,
+    RANDOM_UPPERCASE,
+    ADD_REMOVE_WHITESPACE,
     DELTA_F1_SCORE,
     DELTA_EXACT_MATCH_SCORE,
     DELTA_QUASI_EXACT_MATCH_SCORE,
@@ -63,7 +63,7 @@ class TestQAAccuracySemanticRobustness:
             ),
             TestCaseEvaluateSample(
                 config=QAAccuracySemanticRobustnessConfig(
-                    perturbation_type=RANDOM_UPPER_CASE,
+                    perturbation_type=RANDOM_UPPERCASE,
                     num_perturbations=5,
                     random_uppercase_corrupt_proportion=0.1,
                 ),
@@ -82,7 +82,7 @@ class TestQAAccuracySemanticRobustness:
             ),
             TestCaseEvaluateSample(
                 config=QAAccuracySemanticRobustnessConfig(
-                    perturbation_type=WHITESPACE_ADD_REMOVE,
+                    perturbation_type=ADD_REMOVE_WHITESPACE,
                     num_perturbations=5,
                     whitespace_remove_prob=0.1,
                     whitespace_add_prob=0.05,
@@ -140,7 +140,7 @@ class TestQAAccuracySemanticRobustness:
             ),
             TestCaseEvaluate(
                 config=QAAccuracySemanticRobustnessConfig(
-                    perturbation_type=RANDOM_UPPER_CASE,
+                    perturbation_type=RANDOM_UPPERCASE,
                     num_perturbations=5,
                     random_uppercase_corrupt_proportion=0.1,
                 ),
@@ -159,7 +159,7 @@ class TestQAAccuracySemanticRobustness:
             ),
             TestCaseEvaluate(
                 config=QAAccuracySemanticRobustnessConfig(
-                    perturbation_type=WHITESPACE_ADD_REMOVE,
+                    perturbation_type=ADD_REMOVE_WHITESPACE,
                     num_perturbations=5,
                     whitespace_remove_prob=0.1,
                     whitespace_add_prob=0.05,

--- a/test/integration/test_summarization_accuracy_semantic_robustness.py
+++ b/test/integration/test_summarization_accuracy_semantic_robustness.py
@@ -17,8 +17,8 @@ from fmeval.eval_algorithms.summarization_accuracy_semantic_robustness import (
     DELTA_METEOR_SCORE,
     DELTA_BERT_SCORE,
     BUTTER_FINGER,
-    RANDOM_UPPER_CASE,
-    WHITESPACE_ADD_REMOVE,
+    RANDOM_UPPERCASE,
+    ADD_REMOVE_WHITESPACE,
 )
 from test.integration.models.model_runners import sm_model_runner
 
@@ -30,13 +30,13 @@ BUTTER_FINGER_CONFIG = SummarizationAccuracySemanticRobustnessConfig(
 )
 
 RANDOM_UPPER_CASE_CONFIG = SummarizationAccuracySemanticRobustnessConfig(
-    perturbation_type=RANDOM_UPPER_CASE,
+    perturbation_type=RANDOM_UPPERCASE,
     num_perturbations=5,
     random_uppercase_corrupt_proportion=0.1,
 )
 
 WHITESPACE_CONFIG = SummarizationAccuracySemanticRobustnessConfig(
-    perturbation_type=WHITESPACE_ADD_REMOVE,
+    perturbation_type=ADD_REMOVE_WHITESPACE,
     num_perturbations=5,
     whitespace_remove_prob=0.1,
     whitespace_add_prob=0.05,

--- a/test/unit/eval_algorithms/test_classification_accuracy_semantic_robustness.py
+++ b/test/unit/eval_algorithms/test_classification_accuracy_semantic_robustness.py
@@ -23,8 +23,8 @@ from fmeval.eval_algorithms import (
 from fmeval.eval_algorithms.classification_accuracy_semantic_robustness import (
     ClassificationAccuracySemanticRobustnessConfig,
     ClassificationAccuracySemanticRobustness,
-    RANDOM_UPPER_CASE,
-    WHITESPACE_ADD_REMOVE,
+    RANDOM_UPPERCASE,
+    ADD_REMOVE_WHITESPACE,
     BUTTER_FINGER,
     DELTA_CLASSIFICATION_ACCURACY_SCORE,
 )
@@ -107,7 +107,7 @@ class TestClassificationAccuracySemanticRobustness:
                 valid_labels=["1", "2"],
                 perturbation_type="my_perturb",
                 expected_error_message="Invalid perturbation type 'my_perturb requested, please choose from "
-                "acceptable values: dict_keys(['butter_finger', 'random_upper_case', 'whitespace_add_remove'])",
+                "acceptable values: dict_keys(['butter_finger', 'random_uppercase', 'add_remove_whitespace'])",
             ),
         ],
     )
@@ -187,7 +187,7 @@ class TestClassificationAccuracySemanticRobustness:
                     EvalScore(name=DELTA_CLASSIFICATION_ACCURACY_SCORE, value=0.0),
                 ],
                 config=ClassificationAccuracySemanticRobustnessConfig(
-                    valid_labels=["1", "2", "3", "4", "5"], num_perturbations=2, perturbation_type=RANDOM_UPPER_CASE
+                    valid_labels=["1", "2", "3", "4", "5"], num_perturbations=2, perturbation_type=RANDOM_UPPERCASE
                 ),
             ),
             TestCaseClassificationAccuracySemanticRobustnessEvaluateSample(
@@ -201,7 +201,7 @@ class TestClassificationAccuracySemanticRobustness:
                     EvalScore(name=DELTA_CLASSIFICATION_ACCURACY_SCORE, value=1.0),
                 ],
                 config=ClassificationAccuracySemanticRobustnessConfig(
-                    valid_labels=["1", "2", "3", "4", "5"], num_perturbations=2, perturbation_type=WHITESPACE_ADD_REMOVE
+                    valid_labels=["1", "2", "3", "4", "5"], num_perturbations=2, perturbation_type=ADD_REMOVE_WHITESPACE
                 ),
             ),
         ],

--- a/test/unit/eval_algorithms/test_general_semantic_robustness.py
+++ b/test/unit/eval_algorithms/test_general_semantic_robustness.py
@@ -1,3 +1,4 @@
+import itertools
 import random
 import re
 import string
@@ -7,26 +8,35 @@ from unittest.mock import MagicMock, patch, Mock
 import pytest
 import ray
 from _pytest.fixtures import fixture
-from ray.data import Dataset
 
 from fmeval.constants import (
     DatasetColumns,
     MIME_TYPE_JSON,
 )
-from fmeval.data_loaders.data_config import DataConfig
-from fmeval.eval_algorithms import EvalScore, EvalOutput, CategoryScore, DEFAULT_PROMPT_TEMPLATE
+from fmeval.eval_algorithms import CategoryScore, EvalOutput, EvalScore
 from fmeval.eval_algorithms.general_semantic_robustness import (
     WER_SCORE,
     BERT_SCORE_DISSIMILARITY,
     GeneralSemanticRobustnessConfig,
     GeneralSemanticRobustness,
-    RANDOM_UPPER_CASE,
-    WHITESPACE_ADD_REMOVE,
+    RANDOM_UPPERCASE,
+    ADD_REMOVE_WHITESPACE,
     BUTTER_FINGER,
+    UpdateRobustnessScores,
 )
 from fmeval.exceptions import EvalAlgorithmClientError
+from fmeval.helper_models import BertscoreModel
 from fmeval.model_runners.model_runner import ModelRunner
 from fmeval.eval_algorithms.helper_models.helper_model import BertscoreHelperModelTypes
+from fmeval.transforms.common import GeneratePrompt, GetModelResponse
+from fmeval.transforms.semantic_perturbations import (
+    SemanticPerturbation,
+    ButterFinger,
+    RandomUppercase,
+    AddRemoveWhitespace,
+)
+from fmeval.transforms.semantic_robustness_metrics import BertScoreDissimilarity, WER
+from fmeval.transforms.summarization_accuracy_metrics import BertScore
 
 BERTSCORE_DUMMY_VALUE = (
     0.5  # we don't always evaluate the real BERTScore inside unit tests to reduce runtime, so we hardcode a dummy value
@@ -41,6 +51,7 @@ DATASET_WITH_SCORES = ray.data.from_items(
         {
             DatasetColumns.MODEL_INPUT.value.name: "What is the capital of England?",
             DatasetColumns.CATEGORY.value.name: "dummy_category_1",
+            DatasetColumns.PROMPT.value.name: "unused since we mock the model output",
             DatasetColumns.MODEL_OUTPUT.value.name: "Some model output.",
             WER_SCORE: 0.0,
             BERT_SCORE_DISSIMILARITY: BERTSCORE_DUMMY_VALUE,
@@ -48,6 +59,7 @@ DATASET_WITH_SCORES = ray.data.from_items(
         {
             DatasetColumns.MODEL_INPUT.value.name: "What is the capital of England?",
             DatasetColumns.CATEGORY.value.name: "dummy_category_2",
+            DatasetColumns.PROMPT.value.name: "unused since we mock the model output",
             DatasetColumns.MODEL_OUTPUT.value.name: "Some model output.",
             WER_SCORE: 0.0,
             BERT_SCORE_DISSIMILARITY: BERTSCORE_DUMMY_VALUE,
@@ -91,271 +103,7 @@ class NonDeterministicModel(ModelRunner):
 class TestGeneralSemanticRobustness:
     @fixture(scope="module")
     def config(self) -> GeneralSemanticRobustnessConfig:
-        return GeneralSemanticRobustnessConfig(num_perturbations=2)
-
-    class TestCaseGeneralSemanticRobustnessEvaluateSample(NamedTuple):
-        model_input: str
-        # model_output: Optional[str]
-        original_model_output: str
-        perturbed_model_output_1: str
-        perturbed_model_output_2: str
-        expected_response: List[EvalScore]
-        config: GeneralSemanticRobustnessConfig
-
-    class TestCaseGeneralSemanticRobustnessEvaluateSampleInvalid(NamedTuple):
-        model_input: str
-        model: ModelRunner
-        expected_error_message: str
-        config: GeneralSemanticRobustnessConfig
-
-    @pytest.mark.parametrize(
-        "test_case",
-        [
-            TestCaseGeneralSemanticRobustnessEvaluateSample(
-                model_input="What is the capital of England?",
-                original_model_output="Some model output.",
-                perturbed_model_output_1="Some model output.",
-                perturbed_model_output_2="Some model output.",
-                expected_response=[
-                    EvalScore(name=BERT_SCORE_DISSIMILARITY, value=BERTSCORE_DISSIMILARITY_DUMMY_VALUE),
-                    EvalScore(name=WER_SCORE, value=0.0),
-                ],
-                config=GeneralSemanticRobustnessConfig(num_perturbations=2),
-            ),
-            TestCaseGeneralSemanticRobustnessEvaluateSample(
-                model_input="What is the capital of England?",
-                original_model_output="Some model output.",
-                perturbed_model_output_1="Another model output.",
-                perturbed_model_output_2="Some model output.",
-                expected_response=[
-                    EvalScore(name=BERT_SCORE_DISSIMILARITY, value=BERTSCORE_DISSIMILARITY_DUMMY_VALUE),
-                    EvalScore(name=WER_SCORE, value=(1 / 3 + 0) / 2),
-                ],
-                config=GeneralSemanticRobustnessConfig(num_perturbations=2, perturbation_type=BUTTER_FINGER),
-            ),
-            TestCaseGeneralSemanticRobustnessEvaluateSample(
-                model_input="What is the capital of England?",
-                original_model_output="Some model output.",
-                perturbed_model_output_1="Another model output.",
-                perturbed_model_output_2="Some model output.",
-                expected_response=[
-                    EvalScore(name=BERT_SCORE_DISSIMILARITY, value=BERTSCORE_DISSIMILARITY_DUMMY_VALUE),
-                    EvalScore(name=WER_SCORE, value=(1 / 3 + 0) / 2),
-                ],
-                config=GeneralSemanticRobustnessConfig(num_perturbations=2, perturbation_type=RANDOM_UPPER_CASE),
-            ),
-            TestCaseGeneralSemanticRobustnessEvaluateSample(
-                model_input="What is the capital of England?",
-                original_model_output="Some model output.",
-                perturbed_model_output_1="Another model output.",
-                perturbed_model_output_2="Another model output.",
-                expected_response=[
-                    EvalScore(name=BERT_SCORE_DISSIMILARITY, value=BERTSCORE_DISSIMILARITY_DUMMY_VALUE),
-                    EvalScore(name=WER_SCORE, value=(1 / 3 + 1 / 3) / 2),
-                ],
-                config=GeneralSemanticRobustnessConfig(num_perturbations=2, perturbation_type=WHITESPACE_ADD_REMOVE),
-            ),
-        ],
-    )
-    @patch("fmeval.eval_algorithms.general_semantic_robustness.BertscoreHelperModel")
-    @patch("fmeval.eval_algorithms.general_semantic_robustness.get_bert_score")
-    def test_semantic_robustness_evaluate_sample(self, mock_get_bert_score, bertscore_helper_model, test_case):
-        """
-        GIVEN valid inputs
-        WHEN GeneralSemanticRobustness.evaluate_sample is called
-        THEN correct List of EvalScores is returned
-        """
-        model = MagicMock()
-        model.predict.side_effect = [
-            (test_case.original_model_output,),
-            (test_case.original_model_output,),
-            (test_case.perturbed_model_output_1,),
-            (test_case.perturbed_model_output_2,),
-        ]
-        bertscore_helper_model_instance = MagicMock()
-        bertscore_helper_model.return_value = bertscore_helper_model_instance
-        mock_get_bert_score.return_value = BERTSCORE_DUMMY_VALUE
-
-        eval_algorithm = GeneralSemanticRobustness(test_case.config)
-        assert eval_algorithm.evaluate_sample(test_case.model_input, model) == test_case.expected_response
-        assert model.predict.call_count == 4
-
-    @pytest.mark.parametrize(
-        "test_case",
-        [
-            TestCaseGeneralSemanticRobustnessEvaluateSample(
-                model_input="What is the capital of England?",
-                original_model_output="Some model output.",
-                perturbed_model_output_1="Some model output.",
-                perturbed_model_output_2="Some model output.",
-                expected_response=[
-                    EvalScore(name=BERT_SCORE_DISSIMILARITY, value=BERTSCORE_DISSIMILARITY_DUMMY_VALUE),
-                    EvalScore(name=WER_SCORE, value=0.0),
-                ],
-                config=GeneralSemanticRobustnessConfig(num_perturbations=2),
-            ),
-        ],
-    )
-    @patch("fmeval.eval_algorithms.general_semantic_robustness.BertscoreHelperModel")
-    @patch("fmeval.eval_algorithms.general_semantic_robustness.get_bert_score")
-    def test_semantic_robustness_evaluate_sample_with_model_output(
-        self, mock_get_bert_score, bertscore_helper_model, test_case
-    ):
-        """
-        GIVEN valid inputs with model_output
-        WHEN GeneralSemanticRobustness.evaluate_sample is called
-        THEN correct List of EvalScores is returned
-        """
-        model = MagicMock()
-        model.predict.side_effect = [
-            (test_case.original_model_output,),
-            (test_case.perturbed_model_output_1,),
-            (test_case.perturbed_model_output_2,),
-        ]
-        bertscore_helper_model_instance = MagicMock()
-        bertscore_helper_model.return_value = bertscore_helper_model_instance
-        mock_get_bert_score.return_value = BERTSCORE_DUMMY_VALUE
-
-        eval_algorithm = GeneralSemanticRobustness(test_case.config)
-        assert (
-            eval_algorithm.evaluate_sample(test_case.model_input, model, test_case.original_model_output)
-            == test_case.expected_response
-        )
-        assert model.predict.call_count == 3
-
-    @pytest.mark.parametrize(
-        "test_case",
-        [
-            TestCaseGeneralSemanticRobustnessEvaluateSample(
-                model_input="What is the capital of England?",
-                original_model_output="Some model output.",
-                perturbed_model_output_1="Some model output.",
-                perturbed_model_output_2="Some model output.",
-                expected_response=[
-                    EvalScore(name=BERT_SCORE_DISSIMILARITY, value=BERTSCORE_DISSIMILARITY_DUMMY_VALUE),
-                    EvalScore(name=WER_SCORE, value=0.0),
-                ],
-                config=GeneralSemanticRobustnessConfig(num_perturbations=2),
-            ),
-        ],
-    )
-    @patch("fmeval.eval_algorithms.general_semantic_robustness.BertscoreHelperModel")
-    @patch("fmeval.eval_algorithms.general_semantic_robustness.get_bert_score")
-    def test_semantic_robustness_evaluate_sample_with_deterministic_model(
-        self, mock_get_bert_score, bertscore_helper_model, test_case
-    ):
-        """
-        GIVEN valid inputs with model_output, and a deterministic model
-        WHEN GeneralSemanticRobustness.evaluate_sample is called
-        THEN correct List of EvalScores is returned
-        """
-        model = MagicMock()
-        model.predict.side_effect = [
-            (test_case.perturbed_model_output_1,),
-            (test_case.perturbed_model_output_2,),
-        ]
-        bertscore_helper_model_instance = MagicMock()
-        bertscore_helper_model.return_value = bertscore_helper_model_instance
-        mock_get_bert_score.return_value = BERTSCORE_DUMMY_VALUE
-
-        eval_algorithm = GeneralSemanticRobustness(test_case.config)
-        eval_algorithm._is_model_deterministic = True
-        assert (
-            eval_algorithm.evaluate_sample(
-                model_input=test_case.model_input,
-                model=model,
-                model_output=test_case.original_model_output,
-            )
-            == test_case.expected_response
-        )
-        assert model.predict.call_count == 2
-
-    @pytest.mark.parametrize(
-        "test_case",
-        [
-            TestCaseGeneralSemanticRobustnessEvaluateSampleInvalid(
-                model_input="I like cake.",
-                model=None,
-                expected_error_message="Missing required input: model i.e. ModelRunner, for GeneralSemanticRobustness "
-                "evaluate_sample",
-                config=GeneralSemanticRobustnessConfig(num_perturbations=2),
-            ),
-            TestCaseGeneralSemanticRobustnessEvaluateSampleInvalid(
-                model_input=None,
-                model=MagicMock(),
-                expected_error_message="Missing required input: model_input, for GeneralSemanticRobustness "
-                "evaluate_sample",
-                config=GeneralSemanticRobustnessConfig(num_perturbations=2),
-            ),
-        ],
-    )
-    @patch("fmeval.eval_algorithms.general_semantic_robustness.BertscoreHelperModel")
-    def test_semantic_robustness_evaluate_sample_invalid_input(self, bertscore_helper_model, test_case):
-        """
-        GIVEN invalid inputs
-        WHEN GeneralSemanticRobustness.evaluate_sample is called
-        THEN correct exception with proper message is raised
-        """
-        # We mock the BertscoreHelperModel class so that the model doesn't get loaded into memory.
-        bertscore_helper_model.return_value = Mock()
-
-        eval_algorithm = GeneralSemanticRobustness(test_case.config)
-        with pytest.raises(EvalAlgorithmClientError, match=test_case.expected_error_message):
-            eval_algorithm.evaluate_sample(test_case.model_input, test_case.model)
-
-    @pytest.mark.parametrize(
-        "test_case",
-        [
-            TestCaseGeneralSemanticRobustnessEvaluateSample(
-                model_input="What is the capital of England?",
-                original_model_output="Some model output.",
-                perturbed_model_output_1="Another longer model output.",
-                perturbed_model_output_2="Yet another model output which is even longer.",
-                expected_response=[
-                    EvalScore(name=WER_SCORE, value=0),
-                    EvalScore(name=BERT_SCORE_DISSIMILARITY, value=0),
-                ],
-                config=GeneralSemanticRobustnessConfig(num_perturbations=2, num_baseline_samples=2),
-            )
-        ],
-    )
-    @patch("fmeval.eval_algorithms.general_semantic_robustness.BertscoreHelperModel")
-    @patch("fmeval.eval_algorithms.general_semantic_robustness.get_bert_score")
-    def test_semantic_robustness_evaluate_sample_non_deterministic_model(
-        self, mock_get_bert_score, bertscore_helper_model, test_case
-    ):
-        """
-        GIVEN a non-deterministic model
-        WHEN GeneralSemanticRobustness.evaluate_sample is called
-        THEN the robustness score valueis smaller than it would be for a deterministic model.
-        """
-        bertscore_helper_model_instance = MagicMock()
-        bertscore_helper_model.return_value = bertscore_helper_model_instance
-        mock_get_bert_score.return_value = BERTSCORE_DUMMY_VALUE
-
-        deterministic_model = MagicMock()
-        deterministic_model.predict.side_effect = [
-            (test_case.original_model_output,),  # Original model output
-            (test_case.original_model_output,),  # The determinism check
-            (test_case.perturbed_model_output_1,),  # Output on the first perturbation
-            (test_case.perturbed_model_output_2,),  # Output on the second perturbation
-        ]
-
-        nondeterministic_model = MagicMock()
-        nondeterministic_model.predict.side_effect = [
-            (test_case.original_model_output,),  # Original model output
-            (test_case.original_model_output + "1",),  # The determinism check
-            (test_case.perturbed_model_output_1,),  # Output on the first perturbation
-            (test_case.perturbed_model_output_2,),  # Output on the second perturbation
-            (test_case.original_model_output + "1",),  # Computing baseline: first model call
-            (test_case.original_model_output + "1",),  # Computing baseline: second model call
-        ]
-
-        eval_algorithm = GeneralSemanticRobustness(test_case.config)
-        output_deterministic = eval_algorithm.evaluate_sample(test_case.model_input, deterministic_model)
-        output_nondeterministic = eval_algorithm.evaluate_sample(test_case.model_input, nondeterministic_model)
-        assert output_nondeterministic[0].value < output_deterministic[0].value  # BERTScore Dissimilarity
-        assert output_nondeterministic[1].value < output_deterministic[1].value  # WER
+        return GeneralSemanticRobustnessConfig(num_perturbations=2, num_baseline_samples=3)
 
     @pytest.mark.parametrize(
         "perturbation_type, expected_error_message",
@@ -363,20 +111,20 @@ class TestGeneralSemanticRobustness:
             (
                 "my_perturb",
                 "Invalid perturbation type 'my_perturb requested, please choose from acceptable values: "
-                "dict_keys(['butter_finger', 'random_upper_case', 'whitespace_add_remove'])",
+                "dict_keys(['butter_finger', 'random_uppercase', 'add_remove_whitespace'])",
             )
         ],
     )
-    def test_semantic_robustness_invalid_perturbation_type(self, perturbation_type, expected_error_message):
+    def test_gsr_config_invalid_perturbation_type(self, perturbation_type, expected_error_message):
         """
         GIVEN invalid perturbation types
-        WHEN GeneralSemanticRobustnessConfig is initiated
+        WHEN GeneralSemanticRobustnessConfig is initialized
         THEN correct exception with proper message is raised
         """
         with pytest.raises(EvalAlgorithmClientError, match=re.escape(expected_error_message)):
             GeneralSemanticRobustnessConfig(perturbation_type=perturbation_type)
 
-    def test_semantic_robustness_invalid_bertscore_model(self):
+    def test_gsr_config_invalid_bertscore_model(self):
         """
         GIVEN invalid bertscore model
         WHEN GeneralSemanticRobustnessConfig is initiated
@@ -390,7 +138,7 @@ class TestGeneralSemanticRobustness:
         with pytest.raises(EvalAlgorithmClientError, match=re.escape(expected_error_message)):
             GeneralSemanticRobustnessConfig(model_type_for_bertscore=model_name)
 
-    def test_semantic_robustness_invalid_num_baseline_samples(self):
+    def test_gsr_config_invalid_num_baseline_samples(self):
         """
         GIVEN invalid number of baseline samples
         WHEN GeneralSemanticRobustnessConfig is initiated
@@ -398,317 +146,371 @@ class TestGeneralSemanticRobustness:
         """
         num_baseline_samples = 1
         expected_error_message = (
-            f"Invalid num_baseline_samples: {num_baseline_samples} in GeneralSemanticRobusntessConfig. "
+            f"Invalid num_baseline_samples: {num_baseline_samples} in GeneralSemanticRobustnessConfig. "
             f"The value should be at least 2."
         )
         with pytest.raises(EvalAlgorithmClientError, match=re.escape(expected_error_message)):
             GeneralSemanticRobustnessConfig(num_baseline_samples=num_baseline_samples)
 
-    class TestCaseSemanticRobustnessEvaluate(NamedTuple):
-        input_dataset: Dataset
-        input_dataset_with_generated_model_output: Dataset
-        prompt_template: Optional[str]
-        dataset_config: Optional[DataConfig]
-        expected_response: List[EvalOutput]
-        save_data: bool
-        dataset_with_scores: Dataset
-
-    @pytest.mark.parametrize(
-        "test_case",
-        [
-            # Built-in datasets evaluate for dataset without category
-            TestCaseSemanticRobustnessEvaluate(
-                input_dataset=DATASET_NO_CATEGORY,
-                input_dataset_with_generated_model_output=DATASET_WITH_MODEL_OUTPUT_NO_CATEGORY,
-                dataset_config=None,
-                prompt_template=None,
-                save_data=True,
-                dataset_with_scores=DATASET_WITH_SCORES.drop_columns(cols=DatasetColumns.CATEGORY.value.name),
-                expected_response=[
-                    EvalOutput(
-                        eval_name="general_semantic_robustness",
-                        dataset_name="bold",
-                        dataset_scores=[
-                            EvalScore(name=BERT_SCORE_DISSIMILARITY, value=BERTSCORE_DISSIMILARITY_DUMMY_VALUE),
-                            EvalScore(name=WER_SCORE, value=0.0),
-                        ],
-                        prompt_template=DEFAULT_PROMPT_TEMPLATE,
-                        category_scores=None,
-                        output_path="/tmp/eval_results/general_semantic_robustness_bold.jsonl",
-                    ),
-                    EvalOutput(
-                        eval_name="general_semantic_robustness",
-                        dataset_name="trex",
-                        dataset_scores=[
-                            EvalScore(name=BERT_SCORE_DISSIMILARITY, value=BERTSCORE_DISSIMILARITY_DUMMY_VALUE),
-                            EvalScore(name=WER_SCORE, value=0.0),
-                        ],
-                        prompt_template=DEFAULT_PROMPT_TEMPLATE,
-                        category_scores=None,
-                        output_path="/tmp/eval_results/general_semantic_robustness_trex.jsonl",
-                    ),
-                    EvalOutput(
-                        eval_name="general_semantic_robustness",
-                        dataset_name="wikitext2",
-                        dataset_scores=[
-                            EvalScore(name=BERT_SCORE_DISSIMILARITY, value=BERTSCORE_DISSIMILARITY_DUMMY_VALUE),
-                            EvalScore(name=WER_SCORE, value=0.0),
-                        ],
-                        prompt_template=DEFAULT_PROMPT_TEMPLATE,
-                        category_scores=None,
-                        output_path="/tmp/eval_results/general_semantic_robustness_wikitext2.jsonl",
-                    ),
-                ],
-            ),
-            # Built-in datasets evaluate for dataset with category
-            TestCaseSemanticRobustnessEvaluate(
-                input_dataset=DATASET,
-                input_dataset_with_generated_model_output=DATASET_WITH_MODEL_OUTPUT,
-                dataset_config=None,
-                prompt_template=None,
-                save_data=True,
-                dataset_with_scores=DATASET_WITH_SCORES,
-                expected_response=[
-                    EvalOutput(
-                        eval_name="general_semantic_robustness",
-                        dataset_name="bold",
-                        dataset_scores=[
-                            EvalScore(name=BERT_SCORE_DISSIMILARITY, value=BERTSCORE_DISSIMILARITY_DUMMY_VALUE),
-                            EvalScore(name=WER_SCORE, value=0.0),
-                        ],
-                        prompt_template=DEFAULT_PROMPT_TEMPLATE,
-                        category_scores=[
-                            CategoryScore(
-                                name="dummy_category_1",
-                                scores=[
-                                    EvalScore(name=BERT_SCORE_DISSIMILARITY, value=BERTSCORE_DISSIMILARITY_DUMMY_VALUE),
-                                    EvalScore(name=WER_SCORE, value=0.0),
-                                ],
-                            ),
-                            CategoryScore(
-                                name="dummy_category_2",
-                                scores=[
-                                    EvalScore(name=BERT_SCORE_DISSIMILARITY, value=BERTSCORE_DISSIMILARITY_DUMMY_VALUE),
-                                    EvalScore(name=WER_SCORE, value=0.0),
-                                ],
-                            ),
-                        ],
-                        output_path="/tmp/eval_results/general_semantic_robustness_bold.jsonl",
-                    ),
-                    EvalOutput(
-                        eval_name="general_semantic_robustness",
-                        dataset_name="trex",
-                        dataset_scores=[
-                            EvalScore(name=BERT_SCORE_DISSIMILARITY, value=BERTSCORE_DISSIMILARITY_DUMMY_VALUE),
-                            EvalScore(name=WER_SCORE, value=0.0),
-                        ],
-                        prompt_template=DEFAULT_PROMPT_TEMPLATE,
-                        category_scores=[
-                            CategoryScore(
-                                name="dummy_category_1",
-                                scores=[
-                                    EvalScore(name=BERT_SCORE_DISSIMILARITY, value=BERTSCORE_DISSIMILARITY_DUMMY_VALUE),
-                                    EvalScore(name=WER_SCORE, value=0.0),
-                                ],
-                            ),
-                            CategoryScore(
-                                name="dummy_category_2",
-                                scores=[
-                                    EvalScore(name=BERT_SCORE_DISSIMILARITY, value=BERTSCORE_DISSIMILARITY_DUMMY_VALUE),
-                                    EvalScore(name=WER_SCORE, value=0.0),
-                                ],
-                            ),
-                        ],
-                        output_path="/tmp/eval_results/general_semantic_robustness_trex.jsonl",
-                    ),
-                    EvalOutput(
-                        eval_name="general_semantic_robustness",
-                        dataset_name="wikitext2",
-                        dataset_scores=[
-                            EvalScore(name=BERT_SCORE_DISSIMILARITY, value=BERTSCORE_DISSIMILARITY_DUMMY_VALUE),
-                            EvalScore(name=WER_SCORE, value=0.0),
-                        ],
-                        prompt_template=DEFAULT_PROMPT_TEMPLATE,
-                        category_scores=[
-                            CategoryScore(
-                                name="dummy_category_1",
-                                scores=[
-                                    EvalScore(name=BERT_SCORE_DISSIMILARITY, value=BERTSCORE_DISSIMILARITY_DUMMY_VALUE),
-                                    EvalScore(name=WER_SCORE, value=0.0),
-                                ],
-                            ),
-                            CategoryScore(
-                                name="dummy_category_2",
-                                scores=[
-                                    EvalScore(name=BERT_SCORE_DISSIMILARITY, value=BERTSCORE_DISSIMILARITY_DUMMY_VALUE),
-                                    EvalScore(name=WER_SCORE, value=0.0),
-                                ],
-                            ),
-                        ],
-                        output_path="/tmp/eval_results/general_semantic_robustness_wikitext2.jsonl",
-                    ),
-                ],
-            ),
-            # Custom dataset evaluate with input prompt template
-            TestCaseSemanticRobustnessEvaluate(
-                input_dataset=DATASET_NO_CATEGORY,
-                input_dataset_with_generated_model_output=DATASET_WITH_MODEL_OUTPUT_NO_CATEGORY,
-                dataset_config=DataConfig(
-                    dataset_name="my_custom_dataset",
-                    dataset_uri="tba",
-                    dataset_mime_type=MIME_TYPE_JSON,
-                    model_input_location="tba",
-                    target_output_location="tba",
-                    model_output_location=None,
-                    category_location="tba",
-                ),
-                prompt_template="Answer: $model_input",
-                save_data=False,
-                dataset_with_scores=DATASET_WITH_SCORES.drop_columns(cols=DatasetColumns.CATEGORY.value.name),
-                expected_response=[
-                    EvalOutput(
-                        eval_name="general_semantic_robustness",
-                        dataset_name="my_custom_dataset",
-                        dataset_scores=[
-                            EvalScore(name=BERT_SCORE_DISSIMILARITY, value=BERTSCORE_DISSIMILARITY_DUMMY_VALUE),
-                            EvalScore(name=WER_SCORE, value=0.0),
-                        ],
-                        prompt_template="Answer: $model_input",
-                        category_scores=None,
-                        output_path="/tmp/eval_results/general_semantic_robustness_my_custom_dataset.jsonl",
-                    ),
-                ],
-            ),
-            # Custom dataset evaluate without input prompt template
-            TestCaseSemanticRobustnessEvaluate(
-                input_dataset=DATASET_NO_CATEGORY,
-                input_dataset_with_generated_model_output=DATASET_WITH_MODEL_OUTPUT_NO_CATEGORY,
-                dataset_config=DataConfig(
-                    dataset_name="my_custom_dataset",
-                    dataset_uri="tba",
-                    dataset_mime_type=MIME_TYPE_JSON,
-                    model_input_location="tba",
-                    target_output_location="tba",
-                    model_output_location=None,
-                    category_location="tba",
-                ),
-                prompt_template=None,
-                save_data=False,
-                dataset_with_scores=DATASET_WITH_SCORES.drop_columns(cols=DatasetColumns.CATEGORY.value.name),
-                expected_response=[
-                    EvalOutput(
-                        eval_name="general_semantic_robustness",
-                        dataset_name="my_custom_dataset",
-                        dataset_scores=[
-                            EvalScore(name=BERT_SCORE_DISSIMILARITY, value=BERTSCORE_DISSIMILARITY_DUMMY_VALUE),
-                            EvalScore(name=WER_SCORE, value=0.0),
-                        ],
-                        prompt_template=DEFAULT_PROMPT_TEMPLATE,
-                        category_scores=None,
-                        output_path="/tmp/eval_results/general_semantic_robustness_my_custom_dataset.jsonl",
-                    ),
-                ],
-            ),
-        ],
-    )
-    @patch("fmeval.eval_algorithms.general_semantic_robustness.get_dataset")
-    @patch("fmeval.eval_algorithms.general_semantic_robustness.save_dataset")
-    @patch("fmeval.eval_algorithms.general_semantic_robustness.generate_model_predict_response_for_dataset")
-    @patch("fmeval.eval_algorithms.general_semantic_robustness.BertscoreHelperModel")
-    @patch.object(GeneralSemanticRobustness, "_GeneralSemanticRobustness__add_scores_to_dataset")
-    def test_semantic_robustness_evaluate(
-        self,
-        add_scores_to_dataset,
-        bertscore_helper_model,
-        generate_model_predict_response_for_dataset,
-        save_dataset,
-        get_dataset,
-        test_case,
-        config,
-    ):
+    @pytest.mark.parametrize("use_ray", [True, False])
+    @pytest.mark.parametrize("perturbation_type", [BUTTER_FINGER, RANDOM_UPPERCASE, ADD_REMOVE_WHITESPACE])
+    @patch("fmeval.eval_algorithms.general_semantic_robustness.create_shared_resource")
+    @patch("fmeval.eval_algorithms.general_semantic_robustness.BertscoreModel")
+    def test_init(self, bertscore_model, create_shared_resource, perturbation_type, use_ray):
         """
-        GIVEN valid inputs i.e. input data config for a dataset without model_outputs, an input ModelRunner
-            and request to save records with scores
-        WHEN GeneralSemanticRobustness evaluate() method is called
-        THEN correct EvalOutput is returned
+        GIVEN valid arguments.
+        WHEN a GeneralSemanticRobustness is initialized.
+        THEN its instance attributes match what is expected and `create_shared_resource` is called
+            (or not called) depending on the `use_ray` flag.
         """
-        add_scores_to_dataset.return_value = test_case.dataset_with_scores
+        bertscore_model.return_value = Mock(spec=BertscoreModel)
 
-        # We mock the BertscoreHelperModel class so that the model doesn't get loaded into memory
-        bertscore_helper_model.return_value = Mock()
+        config = GeneralSemanticRobustnessConfig(perturbation_type=perturbation_type)
+        eval_algo = GeneralSemanticRobustness(config, use_ray=use_ray)
 
-        get_dataset.return_value = test_case.input_dataset
-        generate_model_predict_response_for_dataset.return_value = test_case.input_dataset_with_generated_model_output
-        eval_algorithm = GeneralSemanticRobustness(config)
-        actual_response = eval_algorithm.evaluate(
-            model=ConstantModel(),
-            dataset_config=test_case.dataset_config,
-            prompt_template=test_case.prompt_template,
-            save=test_case.save_data,
+        assert eval_algo.num_perturbations == config.num_perturbations
+        assert eval_algo.num_baseline_samples == config.num_baseline_samples
+
+        perturbation = eval_algo.perturbation_transform
+        if perturbation_type == BUTTER_FINGER:
+            assert isinstance(perturbation, ButterFinger)
+            assert perturbation.num_perturbations == config.num_perturbations
+            assert perturbation.perturbation_prob == config.butter_finger_perturbation_prob
+        elif perturbation_type == RANDOM_UPPERCASE:
+            assert isinstance(perturbation, RandomUppercase)
+            assert perturbation.num_perturbations == config.num_perturbations
+            assert perturbation.uppercase_fraction == config.random_uppercase_fraction
+        else:
+            assert isinstance(perturbation, AddRemoveWhitespace)
+            assert perturbation.num_perturbations == config.num_perturbations
+            assert perturbation.add_prob == config.whitespace_add_prob
+            assert perturbation.remove_prob == config.whitespace_remove_prob
+
+        if use_ray:
+            create_shared_resource.assert_called_once()
+        else:
+            create_shared_resource.assert_not_called()
+            bertscore_model.assert_called_with(config.model_type_for_bertscore)
+
+    @pytest.mark.parametrize("is_deterministic", [True, False])
+    @patch("fmeval.eval_algorithms.general_semantic_robustness.BertscoreModel")
+    def test_build_pipeline(self, bertscore_model, is_deterministic, config):
+        """
+        GIVEN a deterministic model.
+        WHEN `build_pipeline` is called.
+        THEN a TransformPipeline with the correct Transforms is returned.
+        """
+        # Mock BertscoreModel so that the actual model doesn't get loaded into memory during test.
+        bertscore_model.return_value = Mock(spec=BertscoreModel)
+
+        eval_algo = GeneralSemanticRobustness(config, use_ray=False)
+        pipeline = eval_algo.build_pipeline(
+            model=Mock(),
+            prompt_template="$model_input",
+            is_deterministic=is_deterministic,
         )
-        assert save_dataset.called == test_case.save_data
-        assert actual_response == test_case.expected_response
 
-    class TestCaseSemanticRobustnessEvaluateInvalid(NamedTuple):
-        input_dataset: Dataset
-        dataset_config: Optional[DataConfig]
-        prompt_template: Optional[str]
-        model_provided: bool
-        expected_error_message: str
+        transforms = pipeline.transforms
+        if is_deterministic:
+            assert len(transforms) == 6
+        else:
+            assert len(transforms) == 11
+
+        perturbation = transforms[0]
+        gen_prompts = transforms[1]
+        model_responses = transforms[2]
+        bert_scores = transforms[3]
+        bsd = transforms[4]
+        wer = transforms[5]
+
+        assert isinstance(perturbation, ButterFinger)  # default perturbation type used by config is BUTTER_FINGER
+        assert isinstance(gen_prompts, GeneratePrompt)
+        assert len(gen_prompts.output_keys) == config.num_perturbations
+        assert isinstance(model_responses, GetModelResponse)
+        assert len(model_responses.output_keys) == config.num_perturbations
+        assert isinstance(bert_scores, BertScore)
+        assert len(bert_scores.output_keys) == config.num_perturbations
+        assert isinstance(bsd, BertScoreDissimilarity)
+        assert isinstance(wer, WER)
+
+        if not is_deterministic:
+            baseline_responses = transforms[6]
+            baseline_bert = transforms[7]
+            baseline_bsd = transforms[8]
+            baseline_wer = transforms[9]
+            update_scores = transforms[10]
+
+            assert isinstance(baseline_responses, GetModelResponse)
+            assert len(baseline_responses.output_keys) == config.num_baseline_samples - 1
+            assert isinstance(baseline_bert, BertScore)
+            assert len(baseline_bert.output_keys) == len(
+                list(itertools.combinations([i for i in range(config.num_baseline_samples)], 2))
+            )
+            assert isinstance(baseline_bsd, BertScoreDissimilarity)
+            assert isinstance(baseline_wer, WER)
+            assert isinstance(update_scores, UpdateRobustnessScores)
+
+    class TestCaseEvaluateSample(NamedTuple):
+        model_input: str
+        original_model_output: str
+        perturbed_model_output_1: str
+        perturbed_model_output_2: str
+        expected_response: List[EvalScore]
 
     @pytest.mark.parametrize(
         "test_case",
         [
-            TestCaseSemanticRobustnessEvaluateInvalid(
-                input_dataset=DATASET_NO_CATEGORY,
-                dataset_config=None,
-                prompt_template=None,
-                model_provided=False,
-                expected_error_message="Missing required input: model i.e. ModelRunner, for GeneralSemanticRobustness "
-                "evaluate method",
+            TestCaseEvaluateSample(
+                model_input="What is the capital of England?",
+                original_model_output="Some model output.",
+                perturbed_model_output_1="Some model output.",
+                perturbed_model_output_2="Some model output.",
+                expected_response=[
+                    EvalScore(name=BERT_SCORE_DISSIMILARITY, value=BERTSCORE_DISSIMILARITY_DUMMY_VALUE),
+                    EvalScore(name=WER_SCORE, value=0.0),
+                ],
             ),
-            TestCaseSemanticRobustnessEvaluateInvalid(
-                input_dataset=DATASET_NO_CATEGORY.drop_columns(cols=[DatasetColumns.MODEL_INPUT.value.name]),
-                dataset_config=DataConfig(
-                    dataset_name="my_custom_dataset",
-                    dataset_uri="tba",
-                    dataset_mime_type=MIME_TYPE_JSON,
-                    model_input_location="tba",
-                    target_output_location="tba",
-                    model_output_location=None,
-                    category_location="tba",
-                ),
-                prompt_template=None,
-                model_provided=True,
-                expected_error_message="Missing required column: model_input, for evaluate() method",
+            TestCaseEvaluateSample(
+                model_input="What is the capital of England?",
+                original_model_output="Some model output.",
+                perturbed_model_output_1="Another model output.",
+                perturbed_model_output_2="Some model output.",
+                expected_response=[
+                    EvalScore(name=BERT_SCORE_DISSIMILARITY, value=BERTSCORE_DISSIMILARITY_DUMMY_VALUE),
+                    EvalScore(name=WER_SCORE, value=(1 / 3 + 0) / 2),
+                ],
+            ),
+            TestCaseEvaluateSample(
+                model_input="What is the capital of England?",
+                original_model_output="Some model output.",
+                perturbed_model_output_1="Another model output.",
+                perturbed_model_output_2="Some model output.",
+                expected_response=[
+                    EvalScore(name=BERT_SCORE_DISSIMILARITY, value=BERTSCORE_DISSIMILARITY_DUMMY_VALUE),
+                    EvalScore(name=WER_SCORE, value=(1 / 3 + 0) / 2),
+                ],
+            ),
+            TestCaseEvaluateSample(
+                model_input="What is the capital of England?",
+                original_model_output="Some model output.",
+                perturbed_model_output_1="Another model output.",
+                perturbed_model_output_2="Another model output.",
+                expected_response=[
+                    EvalScore(name=BERT_SCORE_DISSIMILARITY, value=BERTSCORE_DISSIMILARITY_DUMMY_VALUE),
+                    EvalScore(name=WER_SCORE, value=(1 / 3 + 1 / 3) / 2),
+                ],
             ),
         ],
     )
-    @patch("fmeval.model_runners.model_runner.ModelRunner")
+    @patch("fmeval.eval_algorithms.general_semantic_robustness.BertscoreModel")
+    def test_evaluate_sample_deterministic_model(self, bertscore_model, test_case, config):
+        """
+        GIVEN a deterministic model
+        WHEN GeneralSemanticRobustness.evaluate_sample is called
+        THEN correct List of EvalScores is returned
+        """
+        model = Mock()
+        model.predict.side_effect = [
+            (test_case.original_model_output, None),  # Original model output
+            (test_case.original_model_output, None),  # The determinism check
+            (test_case.perturbed_model_output_1, None),  # Output on the first perturbation
+            (test_case.perturbed_model_output_2, None),  # Output on the second perturbation
+        ]
+        bertscore_model_instance = Mock(spec=BertscoreModel)
+        bertscore_model_instance.invoke_model = Mock(return_value=BERTSCORE_DUMMY_VALUE)
+        bertscore_model.return_value = bertscore_model_instance
+
+        eval_algo = GeneralSemanticRobustness(config, use_ray=False)
+        assert eval_algo.evaluate_sample(test_case.model_input, model) == test_case.expected_response
+        assert model.predict.call_count == 4
+
+    @pytest.mark.parametrize(
+        "test_case",
+        [
+            TestCaseEvaluateSample(
+                model_input="What is the capital of England?",
+                original_model_output="Some model output.",
+                perturbed_model_output_1="Another longer model output.",
+                perturbed_model_output_2="Yet another model output which is even longer.",
+                expected_response=[
+                    EvalScore(name=WER_SCORE, value=0),
+                    EvalScore(name=BERT_SCORE_DISSIMILARITY, value=0),
+                ],
+            )
+        ],
+    )
+    @patch("fmeval.eval_algorithms.general_semantic_robustness.BertscoreModel")
+    def test_semantic_robustness_evaluate_sample_non_deterministic_model(self, bertscore_model, test_case, config):
+        """
+        GIVEN a non-deterministic model.
+        WHEN GeneralSemanticRobustness.evaluate_sample is called.
+        THEN the robustness score value is smaller than it would be for a deterministic model.
+        """
+        bertscore_model_instance = Mock(spec=BertscoreModel)
+        bertscore_model_instance.invoke_model = Mock(return_value=BERTSCORE_DUMMY_VALUE)
+        bertscore_model.return_value = bertscore_model_instance
+
+        deterministic_model = MagicMock()
+        deterministic_model.predict.side_effect = [
+            (test_case.original_model_output, None),  # Original model output
+            (test_case.original_model_output, None),  # The determinism check
+            (test_case.perturbed_model_output_1, None),  # Output on the first perturbation
+            (test_case.perturbed_model_output_2, None),  # Output on the second perturbation
+        ]
+
+        nondeterministic_model = MagicMock()
+        nondeterministic_model.predict.side_effect = [
+            (test_case.original_model_output, None),  # Original model output
+            (test_case.original_model_output + "1", None),  # The determinism check
+            (test_case.perturbed_model_output_1, None),  # Output on the first perturbation
+            (test_case.perturbed_model_output_2, None),  # Output on the second perturbation
+            (test_case.original_model_output + "1", None),  # Computing baseline: first model call
+            (test_case.original_model_output + "1", None),  # Computing baseline: second model call
+            (test_case.original_model_output + "1", None),  # Computing baseline: third model call
+        ]
+
+        eval_algorithm = GeneralSemanticRobustness(config, use_ray=False)
+        output_deterministic = eval_algorithm.evaluate_sample(test_case.model_input, deterministic_model)
+        output_nondeterministic = eval_algorithm.evaluate_sample(test_case.model_input, nondeterministic_model)
+        assert output_nondeterministic[0].value < output_deterministic[0].value  # BERTScore Dissimilarity
+        assert output_nondeterministic[1].value < output_deterministic[1].value  # WER
+
+    class TestCaseEvaluate(NamedTuple):
+        user_provided_prompt_template: Optional[str]
+        dataset_prompt_template: str
+        is_deterministic: bool
+
+    @pytest.mark.parametrize(
+        "test_case",
+        [
+            TestCaseEvaluate(
+                user_provided_prompt_template="Answer: $model_input",
+                dataset_prompt_template="Answer: $model_input",
+                is_deterministic=True,
+            ),
+            TestCaseEvaluate(
+                user_provided_prompt_template=None,
+                dataset_prompt_template="$model_input",
+                is_deterministic=False,
+            ),
+        ],
+    )
+    @patch("fmeval.eval_algorithms.general_semantic_robustness.save_dataset")
+    @patch("fmeval.eval_algorithms.general_semantic_robustness.GeneralSemanticRobustness.build_pipeline")
+    @patch("fmeval.eval_algorithms.general_semantic_robustness.TransformPipeline")
+    @patch("fmeval.eval_algorithms.general_semantic_robustness.verify_model_determinism")
+    @patch("fmeval.eval_algorithms.general_semantic_robustness.GetModelResponse")
+    @patch("fmeval.eval_algorithms.general_semantic_robustness.GeneratePrompt")
     @patch("fmeval.eval_algorithms.general_semantic_robustness.get_dataset")
-    @patch("fmeval.eval_algorithms.general_semantic_robustness.BertscoreHelperModel")
-    def test_semantic_robustness_evaluate_invalid_input(
+    @patch("fmeval.eval_algorithms.general_semantic_robustness.get_dataset_configs")
+    @patch("fmeval.eval_algorithms.general_semantic_robustness.BertscoreModel")
+    def test_evaluate(
         self,
-        bertscore_helper_model,
+        bertscore_model,
+        get_dataset_configs,
         get_dataset,
-        model,
+        generate_prompt,
+        get_model_response,
+        verify_model_determinism,
+        transform_pipeline,
+        build_pipeline,
+        save_dataset,
         test_case,
         config,
     ):
         """
-        GIVEN invalid inputs
-        WHEN GeneralSemanticRobustness evaluate is called
-        THEN correct exception with proper message is raised
+        GIVEN a valid dataset.
+        WHEN the GeneralSemanticRobustness evaluate method is called with save=True.
+        THEN two transform pipelines are created and executed (one for getting original
+            model responses and the other for handling the GSR logic),
+            the EvalOutputs that are returned contain the correct scores,
+            the EvalOutputs indicate that the correct prompt templates were used,
+            and save_dataset is called.
         """
-        # We mock the BertscoreHelperModel class so that an actual ray actor doesn't get created
-        bertscore_helper_model_instance = MagicMock()
-        bertscore_helper_model.return_value = bertscore_helper_model_instance
+        eval_algo = GeneralSemanticRobustness(
+            config,
+            use_ray=False,
+        )
 
-        eval_algorithm = GeneralSemanticRobustness(config)
-        get_dataset.return_value = test_case.input_dataset
-        if not test_case.model_provided:
-            model = None
-        with pytest.raises(EvalAlgorithmClientError, match=re.escape(test_case.expected_error_message)):
-            eval_algorithm.evaluate(
-                model=model, dataset_config=test_case.dataset_config, prompt_template=test_case.prompt_template
+        model_runner = Mock()
+        bertscore_model.return_value = Mock()
+
+        generate_original_prompt = Mock(spec=GeneratePrompt)
+        generate_original_prompt.output_keys = ["prompt"]
+        generate_prompt.return_value = generate_original_prompt
+
+        get_original_model_response = Mock(spec=GetModelResponse)
+        get_original_model_response.output_keys = ["model_output"]
+        get_model_response.return_value = get_original_model_response
+
+        dataset_config = Mock()
+        dataset_config.dataset_name = "my_custom_dataset"
+        get_dataset_configs.return_value = [dataset_config]
+
+        mock_dataset = Mock()
+        mock_dataset.columns = Mock(return_value=[DatasetColumns.MODEL_INPUT.value.name])
+        get_dataset.return_value = mock_dataset
+
+        verify_model_determinism.return_value = test_case.is_deterministic
+
+        # First pipeline that gets executed generates prompt and model output columns.
+        # Second pipeline (created via self.build_pipeline) that gets executed handles everything else.
+        transform_pipeline.execute = Mock(return_value=DATASET_WITH_MODEL_OUTPUT)
+        build_pipeline.return_value = Mock()
+        build_pipeline.return_value.execute = Mock(return_value=DATASET_WITH_SCORES)
+
+        # Expected outputs from calling `evaluate`.
+        expected_dataset_scores = [
+            EvalScore(name=BERT_SCORE_DISSIMILARITY, value=BERTSCORE_DISSIMILARITY_DUMMY_VALUE),
+            EvalScore(name=WER_SCORE, value=0.0),
+        ]
+        expected_category_scores = [
+            CategoryScore(
+                name="dummy_category_1",
+                scores=[
+                    EvalScore(name=BERT_SCORE_DISSIMILARITY, value=BERTSCORE_DISSIMILARITY_DUMMY_VALUE),
+                    EvalScore(name=WER_SCORE, value=0.0),
+                ],
+            ),
+            CategoryScore(
+                name="dummy_category_2",
+                scores=[
+                    EvalScore(name=BERT_SCORE_DISSIMILARITY, value=BERTSCORE_DISSIMILARITY_DUMMY_VALUE),
+                    EvalScore(name=WER_SCORE, value=0.0),
+                ],
+            ),
+        ]
+        expected_outputs = [
+            EvalOutput(
+                eval_name="general_semantic_robustness",
+                prompt_template=test_case.dataset_prompt_template,
+                dataset_name="my_custom_dataset",
+                dataset_scores=expected_dataset_scores,
+                category_scores=expected_category_scores,
+                output_path="/tmp/eval_results/general_semantic_robustness_my_custom_dataset.jsonl",
             )
+        ]
+
+        # Call `evaluate` and validate outputs.
+        eval_outputs = eval_algo.evaluate(
+            model=model_runner,
+            dataset_config=dataset_config,
+            prompt_template=test_case.user_provided_prompt_template,
+            save=True,
+        )
+
+        generate_prompt.assert_called_with(
+            input_keys=[DatasetColumns.MODEL_INPUT.value.name],
+            output_keys=[DatasetColumns.PROMPT.value.name],
+            prompt_template=test_case.dataset_prompt_template,
+        )
+        get_model_response.assert_called_with(
+            input_key_to_response_keys={DatasetColumns.PROMPT.value.name: [(DatasetColumns.MODEL_OUTPUT.value.name,)]},
+            model_runner=model_runner,
+        )
+        transform_pipeline.assert_called_with([generate_original_prompt, get_original_model_response])
+        build_pipeline.assert_called_with(
+            model_runner, test_case.dataset_prompt_template, is_deterministic=test_case.is_deterministic
+        )
+        save_dataset.assert_called_once()
+        assert eval_outputs == expected_outputs

--- a/test/unit/eval_algorithms/test_general_semantic_robustness.py
+++ b/test/unit/eval_algorithms/test_general_semantic_robustness.py
@@ -179,7 +179,7 @@ class TestGeneralSemanticRobustness:
         elif perturbation_type == RANDOM_UPPERCASE:
             assert isinstance(perturbation, RandomUppercase)
             assert perturbation.num_perturbations == config.num_perturbations
-            assert perturbation.uppercase_fraction == config.random_uppercase_fraction
+            assert perturbation.uppercase_fraction == config.random_uppercase_corrupt_proportion
         else:
             assert isinstance(perturbation, AddRemoveWhitespace)
             assert perturbation.num_perturbations == config.num_perturbations

--- a/test/unit/eval_algorithms/test_qa_accuracy_semantic_robustness.py
+++ b/test/unit/eval_algorithms/test_qa_accuracy_semantic_robustness.py
@@ -25,8 +25,8 @@ from fmeval.eval_algorithms import (
 from fmeval.eval_algorithms.qa_accuracy_semantic_robustness import (
     QAAccuracySemanticRobustnessConfig,
     QAAccuracySemanticRobustness,
-    RANDOM_UPPER_CASE,
-    WHITESPACE_ADD_REMOVE,
+    RANDOM_UPPERCASE,
+    ADD_REMOVE_WHITESPACE,
     BUTTER_FINGER,
     DELTA_F1_SCORE,
     DELTA_QUASI_EXACT_MATCH_SCORE,
@@ -124,7 +124,7 @@ class TestQAAccuracySemanticRobustness:
                 target_output_delimiter="<OR>",
                 perturbation_type="my_perturb",
                 expected_error_message="Invalid perturbation type 'my_perturb requested, please choose from "
-                "acceptable values: dict_keys(['butter_finger', 'random_upper_case', 'whitespace_add_remove'])",
+                "acceptable values: dict_keys(['butter_finger', 'random_uppercase', 'add_remove_whitespace'])",
             ),
             TestCaseQAAccuracySemanticRobustnessInvalidConfig(
                 target_output_delimiter="",
@@ -218,7 +218,7 @@ class TestQAAccuracySemanticRobustness:
                     EvalScore(name=DELTA_RECALL_OVER_WORDS, value=1.0),
                 ],
                 config=QAAccuracySemanticRobustnessConfig(
-                    target_output_delimiter="<OR>", num_perturbations=2, perturbation_type=RANDOM_UPPER_CASE
+                    target_output_delimiter="<OR>", num_perturbations=2, perturbation_type=RANDOM_UPPERCASE
                 ),
             ),
             TestCaseQAAccuracySemanticRobustnessEvaluateSample(
@@ -240,7 +240,7 @@ class TestQAAccuracySemanticRobustness:
                     EvalScore(name=DELTA_RECALL_OVER_WORDS, value=1.0),
                 ],
                 config=QAAccuracySemanticRobustnessConfig(
-                    target_output_delimiter="<OR>", num_perturbations=2, perturbation_type=WHITESPACE_ADD_REMOVE
+                    target_output_delimiter="<OR>", num_perturbations=2, perturbation_type=ADD_REMOVE_WHITESPACE
                 ),
             ),
         ],
@@ -442,8 +442,8 @@ class TestQAAccuracySemanticRobustness:
             ),
             # Built-in datasets evaluate for dataset with category
             TestCaseQAAccuracySemanticRobustnessEvaluate(
-                input_dataset=QA_DATASET_WITH_MODEL_OUTPUT,
-                input_dataset_with_generated_model_output=QA_DATASET,
+                input_dataset=QA_DATASET,
+                input_dataset_with_generated_model_output=QA_DATASET_WITH_MODEL_OUTPUT,
                 dataset_config=None,
                 prompt_template=None,
                 save_data=True,
@@ -589,7 +589,7 @@ class TestQAAccuracySemanticRobustness:
     )
     @patch("fmeval.eval_algorithms.qa_accuracy_semantic_robustness.get_dataset")
     @patch("fmeval.eval_algorithms.qa_accuracy_semantic_robustness.save_dataset")
-    @patch("fmeval.eval_algorithms.general_semantic_robustness.generate_model_predict_response_for_dataset")
+    @patch("fmeval.eval_algorithms.qa_accuracy_semantic_robustness.generate_model_predict_response_for_dataset")
     @patch("fmeval.eval_algorithms.qa_accuracy_semantic_robustness.QAAccuracy")
     def test_qa_accuracy_semantic_robustness_evaluate(
         self, qa_accuracy, generate_model_predict_response_for_dataset, save_dataset, get_dataset, test_case, config

--- a/test/unit/eval_algorithms/test_summarization_accuracy_semantic_robustness.py
+++ b/test/unit/eval_algorithms/test_summarization_accuracy_semantic_robustness.py
@@ -22,8 +22,8 @@ from fmeval.eval_algorithms import (
     GOV_REPORT,
 )
 from fmeval.eval_algorithms.general_semantic_robustness import (
-    RANDOM_UPPER_CASE,
-    WHITESPACE_ADD_REMOVE,
+    RANDOM_UPPERCASE,
+    ADD_REMOVE_WHITESPACE,
 )
 from fmeval.eval_algorithms.summarization_accuracy import METEOR_SCORE, ROUGE_SCORE, BERT_SCORE
 from fmeval.eval_algorithms.summarization_accuracy_semantic_robustness import (
@@ -177,7 +177,7 @@ class TestSummarizationAccuracySemanticRobustness:
                     EvalScore(name=DELTA_BERT_SCORE, value=0.25),
                 ],
                 config=SummarizationAccuracySemanticRobustnessConfig(
-                    num_perturbations=2, perturbation_type=RANDOM_UPPER_CASE
+                    num_perturbations=2, perturbation_type=RANDOM_UPPERCASE
                 ),
             ),
             TestCaseSummarizationAccuracySemanticRobustnessEvaluateSample(
@@ -210,7 +210,7 @@ class TestSummarizationAccuracySemanticRobustness:
                     EvalScore(name=DELTA_BERT_SCORE, value=0.25),
                 ],
                 config=SummarizationAccuracySemanticRobustnessConfig(
-                    num_perturbations=2, perturbation_type=WHITESPACE_ADD_REMOVE
+                    num_perturbations=2, perturbation_type=ADD_REMOVE_WHITESPACE
                 ),
             ),
         ],
@@ -388,7 +388,7 @@ class TestSummarizationAccuracySemanticRobustness:
                 bertscore_model_type="distilbert-base-uncased",
                 perturbation_type="my_perturb",
                 expected_error_message="Invalid perturbation type 'my_perturb requested, please choose from "
-                "acceptable values: dict_keys(['butter_finger', 'random_upper_case', 'whitespace_add_remove'])",
+                "acceptable values: dict_keys(['butter_finger', 'random_uppercase', 'add_remove_whitespace'])",
             ),
         ],
     )

--- a/test/unit/transforms/test_common.py
+++ b/test/unit/transforms/test_common.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import patch
 from typing import NamedTuple, List, Optional, Dict, Any, Tuple
 
-from fmeval.transforms.common import GeneratePrompt, GetModelResponse
+from fmeval.transforms.common import GeneratePrompt, GetModelResponse, Mean
 from fmeval.util import EvalAlgorithmInternalError
 
 
@@ -172,3 +172,14 @@ def test_get_model_response_call_failure(model_output, log_prob, response_keys):
         )
         with pytest.raises(EvalAlgorithmInternalError, match="The number of elements in model response"):
             get_model_response(sample)
+
+
+def test_mean_call():
+    """
+    GIVEN a Mean instance.
+    WHEN its __call__ method is called.
+    THEN the correct output is returned.
+    """
+    m = Mean(input_keys=["a", "b", "c"], output_key="mean")
+    sample = {"a": 1, "b": 6, "c": 2}
+    assert m(sample)["mean"] == 3.0

--- a/test/unit/transforms/test_semantic_robustness_metrics.py
+++ b/test/unit/transforms/test_semantic_robustness_metrics.py
@@ -1,0 +1,64 @@
+import pytest
+from unittest.mock import Mock, patch
+from fmeval.util import EvalAlgorithmClientError
+from fmeval.transforms.semantic_robustness_metrics import BertScoreDissimilarity, WER
+
+
+def test_bertscore_dissimilarity_call():
+    """
+    GIVEN a BertScoreDissimilarity instance.
+    WHEN its __call__ method is called.
+    THEN the correct output is returned.
+    """
+    bsd = BertScoreDissimilarity(bert_score_keys=["a", "b", "c", "d"], output_key="bsd")
+    sample = {"a": 0.1, "b": 0.2, "c": 0.3, "d": 0.4}
+    actual_bsd_score = bsd(sample)["bsd"]
+    assert actual_bsd_score == 0.75  # 1 - mean(0.1, 0.2, 0.3, 0.4)
+
+
+def test_wer_init_failure():
+    """
+    GIVEN prediction_keys and reference_keys arguments with mismatching lengths.
+    WHEN a WER is initialized.
+    THEN an exception with the correct error message is raised.
+    """
+    err_msg = (
+        "prediction_keys and reference_keys should have the same number of elements. "
+        "prediction_keys has 2 elements while reference_keys has "
+        "3 elements."
+    )
+    with pytest.raises(EvalAlgorithmClientError, match=err_msg):
+        WER(
+            prediction_keys=["p1", "p2"],
+            reference_keys=["r1", "r2", "r3"],
+            output_key="wer",
+        )
+
+
+def test_wer_call():
+    """
+    GIVEN a WER instance.
+    WHEN its __call__ method is called.
+    THEN the huggingface wer metric is called with the correct arguments
+        and the record is augmented with the output from calling the
+        huggingface wer metric.
+    """
+    with patch("fmeval.transforms.summarization_accuracy_metrics.hf_evaluate.load") as mock_hf_load:
+        mock_wer_metric = Mock()
+        mock_wer_metric.compute = Mock()
+        mock_wer_metric.compute.return_value = 0.123
+        mock_hf_load.return_value = mock_wer_metric
+
+        wer = WER(
+            prediction_keys=["p1", "p2", "p3"],
+            reference_keys=["r1", "r2", "r3"],
+            output_key="wer",
+        )
+
+        sample = {"p1": "a", "p2": "b", "p3": "c", "r1": "d", "r2": "e", "r3": "f"}
+        result = wer(sample)["wer"]
+        mock_wer_metric.compute.assert_called_once_with(
+            predictions=["a", "b", "c"],
+            references=["d", "e", "f"],
+        )
+        assert result == 0.123

--- a/test/unit/transforms/test_transform_pipeline.py
+++ b/test/unit/transforms/test_transform_pipeline.py
@@ -4,7 +4,6 @@ import pytest
 from unittest.mock import Mock, patch
 from typing import Any, List, NamedTuple, Dict
 
-from fmeval.constants import TRANSFORM_PIPELINE_MAX_SIZE
 from fmeval.exceptions import EvalAlgorithmClientError
 from fmeval.transforms.common import GeneratePrompt
 from fmeval.transforms.transform import Transform
@@ -70,12 +69,6 @@ class TestCaseInitFailure(NamedTuple):
                 "{GeneratePrompt(input_keys=['input_1'], output_keys=['output_1'], "
                 "args=[['input_1'], ['output_1'], '1'], kwargs={}): ['output_1']}"
             ),
-        ),
-        TestCaseInitFailure(
-            transforms=[
-                GeneratePrompt([f"input_{i}"], [f"output_{i}"], str(i)) for i in range(TRANSFORM_PIPELINE_MAX_SIZE + 1)
-            ],
-            err_msg=f"TransformPipeline initialized with {TRANSFORM_PIPELINE_MAX_SIZE + 1} Transforms.",
         ),
     ],
 )


### PR DESCRIPTION
*Description of changes:*
This PR updates the `GeneralSemanticRobustness` algorithm such that evaluation logic is implemented via the use of `Transform`s. This PR is analogous to #214, but for General Semantic Robustness (GSR).

The diff indicates that many files have been changed, but all of the changes to code that is not related to GSR are due to my renaming of some constants (`RANDOM_UPPER_CASE` -> `RANDOM_UPPERCASE` and `WHITESPACE_ADD_REMOVE` -> `ADD_REMOVE_WHITESPACE`).

The main files to review are the following:
- [src/fmeval/eval_algorithms/general_semantic_robustness.py](https://github.com/aws/fmeval/compare/main...danielezhu:fmeval:gsr?expand=1#diff-d9531d2c2473c43760c708bfdedb205b4cfe89efeb9e108b2554937df63ecd9a) which obviously contains the new implementation of GSR.
- [src/fmeval/transforms/semantic_robustness_metrics.py](https://github.com/aws/fmeval/compare/main...danielezhu:fmeval:gsr?expand=1#diff-9b5ee69a90366ce4d4f6050ec8e23c8250d36dcf99442549e5166a4cc31852f9) which contains the implementations of the BertScore Dissimilarity and WER metrics.
- [test/unit/eval_algorithms/test_general_semantic_robustness.py](https://github.com/aws/fmeval/compare/main...danielezhu:fmeval:gsr?expand=1#diff-0b269abe96b20327ed9a56edd191b7e4061af9f62130fb3966a22cf9125bad5b) which contains a complete rework of the unit tests for GSR. Note that when reviewing this file, it may be easier to just look at the file in its entirety instead of the diff.

Aside from these main changes, I've introduced a new util function `create_output_key` and a new `Mean` transform. Both of these are used by GSR.

Note that the expected values for the Bertscore Dissimilarity and WER scores in the GSR integration tests are now different due to the fact that the implementation of the semantic perturbation transforms uses the latest Numpy APIs for random number generation. See this [commit](https://github.com/aws/fmeval/pull/215/commits/1f5b0d639b2cd27fcd88a4e16b7c41b78dbe80fc) from #215.

In order to verify that the numerical score values are changing solely due to the new random number generation APIs and not due to bugs in my re-implementation of GSR, I did the following:
1. Run the `evaluate_sample` integration tests on the current `main` branch code, and take note of the scores that are generated
2. Run the `evaluate_sample` integration tests using the new `Transform`-based implementation, but change the code in `semantic_perturbations.py` so that we use the old `numpy` and `random` RNG code.
3. Make sure that the scores generated by step 1 match those generated by step 2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
