### PR TITLE
fix: update GetModelResponse transform to work with any ModelRunner

### DIFF
--- a/src/fmeval/eval_algorithms/summarization_accuracy.py
+++ b/src/fmeval/eval_algorithms/summarization_accuracy.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import Dict, Any, Optional, List
 
 from fmeval.perf_util import timed_block
-from fmeval.transforms.common import GeneratePrompt, GetModelResponse
+from fmeval.transforms.common import GeneratePrompt, GetModelOutputs
 from fmeval.util import require
 from fmeval.constants import BERTSCORE_DEFAULT_MODEL, DatasetColumns, MEAN
 from fmeval.data_loaders.data_config import DataConfig
@@ -184,13 +184,11 @@ class SummarizationAccuracy(EvalAlgorithmInterface):
                     output_keys=[DatasetColumns.PROMPT.value.name],
                     prompt_template=dataset_prompt_template,
                 )
-                get_model_response = GetModelResponse(
-                    input_key_to_response_keys={
-                        DatasetColumns.PROMPT.value.name: [(DatasetColumns.MODEL_OUTPUT.value.name,)]
-                    },
+                get_model_outputs = GetModelOutputs(
+                    input_to_output_keys={DatasetColumns.PROMPT.value.name: [DatasetColumns.MODEL_OUTPUT.value.name]},
                     model_runner=model,
                 )
-                pipeline = TransformPipeline([gen_prompt, get_model_response, pipeline])
+                pipeline = TransformPipeline([gen_prompt, get_model_outputs, pipeline])
 
             with timed_block(f"Computing score and aggregation on dataset {dataset_config.dataset_name}", logger):
                 dataset = pipeline.execute(dataset)

--- a/src/fmeval/transforms/common.py
+++ b/src/fmeval/transforms/common.py
@@ -1,11 +1,10 @@
 import numpy as np
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List
 
 from fmeval.model_runners.composers.composers import PromptComposer
 from fmeval.model_runners.model_runner import ModelRunner
 from fmeval.transforms.transform import Transform
 from fmeval.transforms.util import validate_call
-from fmeval.util import assert_condition
 
 
 class GeneratePrompt(Transform):
@@ -41,82 +40,55 @@ class GeneratePrompt(Transform):
         return record
 
 
-class GetModelResponse(Transform):
-    """This transform invokes a ModelRunner's `predict` method and augments the input record with the response payload.
+class GetModelOutputs(Transform):
+    """Invokes a ModelRunner's `predict` method and augments the input record with the model output.
 
-    An instance of this transform can be configured to get model responses for multiple inputs.
+    An instance of this transform can be configured to get model outputs for multiple inputs.
     See __init__ docstring for more details.
     """
 
     def __init__(
         self,
-        input_key_to_response_keys: Dict[str, List[Tuple[str]]],
+        input_to_output_keys: Dict[str, List[str]],
         model_runner: ModelRunner,
     ):
-        """GetModelResponse initializer.
+        """GetModelOutputs initializer.
 
-        :param input_key_to_response_keys: Maps an input key (corresponding to
-            the input payload to the model) to a list of tuples, where each tuple
-            contains the keys for the model response payload that results from
-            invoking the model on the input. Since the model can be invoked on
-            the same input multiple times, we map the input key to a list of tuples
-            instead of a single tuple.
+        :param input_to_output_keys: Maps an input key (corresponding to
+            the input payload to the model) to a list of output keys, where
+            each output key corresponds to the model output that is returned
+            when calling the `predict` method of `model_runner` on the input.
 
-            Note that the format of the response key tuple depends on the behavior of
-            model_runner's `predict` method. For ModelRunners whose `predict` method
-            returns both a model output and a log probability, the response key tuple
-            will be of the form (model_output_key, log_probability_key). If `predict`
-            returns only the model output or only the log probability, the response key
-            tuple will correspondingly be a single-element tuple.
+            Note that the reason a list of output keys is used (as opposed to
+            a singular key) is so that `model_runner` can be invoked on the
+            same input multiple times.
 
-            Example:
-                input_key_to_response_keys = {
-                    "input_1": [
-                        ("input_1_model_output_1", "input_1_log_prob_1"),
-                        ("input_1_model_output_2", "input_1_log_prob_2")
-                    ],
-                    "input_2": [
-                        ("input_2_model_output_1", "input_2_log_prob_1"),
-                        ("input_2_model_output_2", "input_2_log_prob_2")
-                    ],
-                }
-
-        :param model_runner: The ModelRunner instance whose responses will be obtained.
+            Note that the response payload from calling `predict` will be a tuple of the
+            form (model_output, log_probability), and this transform is only concerned with
+            the model_output element.
+        :param model_runner: The ModelRunner instance whose outputs will be obtained.
         """
-        super().__init__(input_key_to_response_keys, model_runner)
+        super().__init__(input_to_output_keys, model_runner)
         self.register_input_output_keys(
-            input_keys=list(input_key_to_response_keys.keys()),
+            input_keys=list(input_to_output_keys.keys()),
             output_keys=[
-                response_key
-                for list_of_response_key_tuples in input_key_to_response_keys.values()
-                for response_key_tuple in list_of_response_key_tuples
-                for response_key in response_key_tuple
+                output_key for output_key_list in input_to_output_keys.values() for output_key in output_key_list
             ],
         )
-        self.input_key_to_response_keys = input_key_to_response_keys
+        self.input_to_output_keys = input_to_output_keys
         self.model_runner = model_runner
 
     @validate_call
     def __call__(self, record: Dict[str, Any]) -> Dict[str, Any]:
-        """Augment the input record with model responses and returns said record.
+        """Augment the input record with model outputs and return said record.
 
         :param record: The input record.
-        :returns: The input record with model response data added in.
+        :returns: The input record with model output data added in.
         """
-        for input_key in self.input_keys:
-            response_key_tuples = self.input_key_to_response_keys[input_key]
-            for response_key_tuple in response_key_tuples:
-                model_output, log_prob = self.model_runner.predict(record[input_key])
-                model_response = ((model_output,) if model_output is not None else ()) + (
-                    (log_prob,) if log_prob is not None else ()
-                )
-                assert_condition(
-                    len(model_response) == len(response_key_tuple),
-                    f"The number of elements in model response {model_response} "
-                    f"does not match number of response keys in {response_key_tuple}.",
-                )
-                for model_response_key, model_response_item in zip(response_key_tuple, model_response):
-                    record[model_response_key] = model_response_item
+        for input_key, output_keys in self.input_to_output_keys.items():
+            for output_key in output_keys:
+                model_output, _ = self.model_runner.predict(record[input_key])
+                record[output_key] = model_output
         return record
 
 

--- a/test/integration/transforms/test_transform_pipeline.py
+++ b/test/integration/transforms/test_transform_pipeline.py
@@ -1,5 +1,5 @@
 from fmeval.data_loaders.util import get_dataset
-from fmeval.transforms.common import GeneratePrompt, GetModelResponse
+from fmeval.transforms.common import GeneratePrompt, GetModelOutputs
 from fmeval.transforms.transform_pipeline import TransformPipeline
 from fmeval.eval_algorithms import DATASET_CONFIGS, TREX
 from test.integration.models.model_runners import sm_model_runner
@@ -21,12 +21,12 @@ def test_pipeline_execution():
         prompt_template="Summarize the following text in one sentence: $model_input",
     )
 
-    get_model_response = GetModelResponse(
-        input_key_to_response_keys={gen_prompt.output_keys[0]: [("model_output",)]},
+    get_model_output = GetModelOutputs(
+        input_to_output_keys={gen_prompt.output_keys[0]: ["model_output"]},
         model_runner=sm_model_runner,
     )
 
-    pipeline = TransformPipeline([gen_prompt, get_model_response])
+    pipeline = TransformPipeline([gen_prompt, get_model_output])
     ds = pipeline.execute(ds)
 
     new_columns = set(ds.columns())

--- a/test/unit/eval_algorithms/test_general_semantic_robustness.py
+++ b/test/unit/eval_algorithms/test_general_semantic_robustness.py
@@ -28,7 +28,7 @@ from fmeval.exceptions import EvalAlgorithmClientError
 from fmeval.helper_models import BertscoreModel
 from fmeval.model_runners.model_runner import ModelRunner
 from fmeval.eval_algorithms.helper_models.helper_model import BertscoreHelperModelTypes
-from fmeval.transforms.common import GeneratePrompt, GetModelResponse
+from fmeval.transforms.common import GeneratePrompt, GetModelOutputs
 from fmeval.transforms.semantic_perturbations import (
     SemanticPerturbation,
     ButterFinger,
@@ -226,7 +226,7 @@ class TestGeneralSemanticRobustness:
         assert isinstance(perturbation, ButterFinger)  # default perturbation type used by config is BUTTER_FINGER
         assert isinstance(gen_prompts, GeneratePrompt)
         assert len(gen_prompts.output_keys) == config.num_perturbations
-        assert isinstance(model_responses, GetModelResponse)
+        assert isinstance(model_responses, GetModelOutputs)
         assert len(model_responses.output_keys) == config.num_perturbations
         assert isinstance(bert_scores, BertScore)
         assert len(bert_scores.output_keys) == config.num_perturbations
@@ -240,7 +240,7 @@ class TestGeneralSemanticRobustness:
             baseline_wer = transforms[9]
             update_scores = transforms[10]
 
-            assert isinstance(baseline_responses, GetModelResponse)
+            assert isinstance(baseline_responses, GetModelOutputs)
             assert len(baseline_responses.output_keys) == config.num_baseline_samples - 1
             assert isinstance(baseline_bert, BertScore)
             assert len(baseline_bert.output_keys) == len(
@@ -399,7 +399,7 @@ class TestGeneralSemanticRobustness:
     @patch("fmeval.eval_algorithms.general_semantic_robustness.GeneralSemanticRobustness.build_pipeline")
     @patch("fmeval.eval_algorithms.general_semantic_robustness.TransformPipeline")
     @patch("fmeval.eval_algorithms.general_semantic_robustness.verify_model_determinism")
-    @patch("fmeval.eval_algorithms.general_semantic_robustness.GetModelResponse")
+    @patch("fmeval.eval_algorithms.general_semantic_robustness.GetModelOutputs")
     @patch("fmeval.eval_algorithms.general_semantic_robustness.GeneratePrompt")
     @patch("fmeval.eval_algorithms.general_semantic_robustness.get_dataset")
     @patch("fmeval.eval_algorithms.general_semantic_robustness.get_dataset_configs")
@@ -410,7 +410,7 @@ class TestGeneralSemanticRobustness:
         get_dataset_configs,
         get_dataset,
         generate_prompt,
-        get_model_response,
+        get_model_outputs,
         verify_model_determinism,
         transform_pipeline,
         build_pipeline,
@@ -439,9 +439,9 @@ class TestGeneralSemanticRobustness:
         generate_original_prompt.output_keys = ["prompt"]
         generate_prompt.return_value = generate_original_prompt
 
-        get_original_model_response = Mock(spec=GetModelResponse)
-        get_original_model_response.output_keys = ["model_output"]
-        get_model_response.return_value = get_original_model_response
+        get_original_model_outputs = Mock(spec=GetModelOutputs)
+        get_original_model_outputs.output_keys = ["model_output"]
+        get_model_outputs.return_value = get_original_model_outputs
 
         dataset_config = Mock()
         dataset_config.dataset_name = "my_custom_dataset"
@@ -504,11 +504,11 @@ class TestGeneralSemanticRobustness:
             output_keys=[DatasetColumns.PROMPT.value.name],
             prompt_template=test_case.dataset_prompt_template,
         )
-        get_model_response.assert_called_with(
-            input_key_to_response_keys={DatasetColumns.PROMPT.value.name: [(DatasetColumns.MODEL_OUTPUT.value.name,)]},
+        get_model_outputs.assert_called_with(
+            input_to_output_keys={DatasetColumns.PROMPT.value.name: [DatasetColumns.MODEL_OUTPUT.value.name]},
             model_runner=model_runner,
         )
-        transform_pipeline.assert_called_with([generate_original_prompt, get_original_model_response])
+        transform_pipeline.assert_called_with([generate_original_prompt, get_original_model_outputs])
         build_pipeline.assert_called_with(
             model_runner, test_case.dataset_prompt_template, is_deterministic=test_case.is_deterministic
         )

--- a/test/unit/eval_algorithms/test_summarization_accuracy.py
+++ b/test/unit/eval_algorithms/test_summarization_accuracy.py
@@ -18,7 +18,7 @@ from fmeval.eval_algorithms import (
     EvalScore,
 )
 from fmeval.helper_models import BertscoreModel
-from fmeval.transforms.common import GetModelResponse, GeneratePrompt
+from fmeval.transforms.common import GetModelOutputs, GeneratePrompt
 from fmeval.transforms.summarization_accuracy_metrics import ROUGE_L
 from fmeval.eval_algorithms.summarization_accuracy import (
     SummarizationAccuracyConfig,
@@ -245,7 +245,7 @@ class TestSummarizationAccuracy:
     )
     @patch("fmeval.eval_algorithms.summarization_accuracy.save_dataset")
     @patch("fmeval.transforms.transform_pipeline.TransformPipeline.execute")
-    @patch("fmeval.eval_algorithms.summarization_accuracy.GetModelResponse")
+    @patch("fmeval.eval_algorithms.summarization_accuracy.GetModelOutputs")
     @patch("fmeval.eval_algorithms.summarization_accuracy.GeneratePrompt")
     @patch("fmeval.eval_algorithms.summarization_accuracy.get_dataset")
     @patch("fmeval.eval_algorithms.summarization_accuracy.get_dataset_configs")
@@ -255,8 +255,8 @@ class TestSummarizationAccuracy:
         bertscore_model,
         get_dataset_configs,
         get_dataset,
-        generate_prompt,
-        get_model_response,
+        generate_prompt_cls,
+        get_model_outputs_cls,
         pipeline_execute,
         save_dataset,
         test_case,
@@ -276,11 +276,11 @@ class TestSummarizationAccuracy:
 
         generate_prompt_instance = Mock(spec=GeneratePrompt)
         generate_prompt_instance.output_keys = ["prompt"]
-        generate_prompt.return_value = generate_prompt_instance
+        generate_prompt_cls.return_value = generate_prompt_instance
 
-        get_model_response_instance = Mock(spec=GetModelResponse)
-        get_model_response_instance.output_keys = ["model_output"]
-        get_model_response.return_value = get_model_response_instance
+        get_model_outputs_instance = Mock(spec=GetModelOutputs)
+        get_model_outputs_instance.output_keys = ["model_output"]
+        get_model_outputs_cls.return_value = get_model_outputs_instance
 
         dataset_config = Mock()
         dataset_config.dataset_name = "my_custom_dataset"
@@ -337,13 +337,13 @@ class TestSummarizationAccuracy:
             save=True,
         )
 
-        generate_prompt.assert_called_with(
+        generate_prompt_cls.assert_called_with(
             input_keys=[DatasetColumns.MODEL_INPUT.value.name],
             output_keys=[DatasetColumns.PROMPT.value.name],
             prompt_template=test_case.eval_output_prompt_template,
         )
-        get_model_response.assert_called_with(
-            input_key_to_response_keys={DatasetColumns.PROMPT.value.name: [(DatasetColumns.MODEL_OUTPUT.value.name,)]},
+        get_model_outputs_cls.assert_called_with(
+            input_to_output_keys={DatasetColumns.PROMPT.value.name: [DatasetColumns.MODEL_OUTPUT.value.name]},
             model_runner=model_runner,
         )
         save_dataset.assert_called_once()
@@ -353,7 +353,7 @@ class TestSummarizationAccuracy:
 
     @patch("fmeval.eval_algorithms.summarization_accuracy.save_dataset")
     @patch("fmeval.transforms.transform_pipeline.TransformPipeline.execute")
-    @patch("fmeval.eval_algorithms.summarization_accuracy.GetModelResponse")
+    @patch("fmeval.eval_algorithms.summarization_accuracy.GetModelOutputs")
     @patch("fmeval.eval_algorithms.summarization_accuracy.GeneratePrompt")
     @patch("fmeval.eval_algorithms.summarization_accuracy.get_dataset")
     @patch("fmeval.eval_algorithms.summarization_accuracy.get_dataset_configs")
@@ -364,7 +364,7 @@ class TestSummarizationAccuracy:
         get_dataset_configs,
         get_dataset,
         generate_prompt,
-        get_model_response,
+        get_model_outputs,
         pipeline_execute,
         save_dataset,
         eval_algo,
@@ -418,7 +418,7 @@ class TestSummarizationAccuracy:
         )
 
         generate_prompt.assert_not_called()
-        get_model_response.assert_not_called()
+        get_model_outputs.assert_not_called()
         save_dataset.assert_not_called()
         assert len(eval_outputs) == len(expected_outputs)
         for expected, actual in zip(expected_outputs, eval_outputs):

--- a/test/unit/transforms/test_common.py
+++ b/test/unit/transforms/test_common.py
@@ -1,9 +1,7 @@
 import pytest
 from unittest.mock import patch
-from typing import NamedTuple, List, Optional, Dict, Any, Tuple
 
-from fmeval.transforms.common import GeneratePrompt, GetModelResponse, Mean
-from fmeval.util import EvalAlgorithmInternalError
+from fmeval.transforms.common import GeneratePrompt, GetModelOutputs, Mean
 
 
 def test_generate_prompt_init():
@@ -38,79 +36,57 @@ def test_generate_prompt_call():
     }
 
 
-def test_get_model_response_init_success():
+def test_get_model_outputs_init_success():
     """
     GIVEN valid initializer arguments.
-    WHEN a GeneratePrompt object is instantiated.
+    WHEN a GetModelOutputs object is instantiated.
     THEN the instance's attributes match what is expected.
     """
     with patch("fmeval.transforms.common.ModelRunner") as mock_model_runner:
-        get_model_response = GetModelResponse(
-            input_key_to_response_keys={"prompt": [("model_output",)]}, model_runner=mock_model_runner
+        get_model_outputs = GetModelOutputs(
+            input_to_output_keys={
+                "prompt_a": ["model_output_1", "model_output_2"],
+                "prompt_b": ["model_output_3", "model_output_4"],
+            },
+            model_runner=mock_model_runner,
         )
-        assert get_model_response.input_keys == ["prompt"]
-        assert get_model_response.output_keys == ["model_output"]
-        assert get_model_response.model_runner == mock_model_runner
+        assert get_model_outputs.input_keys == ["prompt_a", "prompt_b"]
+        assert get_model_outputs.output_keys == ["model_output_1", "model_output_2", "model_output_3", "model_output_4"]
+        assert get_model_outputs.model_runner == mock_model_runner
 
 
-class TestCaseGetModelResponseSuccess(NamedTuple):
-    model_output: Optional[str]
-    log_prob: Optional[float]
-    response_keys: List[Tuple[str]]
-    expected_result: Dict[str, Any]
-
-
-@pytest.mark.parametrize(
-    "model_output, log_prob, response_keys, expected_result",
-    [
-        TestCaseGetModelResponseSuccess(
-            model_output="some output",
-            log_prob=-0.162,
-            response_keys=[("model_output", "log_prob")],
-            expected_result={"input": "Hello", "model_output": "some output", "log_prob": -0.162},
-        ),
-        TestCaseGetModelResponseSuccess(
-            model_output="some output",
-            log_prob=None,
-            response_keys=[("model_output",)],
-            expected_result={"input": "Hello", "model_output": "some output"},
-        ),
-        TestCaseGetModelResponseSuccess(
-            model_output=None,
-            log_prob=-0.162,
-            response_keys=[("log_prob",)],
-            expected_result={"input": "Hello", "log_prob": -0.162},
-        ),
-    ],
-)
-def test_get_model_response_call_success(model_output, log_prob, response_keys, expected_result):
+@pytest.mark.parametrize("model_output", [None, "some output"])
+@pytest.mark.parametrize("log_prob", [None, -0.162])
+def test_get_model_response_call_success(model_output, log_prob):
     """
-    GIVEN a GetModelResponse instance.
+    GIVEN a GetModelOutputs instance.
     WHEN its __call__ method is called on a record.
-    THEN the correct output is returned.
+    THEN the output contains the model_output portion of the model
+        response payload and does *not* include the log probability
+        portion of the response payload, even if it is non-null.
     """
     with patch("fmeval.transforms.common.ModelRunner") as mock_model_runner:
         mock_model_runner.predict.return_value = (model_output, log_prob)
-        get_model_response = GetModelResponse(
-            input_key_to_response_keys={"input": response_keys}, model_runner=mock_model_runner
+        get_model_outputs = GetModelOutputs(
+            input_to_output_keys={"input": ["model_output"]}, model_runner=mock_model_runner
         )
         sample = {"input": "Hello"}
-        result = get_model_response(sample)
-        assert result == expected_result
+        result = get_model_outputs(sample)
+        assert result == {"input": "Hello", "model_output": model_output}
 
 
-def test_get_model_response_call_multiple_inputs():
+def test_get_model_outputs_call_multiple_inputs():
     """
-    GIVEN a GetModelResponse instance with multiple input keys configured.
+    GIVEN a GetModelOutputs instance with multiple input keys configured.
     WHEN its __call__ method is called.
     THEN the correct output is returned.
     """
     with patch("fmeval.transforms.common.ModelRunner") as mock_model_runner:
-        mock_model_runner.predict.side_effect = [("output 1", -0.162), ("output 2", -0.189), ("output 3", -0.126)]
-        get_model_response = GetModelResponse(
-            input_key_to_response_keys={
-                "input_1": [("output_key_1", "log_prob_key_1"), ("output_key_2", "log_prob_key_2")],
-                "input_2": [("output_key_3", "log_prob_key_3")],
+        mock_model_runner.predict.side_effect = [("output 1", -0.162), ("output 2", -0.189)]
+        get_model_outputs = GetModelOutputs(
+            input_to_output_keys={
+                "input_1": ["output_key_1"],
+                "input_2": ["output_key_2"],
             },
             model_runner=mock_model_runner,
         )
@@ -118,60 +94,35 @@ def test_get_model_response_call_multiple_inputs():
         expected_result = {
             "input_1": "input 1",
             "output_key_1": "output 1",
-            "log_prob_key_1": -0.162,
             "input_2": "input 2",
             "output_key_2": "output 2",
-            "log_prob_key_2": -0.189,
-            "output_key_3": "output 3",
-            "log_prob_key_3": -0.126,
         }
-        result = get_model_response(sample)
+        result = get_model_outputs(sample)
         assert result == expected_result
 
 
-class TestCaseGetModelResponseFailure(NamedTuple):
-    model_output: Optional[str]
-    log_prob: Optional[float]
-    response_keys: List[Tuple[str]]
-
-
-@pytest.mark.parametrize(
-    "model_output, log_prob, response_keys",
-    [
-        TestCaseGetModelResponseFailure(
-            model_output="some output",
-            log_prob=-0.162,
-            response_keys=[("model_output",)],
-        ),
-        TestCaseGetModelResponseFailure(
-            model_output="some output",
-            log_prob=None,
-            response_keys=[("model_output", "log_prob")],
-        ),
-        TestCaseGetModelResponseFailure(
-            model_output=None,
-            log_prob=-0.162,
-            response_keys=[("model_output", "log_prob")],
-        ),
-    ],
-)
-def test_get_model_response_call_failure(model_output, log_prob, response_keys):
+def test_get_model_outputs_call_multiple_output_keys():
     """
-    GIVEN a GetModelResponse instance where the number of output keys corresponding to
-        a particular input key does not match the number of non-null elements in its model runner's
-        predict() response.
+    GIVEN a GetModelOutputs instance with multiple output keys configured for a single input key.
     WHEN its __call__ method is called.
-    THEN an EvalAlgorithmInternalError is raised.
+    THEN the correct output is returned.
     """
-    sample = {"input": "Hello"}
     with patch("fmeval.transforms.common.ModelRunner") as mock_model_runner:
-        mock_model_runner.predict.return_value = (model_output, log_prob)
-        get_model_response = GetModelResponse(
-            input_key_to_response_keys={"input": response_keys},
+        mock_model_runner.predict.side_effect = [("output 1", -0.162), ("output 2", -0.189)]
+        get_model_outputs = GetModelOutputs(
+            input_to_output_keys={
+                "input": ["output_key_1", "output_key_2"],
+            },
             model_runner=mock_model_runner,
         )
-        with pytest.raises(EvalAlgorithmInternalError, match="The number of elements in model response"):
-            get_model_response(sample)
+        sample = {"input": "some input"}
+        expected_result = {
+            "input": "some input",
+            "output_key_1": "output 1",
+            "output_key_2": "output 2",
+        }
+        result = get_model_outputs(sample)
+        assert result == expected_result
 
 
 def test_mean_call():


### PR DESCRIPTION
*Description of changes:*
Currently, `GetModelResponse` is a transform that augments the input record with the entire model response payload from calling the `predict` method of a `ModelRunner`. The response payload is of the form `(model_output, log_prob)`, where both `model_output` and `log_prob` are optional, and whether they are non-null depends on the particular `ModelRunner` being used.

When initializing a `GetModelResponse`, one must provide a tuple representing the keys that will be associated with the data in a response payload. Algorithms like `SummarizationAccuracy` that currently utilize `GetModelReponse` only care about obtaining model outputs (and not the log probabilities), and thus only provide a key for the model output when constructing `GetModelResponse` instances.

The bug is that `GetModelResponse` is currently requiring the response payload to conform to the format of the response payload keys, instead of the other way around. For example, if a `GetModelResponse` is initialized with the response key tuple `(model_output_key, )`, then its `__call__` method will raise an error if the model's `predict` method returns a payload that contains log probabilities.

```
assert_condition(
    len(model_response) == len(response_key_tuple),
    f"The number of elements in model response {model_response} "
    f"does not match number of response keys in {response_key_tuple}.",
)
```

This PR renames `GetModelResponse` to `GetModelOutputs` and fixes the bug above. Now, `GetModelOutputs` is responsible solely for extracting the `model_output` portion of the `(model_output, log_probability)` `predict` response, and more importantly, the `__call__` logic does not make any assumptions about the format of the response payload.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
