### PR TITLE
fix: restore semantic perturbation constants to their original values

### DIFF
--- a/src/fmeval/constants.py
+++ b/src/fmeval/constants.py
@@ -97,8 +97,8 @@ SEED = 1234
 
 # Semantic robustness perturbation types
 BUTTER_FINGER = "butter_finger"
-RANDOM_UPPERCASE = "random_uppercase"
-ADD_REMOVE_WHITESPACE = "add_remove_whitespace"
+RANDOM_UPPER_CASE = "random_upper_case"
+WHITESPACE_ADD_REMOVE = "whitespace_add_remove"
 
 PREFIX_FOR_DELTA_SCORES = "delta_"
 

--- a/src/fmeval/eval_algorithms/classification_accuracy_semantic_robustness.py
+++ b/src/fmeval/eval_algorithms/classification_accuracy_semantic_robustness.py
@@ -11,8 +11,8 @@ from fmeval.constants import (
     DatasetColumns,
     MEAN,
     BUTTER_FINGER,
-    RANDOM_UPPERCASE,
-    ADD_REMOVE_WHITESPACE,
+    RANDOM_UPPER_CASE,
+    WHITESPACE_ADD_REMOVE,
     PREFIX_FOR_DELTA_SCORES,
 )
 from fmeval.data_loaders.util import get_dataset
@@ -60,8 +60,8 @@ from fmeval.eval_algorithms.semantic_perturbation_utils import ButterFinger, Ran
 # All the perturbation types supported by this eval algo
 PERTURBATION_TYPE_TO_HELPER_CLASS = {
     BUTTER_FINGER: ButterFinger,
-    RANDOM_UPPERCASE: RandomUpperCase,
-    ADD_REMOVE_WHITESPACE: WhitespaceAddRemove,
+    RANDOM_UPPER_CASE: RandomUpperCase,
+    WHITESPACE_ADD_REMOVE: WhitespaceAddRemove,
 }
 
 PREFIX_FOR_DELTA_SCORES = "delta_"
@@ -82,11 +82,11 @@ class ClassificationAccuracySemanticRobustnessConfig(EvalAlgorithmConfig):
     :param butter_finger_perturbation_prob: The probability that a given character will be perturbed. Used for
         butter_finger perturbation_type
     :param random_uppercase_corrupt_proportion: Fraction of characters to be changed to uppercase. Used for
-        random_uppercase perturbation_type
+        random_upper_case perturbation_type
     :param whitespace_remove_prob: Given a whitespace, remove it with this much probability. Used for
-        add_remove_whitespace perturbation_type
+        whitespace_add_remove perturbation_type
     :param whitespace_add_prob: Given a non-whitespace, add a whitespace before it with this probability. Used for
-        add_remove_whitespace perturbation_type
+        whitespace_add_remove perturbation_type
     """
 
     valid_labels: Optional[List[str]] = None
@@ -141,7 +141,7 @@ class ClassificationAccuracySemanticRobustness(EvalAlgorithmInterface):
 
         if self._eval_algorithm_config.perturbation_type == BUTTER_FINGER:
             self._perturbation_config = ButterFingerConfig(self._eval_algorithm_config.butter_finger_perturbation_prob)
-        elif self._eval_algorithm_config.perturbation_type == RANDOM_UPPERCASE:
+        elif self._eval_algorithm_config.perturbation_type == RANDOM_UPPER_CASE:
             self._perturbation_config = RandomUpperCaseConfig(
                 self._eval_algorithm_config.random_uppercase_corrupt_proportion
             )

--- a/src/fmeval/eval_algorithms/general_semantic_robustness.py
+++ b/src/fmeval/eval_algorithms/general_semantic_robustness.py
@@ -7,8 +7,8 @@ from fmeval.constants import (
     DatasetColumns,
     MEAN,
     BUTTER_FINGER,
-    RANDOM_UPPERCASE,
-    ADD_REMOVE_WHITESPACE,
+    RANDOM_UPPER_CASE,
+    WHITESPACE_ADD_REMOVE,
 )
 from fmeval.data_loaders.data_config import DataConfig
 from fmeval.data_loaders.util import get_dataset
@@ -40,7 +40,6 @@ from fmeval.model_runners.composers.composers import PromptComposer
 from fmeval.model_runners.model_runner import ModelRunner
 from fmeval.perf_util import timed_block
 from fmeval.constants import BERTSCORE_DEFAULT_MODEL
-from fmeval.eval_algorithms.helper_models.helper_model import BertscoreHelperModelTypes
 from fmeval.transforms.summarization_accuracy_metrics import BertScore
 from fmeval.transforms.semantic_robustness_metrics import BertScoreDissimilarity, WER
 from fmeval.transforms.transform import Transform
@@ -53,8 +52,8 @@ logger = logging.getLogger(__name__)
 # All the perturbation types supported by this eval algo
 PERTURBATION_TYPE_TO_HELPER_CLASS = {
     BUTTER_FINGER: ButterFinger,
-    RANDOM_UPPERCASE: RandomUppercase,
-    ADD_REMOVE_WHITESPACE: AddRemoveWhitespace,
+    RANDOM_UPPER_CASE: RandomUppercase,
+    WHITESPACE_ADD_REMOVE: AddRemoveWhitespace,
 }
 
 WER_SCORE = "word_error_rate"
@@ -69,7 +68,7 @@ class GeneralSemanticRobustnessConfig(EvalAlgorithmConfig):
     """Configures the general semantic robustness evaluation algorithm.
 
     :param perturbation_type: Perturbation type for generating perturbed inputs.
-        Either BUTTER_FINGER, RANDOM_UPPERCASE, or ADD_REMOVE_WHITESPACE.
+        Either BUTTER_FINGER, RANDOM_UPPER_CASE, or WHITESPACE_ADD_REMOVE.
     :param num_perturbations: Number of perturbed outputs to be generated for robustness evaluation.
     :param num_baseline_samples: Only used for non-deterministic models. Number of times we generate
         the model output with the same input to compute the "baseline" change in model output. We
@@ -77,11 +76,11 @@ class GeneralSemanticRobustnessConfig(EvalAlgorithmConfig):
     :param butter_finger_perturbation_prob: The probability that a given character will be perturbed.
         Used when perturbation_type is BUTTER_FINGER.
     :param random_uppercase_corrupt_proportion: Fraction of characters to be changed to uppercase.
-        Used when perturbation_type is RANDOM_UPPERCASE.
+        Used when perturbation_type is RANDOM_UPPER_CASE.
     :param whitespace_remove_prob: The probability of removing a whitespace character.
-        Used when perturbation_type is ADD_REMOVE_WHITESPACE.
+        Used when perturbation_type is WHITESPACE_ADD_REMOVE.
     :param whitespace_add_prob: The probability of adding a whitespace character after a non-whitespace character.
-        Used when perturbation_type is ADD_REMOVE_WHITESPACE.
+        Used when perturbation_type is WHITESPACE_ADD_REMOVE.
     :param model_type_for_bertscore: Model type to use for BERT score.
     """
 
@@ -100,7 +99,7 @@ class GeneralSemanticRobustnessConfig(EvalAlgorithmConfig):
                 f"Invalid perturbation type '{self.perturbation_type} requested, please "
                 f"choose from acceptable values: {PERTURBATION_TYPE_TO_HELPER_CLASS.keys()}"
             )
-        if not BertscoreHelperModelTypes.model_is_allowed(self.model_type_for_bertscore):
+        if not BertscoreModelTypes.model_is_allowed(self.model_type_for_bertscore):
             raise EvalAlgorithmClientError(
                 f"Invalid model_type_for_bertscore: {self.model_type_for_bertscore} requested in "
                 f"GeneralSemanticRobustnessConfig, please choose from acceptable values: {BertscoreModelTypes.model_list()}."
@@ -171,7 +170,7 @@ class GeneralSemanticRobustness(EvalAlgorithmInterface):
                 num_perturbations=self.num_perturbations,
                 perturbation_prob=eval_algorithm_config.butter_finger_perturbation_prob,
             )
-        elif eval_algorithm_config.perturbation_type == RANDOM_UPPERCASE:
+        elif eval_algorithm_config.perturbation_type == RANDOM_UPPER_CASE:
             self.perturbation_transform = RandomUppercase(
                 input_key=DatasetColumns.MODEL_INPUT.value.name,
                 output_keys=[

--- a/src/fmeval/eval_algorithms/qa_accuracy_semantic_robustness.py
+++ b/src/fmeval/eval_algorithms/qa_accuracy_semantic_robustness.py
@@ -12,8 +12,8 @@ from fmeval.constants import (
     DatasetColumns,
     MEAN,
     BUTTER_FINGER,
-    RANDOM_UPPERCASE,
-    ADD_REMOVE_WHITESPACE,
+    RANDOM_UPPER_CASE,
+    WHITESPACE_ADD_REMOVE,
     PREFIX_FOR_DELTA_SCORES,
 )
 from fmeval.data_loaders.util import get_dataset
@@ -65,8 +65,8 @@ from fmeval.eval_algorithms.qa_accuracy import (
 # All the perturbation types supported by this eval algo
 PERTURBATION_TYPE_TO_HELPER_CLASS = {
     BUTTER_FINGER: ButterFinger,
-    RANDOM_UPPERCASE: RandomUpperCase,
-    ADD_REMOVE_WHITESPACE: WhitespaceAddRemove,
+    RANDOM_UPPER_CASE: RandomUpperCase,
+    WHITESPACE_ADD_REMOVE: WhitespaceAddRemove,
 }
 
 DELTA_F1_SCORE = PREFIX_FOR_DELTA_SCORES + F1_SCORE
@@ -91,11 +91,11 @@ class QAAccuracySemanticRobustnessConfig(EvalAlgorithmConfig):
     :param butter_finger_perturbation_prob: The probability that a given character will be perturbed. Used for
         butter_finger perturbation_type
     :param random_uppercase_corrupt_proportion: Fraction of characters to be changed to uppercase. Used for
-        random_uppercase perturbation_type
+        random_upper_case perturbation_type
     :param whitespace_remove_prob: Given a whitespace, remove it with this much probability. Used for
-        add_remove_whitespace perturbation_type
+        whitespace_add_remove perturbation_type
     :param whitespace_add_prob: Given a non-whitespace, add a whitespace before it with this probability. Used for
-        add_remove_whitespace perturbation_type
+        whitespace_add_remove perturbation_type
     """
 
     target_output_delimiter: Optional[str] = "<OR>"
@@ -139,7 +139,7 @@ class QAAccuracySemanticRobustness(EvalAlgorithmInterface):
 
         if self._eval_algorithm_config.perturbation_type == BUTTER_FINGER:
             self._perturbation_config = ButterFingerConfig(self._eval_algorithm_config.butter_finger_perturbation_prob)
-        elif self._eval_algorithm_config.perturbation_type == RANDOM_UPPERCASE:
+        elif self._eval_algorithm_config.perturbation_type == RANDOM_UPPER_CASE:
             self._perturbation_config = RandomUpperCaseConfig(
                 self._eval_algorithm_config.random_uppercase_corrupt_proportion
             )

--- a/src/fmeval/eval_algorithms/summarization_accuracy_semantic_robustness.py
+++ b/src/fmeval/eval_algorithms/summarization_accuracy_semantic_robustness.py
@@ -12,8 +12,8 @@ from fmeval.constants import (
     DatasetColumns,
     MEAN,
     BUTTER_FINGER,
-    RANDOM_UPPERCASE,
-    ADD_REMOVE_WHITESPACE,
+    RANDOM_UPPER_CASE,
+    WHITESPACE_ADD_REMOVE,
     PREFIX_FOR_DELTA_SCORES,
 )
 from fmeval.data_loaders.data_config import DataConfig
@@ -67,8 +67,8 @@ logger = logging.getLogger(__name__)
 # All the perturbation types supported by this eval algo
 PERTURBATION_TYPE_TO_HELPER_CLASS = {
     BUTTER_FINGER: ButterFinger,
-    RANDOM_UPPERCASE: RandomUpperCase,
-    ADD_REMOVE_WHITESPACE: WhitespaceAddRemove,
+    RANDOM_UPPER_CASE: RandomUpperCase,
+    WHITESPACE_ADD_REMOVE: WhitespaceAddRemove,
 }
 
 DELTA_ROUGE_SCORE = PREFIX_FOR_DELTA_SCORES + ROUGE_SCORE
@@ -124,11 +124,11 @@ class SummarizationAccuracySemanticRobustnessConfig(EvalAlgorithmConfig):
     :param butter_finger_perturbation_prob: The probability that a given character will be perturbed. Used for
         butter_finger perturbation_type
     :param random_uppercase_corrupt_proportion: Fraction of characters to be changed to uppercase. Used for
-        random_uppercase perturbation_type
+        random_upper_case perturbation_type
     :param whitespace_remove_prob: Given a whitespace, remove it with this much probability. Used for
-        add_remove_whitespace perturbation_type
+        whitespace_add_remove perturbation_type
     :param whitespace_add_prob: Given a non-whitespace, add a whitespace before it with this probability. Used for
-        add_remove_whitespace perturbation_type
+        whitespace_add_remove perturbation_type
     :param rouge_type: Type of rouge metric in eval results
     :param use_stemmer_for_rouge: bool value to set using stemmer for rouge metric
     :param model_type_for_bertscore: model to use for bert score
@@ -193,7 +193,7 @@ class SummarizationAccuracySemanticRobustness(EvalAlgorithmInterface):
 
         if self._eval_algorithm_config.perturbation_type == BUTTER_FINGER:
             self._perturbation_config = ButterFingerConfig(self._eval_algorithm_config.butter_finger_perturbation_prob)
-        elif self._eval_algorithm_config.perturbation_type == RANDOM_UPPERCASE:
+        elif self._eval_algorithm_config.perturbation_type == RANDOM_UPPER_CASE:
             self._perturbation_config = RandomUpperCaseConfig(
                 self._eval_algorithm_config.random_uppercase_corrupt_proportion
             )

--- a/test/integration/test_classification_accuracy_semantic_robustness.py
+++ b/test/integration/test_classification_accuracy_semantic_robustness.py
@@ -13,8 +13,8 @@ from fmeval.eval_algorithms.classification_accuracy_semantic_robustness import (
     ClassificationAccuracySemanticRobustness,
     ClassificationAccuracySemanticRobustnessConfig,
     DELTA_CLASSIFICATION_ACCURACY_SCORE,
-    RANDOM_UPPERCASE,
-    ADD_REMOVE_WHITESPACE,
+    RANDOM_UPPER_CASE,
+    WHITESPACE_ADD_REMOVE,
 )
 
 from test.integration.models.model_runners import (
@@ -53,7 +53,7 @@ class TestClassificationAccuracySemanticRobustness:
             CASRTestCase(
                 config=ClassificationAccuracySemanticRobustnessConfig(
                     valid_labels=SAMPLE_VALID_LABELS,
-                    perturbation_type=RANDOM_UPPERCASE,
+                    perturbation_type=RANDOM_UPPER_CASE,
                     num_perturbations=5,
                     random_uppercase_corrupt_proportion=0.1,
                 ),
@@ -66,7 +66,7 @@ class TestClassificationAccuracySemanticRobustness:
             CASRTestCase(
                 config=ClassificationAccuracySemanticRobustnessConfig(
                     valid_labels=SAMPLE_VALID_LABELS,
-                    perturbation_type=ADD_REMOVE_WHITESPACE,
+                    perturbation_type=WHITESPACE_ADD_REMOVE,
                     num_perturbations=5,
                     whitespace_remove_prob=0.1,
                     whitespace_add_prob=0.05,
@@ -169,7 +169,7 @@ class TestClassificationAccuracySemanticRobustness:
             CASRTestCase(
                 config=ClassificationAccuracySemanticRobustnessConfig(
                     valid_labels=SAMPLE_VALID_LABELS,
-                    perturbation_type=RANDOM_UPPERCASE,
+                    perturbation_type=RANDOM_UPPER_CASE,
                     num_perturbations=5,
                     random_uppercase_corrupt_proportion=0.1,
                 ),
@@ -239,7 +239,7 @@ class TestClassificationAccuracySemanticRobustness:
             CASRTestCase(
                 config=ClassificationAccuracySemanticRobustnessConfig(
                     valid_labels=SAMPLE_VALID_LABELS,
-                    perturbation_type=ADD_REMOVE_WHITESPACE,
+                    perturbation_type=WHITESPACE_ADD_REMOVE,
                     num_perturbations=5,
                     whitespace_remove_prob=0.1,
                     whitespace_add_prob=0.05,

--- a/test/integration/test_general_semantic_robustness.py
+++ b/test/integration/test_general_semantic_robustness.py
@@ -10,8 +10,8 @@ from fmeval.eval_algorithms import (
 )
 from fmeval.eval_algorithms.general_semantic_robustness import (
     BUTTER_FINGER,
-    RANDOM_UPPERCASE,
-    ADD_REMOVE_WHITESPACE,
+    RANDOM_UPPER_CASE,
+    WHITESPACE_ADD_REMOVE,
     GeneralSemanticRobustness,
     GeneralSemanticRobustnessConfig,
     WER_SCORE,
@@ -63,7 +63,7 @@ class TestGeneralSemanticRobustness:
         [
             GSRTestCase(
                 config=GeneralSemanticRobustnessConfig(
-                    perturbation_type=ADD_REMOVE_WHITESPACE,
+                    perturbation_type=WHITESPACE_ADD_REMOVE,
                     num_perturbations=5,
                     whitespace_remove_prob=0.1,
                     whitespace_add_prob=0.05,

--- a/test/integration/test_qa_accuracy_semantic_robustness.py
+++ b/test/integration/test_qa_accuracy_semantic_robustness.py
@@ -7,8 +7,8 @@ from fmeval.eval_algorithms.qa_accuracy_semantic_robustness import (
     QAAccuracySemanticRobustness,
     QAAccuracySemanticRobustnessConfig,
     BUTTER_FINGER,
-    RANDOM_UPPERCASE,
-    ADD_REMOVE_WHITESPACE,
+    RANDOM_UPPER_CASE,
+    WHITESPACE_ADD_REMOVE,
     DELTA_F1_SCORE,
     DELTA_EXACT_MATCH_SCORE,
     DELTA_QUASI_EXACT_MATCH_SCORE,
@@ -63,7 +63,7 @@ class TestQAAccuracySemanticRobustness:
             ),
             TestCaseEvaluateSample(
                 config=QAAccuracySemanticRobustnessConfig(
-                    perturbation_type=RANDOM_UPPERCASE,
+                    perturbation_type=RANDOM_UPPER_CASE,
                     num_perturbations=5,
                     random_uppercase_corrupt_proportion=0.1,
                 ),
@@ -82,7 +82,7 @@ class TestQAAccuracySemanticRobustness:
             ),
             TestCaseEvaluateSample(
                 config=QAAccuracySemanticRobustnessConfig(
-                    perturbation_type=ADD_REMOVE_WHITESPACE,
+                    perturbation_type=WHITESPACE_ADD_REMOVE,
                     num_perturbations=5,
                     whitespace_remove_prob=0.1,
                     whitespace_add_prob=0.05,
@@ -140,7 +140,7 @@ class TestQAAccuracySemanticRobustness:
             ),
             TestCaseEvaluate(
                 config=QAAccuracySemanticRobustnessConfig(
-                    perturbation_type=RANDOM_UPPERCASE,
+                    perturbation_type=RANDOM_UPPER_CASE,
                     num_perturbations=5,
                     random_uppercase_corrupt_proportion=0.1,
                 ),
@@ -159,7 +159,7 @@ class TestQAAccuracySemanticRobustness:
             ),
             TestCaseEvaluate(
                 config=QAAccuracySemanticRobustnessConfig(
-                    perturbation_type=ADD_REMOVE_WHITESPACE,
+                    perturbation_type=WHITESPACE_ADD_REMOVE,
                     num_perturbations=5,
                     whitespace_remove_prob=0.1,
                     whitespace_add_prob=0.05,

--- a/test/integration/test_summarization_accuracy_semantic_robustness.py
+++ b/test/integration/test_summarization_accuracy_semantic_robustness.py
@@ -17,8 +17,8 @@ from fmeval.eval_algorithms.summarization_accuracy_semantic_robustness import (
     DELTA_METEOR_SCORE,
     DELTA_BERT_SCORE,
     BUTTER_FINGER,
-    RANDOM_UPPERCASE,
-    ADD_REMOVE_WHITESPACE,
+    RANDOM_UPPER_CASE,
+    WHITESPACE_ADD_REMOVE,
 )
 from test.integration.models.model_runners import sm_model_runner
 
@@ -30,13 +30,13 @@ BUTTER_FINGER_CONFIG = SummarizationAccuracySemanticRobustnessConfig(
 )
 
 RANDOM_UPPER_CASE_CONFIG = SummarizationAccuracySemanticRobustnessConfig(
-    perturbation_type=RANDOM_UPPERCASE,
+    perturbation_type=RANDOM_UPPER_CASE,
     num_perturbations=5,
     random_uppercase_corrupt_proportion=0.1,
 )
 
 WHITESPACE_CONFIG = SummarizationAccuracySemanticRobustnessConfig(
-    perturbation_type=ADD_REMOVE_WHITESPACE,
+    perturbation_type=WHITESPACE_ADD_REMOVE,
     num_perturbations=5,
     whitespace_remove_prob=0.1,
     whitespace_add_prob=0.05,

--- a/test/unit/eval_algorithms/test_classification_accuracy_semantic_robustness.py
+++ b/test/unit/eval_algorithms/test_classification_accuracy_semantic_robustness.py
@@ -23,8 +23,8 @@ from fmeval.eval_algorithms import (
 from fmeval.eval_algorithms.classification_accuracy_semantic_robustness import (
     ClassificationAccuracySemanticRobustnessConfig,
     ClassificationAccuracySemanticRobustness,
-    RANDOM_UPPERCASE,
-    ADD_REMOVE_WHITESPACE,
+    RANDOM_UPPER_CASE,
+    WHITESPACE_ADD_REMOVE,
     BUTTER_FINGER,
     DELTA_CLASSIFICATION_ACCURACY_SCORE,
 )
@@ -107,7 +107,7 @@ class TestClassificationAccuracySemanticRobustness:
                 valid_labels=["1", "2"],
                 perturbation_type="my_perturb",
                 expected_error_message="Invalid perturbation type 'my_perturb requested, please choose from "
-                "acceptable values: dict_keys(['butter_finger', 'random_uppercase', 'add_remove_whitespace'])",
+                "acceptable values: dict_keys(['butter_finger', 'random_upper_case', 'whitespace_add_remove'])",
             ),
         ],
     )
@@ -187,7 +187,7 @@ class TestClassificationAccuracySemanticRobustness:
                     EvalScore(name=DELTA_CLASSIFICATION_ACCURACY_SCORE, value=0.0),
                 ],
                 config=ClassificationAccuracySemanticRobustnessConfig(
-                    valid_labels=["1", "2", "3", "4", "5"], num_perturbations=2, perturbation_type=RANDOM_UPPERCASE
+                    valid_labels=["1", "2", "3", "4", "5"], num_perturbations=2, perturbation_type=RANDOM_UPPER_CASE
                 ),
             ),
             TestCaseClassificationAccuracySemanticRobustnessEvaluateSample(
@@ -201,7 +201,7 @@ class TestClassificationAccuracySemanticRobustness:
                     EvalScore(name=DELTA_CLASSIFICATION_ACCURACY_SCORE, value=1.0),
                 ],
                 config=ClassificationAccuracySemanticRobustnessConfig(
-                    valid_labels=["1", "2", "3", "4", "5"], num_perturbations=2, perturbation_type=ADD_REMOVE_WHITESPACE
+                    valid_labels=["1", "2", "3", "4", "5"], num_perturbations=2, perturbation_type=WHITESPACE_ADD_REMOVE
                 ),
             ),
         ],

--- a/test/unit/eval_algorithms/test_general_semantic_robustness.py
+++ b/test/unit/eval_algorithms/test_general_semantic_robustness.py
@@ -19,8 +19,8 @@ from fmeval.eval_algorithms.general_semantic_robustness import (
     BERT_SCORE_DISSIMILARITY,
     GeneralSemanticRobustnessConfig,
     GeneralSemanticRobustness,
-    RANDOM_UPPERCASE,
-    ADD_REMOVE_WHITESPACE,
+    RANDOM_UPPER_CASE,
+    WHITESPACE_ADD_REMOVE,
     BUTTER_FINGER,
     UpdateRobustnessScores,
 )
@@ -111,7 +111,7 @@ class TestGeneralSemanticRobustness:
             (
                 "my_perturb",
                 "Invalid perturbation type 'my_perturb requested, please choose from acceptable values: "
-                "dict_keys(['butter_finger', 'random_uppercase', 'add_remove_whitespace'])",
+                "dict_keys(['butter_finger', 'random_upper_case', 'whitespace_add_remove'])",
             )
         ],
     )
@@ -153,7 +153,7 @@ class TestGeneralSemanticRobustness:
             GeneralSemanticRobustnessConfig(num_baseline_samples=num_baseline_samples)
 
     @pytest.mark.parametrize("use_ray", [True, False])
-    @pytest.mark.parametrize("perturbation_type", [BUTTER_FINGER, RANDOM_UPPERCASE, ADD_REMOVE_WHITESPACE])
+    @pytest.mark.parametrize("perturbation_type", [BUTTER_FINGER, RANDOM_UPPER_CASE, WHITESPACE_ADD_REMOVE])
     @patch("fmeval.eval_algorithms.general_semantic_robustness.create_shared_resource")
     @patch("fmeval.eval_algorithms.general_semantic_robustness.BertscoreModel")
     def test_init(self, bertscore_model, create_shared_resource, perturbation_type, use_ray):
@@ -176,7 +176,7 @@ class TestGeneralSemanticRobustness:
             assert isinstance(perturbation, ButterFinger)
             assert perturbation.num_perturbations == config.num_perturbations
             assert perturbation.perturbation_prob == config.butter_finger_perturbation_prob
-        elif perturbation_type == RANDOM_UPPERCASE:
+        elif perturbation_type == RANDOM_UPPER_CASE:
             assert isinstance(perturbation, RandomUppercase)
             assert perturbation.num_perturbations == config.num_perturbations
             assert perturbation.uppercase_fraction == config.random_uppercase_corrupt_proportion

--- a/test/unit/eval_algorithms/test_qa_accuracy_semantic_robustness.py
+++ b/test/unit/eval_algorithms/test_qa_accuracy_semantic_robustness.py
@@ -25,8 +25,8 @@ from fmeval.eval_algorithms import (
 from fmeval.eval_algorithms.qa_accuracy_semantic_robustness import (
     QAAccuracySemanticRobustnessConfig,
     QAAccuracySemanticRobustness,
-    RANDOM_UPPERCASE,
-    ADD_REMOVE_WHITESPACE,
+    RANDOM_UPPER_CASE,
+    WHITESPACE_ADD_REMOVE,
     BUTTER_FINGER,
     DELTA_F1_SCORE,
     DELTA_QUASI_EXACT_MATCH_SCORE,
@@ -124,7 +124,7 @@ class TestQAAccuracySemanticRobustness:
                 target_output_delimiter="<OR>",
                 perturbation_type="my_perturb",
                 expected_error_message="Invalid perturbation type 'my_perturb requested, please choose from "
-                "acceptable values: dict_keys(['butter_finger', 'random_uppercase', 'add_remove_whitespace'])",
+                "acceptable values: dict_keys(['butter_finger', 'random_upper_case', 'whitespace_add_remove'])",
             ),
             TestCaseQAAccuracySemanticRobustnessInvalidConfig(
                 target_output_delimiter="",
@@ -218,7 +218,7 @@ class TestQAAccuracySemanticRobustness:
                     EvalScore(name=DELTA_RECALL_OVER_WORDS, value=1.0),
                 ],
                 config=QAAccuracySemanticRobustnessConfig(
-                    target_output_delimiter="<OR>", num_perturbations=2, perturbation_type=RANDOM_UPPERCASE
+                    target_output_delimiter="<OR>", num_perturbations=2, perturbation_type=RANDOM_UPPER_CASE
                 ),
             ),
             TestCaseQAAccuracySemanticRobustnessEvaluateSample(
@@ -240,7 +240,7 @@ class TestQAAccuracySemanticRobustness:
                     EvalScore(name=DELTA_RECALL_OVER_WORDS, value=1.0),
                 ],
                 config=QAAccuracySemanticRobustnessConfig(
-                    target_output_delimiter="<OR>", num_perturbations=2, perturbation_type=ADD_REMOVE_WHITESPACE
+                    target_output_delimiter="<OR>", num_perturbations=2, perturbation_type=WHITESPACE_ADD_REMOVE
                 ),
             ),
         ],

--- a/test/unit/eval_algorithms/test_summarization_accuracy_semantic_robustness.py
+++ b/test/unit/eval_algorithms/test_summarization_accuracy_semantic_robustness.py
@@ -22,8 +22,8 @@ from fmeval.eval_algorithms import (
     GOV_REPORT,
 )
 from fmeval.eval_algorithms.general_semantic_robustness import (
-    RANDOM_UPPERCASE,
-    ADD_REMOVE_WHITESPACE,
+    RANDOM_UPPER_CASE,
+    WHITESPACE_ADD_REMOVE,
 )
 from fmeval.eval_algorithms.summarization_accuracy import METEOR_SCORE, ROUGE_SCORE, BERT_SCORE
 from fmeval.eval_algorithms.summarization_accuracy_semantic_robustness import (
@@ -177,7 +177,7 @@ class TestSummarizationAccuracySemanticRobustness:
                     EvalScore(name=DELTA_BERT_SCORE, value=0.25),
                 ],
                 config=SummarizationAccuracySemanticRobustnessConfig(
-                    num_perturbations=2, perturbation_type=RANDOM_UPPERCASE
+                    num_perturbations=2, perturbation_type=RANDOM_UPPER_CASE
                 ),
             ),
             TestCaseSummarizationAccuracySemanticRobustnessEvaluateSample(
@@ -210,7 +210,7 @@ class TestSummarizationAccuracySemanticRobustness:
                     EvalScore(name=DELTA_BERT_SCORE, value=0.25),
                 ],
                 config=SummarizationAccuracySemanticRobustnessConfig(
-                    num_perturbations=2, perturbation_type=ADD_REMOVE_WHITESPACE
+                    num_perturbations=2, perturbation_type=WHITESPACE_ADD_REMOVE
                 ),
             ),
         ],
@@ -388,7 +388,7 @@ class TestSummarizationAccuracySemanticRobustness:
                 bertscore_model_type="distilbert-base-uncased",
                 perturbation_type="my_perturb",
                 expected_error_message="Invalid perturbation type 'my_perturb requested, please choose from "
-                "acceptable values: dict_keys(['butter_finger', 'random_uppercase', 'add_remove_whitespace'])",
+                "acceptable values: dict_keys(['butter_finger', 'random_upper_case', 'whitespace_add_remove'])",
             ),
         ],
     )


### PR DESCRIPTION
*Description of changes:*
Certain software relies on these constants, so they should not have been changed by #222. This PR simply reverts the renamings introduced in #222.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
