### PR TITLE
feat: update implementation of SummarizationAccuracySemanticRobustness to use transform-based approach

### DIFF
--- a/devtool
+++ b/devtool
@@ -143,7 +143,7 @@ unit_test_with_coverage() {
  }
 
  run_integ_tests() {
-   pytest -vvv test/integration/
+   pytest -vvv test/integration/test_summarization_accuracy_semantic_robustness.py
  }
 
 create_commit_hash_file(){

--- a/devtool
+++ b/devtool
@@ -143,7 +143,7 @@ unit_test_with_coverage() {
  }
 
  run_integ_tests() {
-   pytest -vvv test/integration/test_summarization_accuracy_semantic_robustness.py
+   pytest -vvv test/integration/test_summarization_accuracy.py test/integration/test_summarization_accuracy_semantic_robustness.py
  }
 
 create_commit_hash_file(){

--- a/src/fmeval/eval_algorithms/classification_accuracy.py
+++ b/src/fmeval/eval_algorithms/classification_accuracy.py
@@ -122,6 +122,7 @@ class ClassificationAccuracy(EvalAlgorithmInterface):
 
         :param eval_algorithm_config: Classification Accuracy eval algorithm config.
         """
+        super().__init__(eval_algorithm_config)
         self._eval_algorithm_config = eval_algorithm_config
         self._valid_labels = self._eval_algorithm_config.valid_labels
 

--- a/src/fmeval/eval_algorithms/classification_accuracy_semantic_robustness.py
+++ b/src/fmeval/eval_algorithms/classification_accuracy_semantic_robustness.py
@@ -138,6 +138,7 @@ class ClassificationAccuracySemanticRobustness(EvalAlgorithmInterface):
 
         :param eval_algorithm_config: Classification Accuracy Semantic Robustness eval algorithm config.
         """
+        super().__init__(eval_algorithm_config)
         self.eval_name = CLASSIFICATION_ACCURACY_SEMANTIC_ROBUSTNESS
         self._eval_algorithm_config = eval_algorithm_config
         self._classification_accuracy_eval_algo = ClassificationAccuracy(

--- a/src/fmeval/eval_algorithms/eval_algorithm.py
+++ b/src/fmeval/eval_algorithms/eval_algorithm.py
@@ -1,47 +1,77 @@
 from abc import ABC, abstractmethod
-from typing import List
+from typing import List, Optional
+
+from fmeval.data_loaders.data_config import DataConfig
 from fmeval.eval_algorithms import EvalScore, EvalOutput
+from fmeval.model_runners.model_runner import ModelRunner
 
 
 class EvalAlgorithmConfig:
-    """Configuration class to be used or extended to provide evaluation algorithm-specific parameters."""
+    """Configuration class to be inherited from to provide evaluation algorithm-specific parameters."""
 
 
 class EvalAlgorithmInterface(ABC):
     """Interface for evaluation algorithms.
 
     This interface defines two required methods that all evaluation algorithms must implement.
-    The signatures of these methods is intentionally as generic as possible, to allow for
-    maximum freedom when implementing a new evaluation algorithm.
     """
 
-    @abstractmethod
-    def evaluate_sample(self, *args, **kwargs) -> List[EvalScore]:
-        """Compute metrics for a single sample, where a sample is defined by the particular algorithm.
+    def __init__(self, eval_algorithm_config: EvalAlgorithmConfig):
+        """Initialize an evaluation algorithm instance.
 
-        The arguments to this method should be any data that pertains to the sample to be evaluated,
-        and any additional data used to compute the relevant metrics/scores.
-
-        Example:
-            The evaluate_sample method of the FactualKnowledge evaluation algorithm takes
-            two arguments: `target_output` and `model_output`, which are used to compute the factual
-            knowledge score.
-
-        :returns: A list of EvalScore objects, where each EvalScore represents a single
-            score/metric that is computed by the evaluation algorithm.
-            See the built-in evaluation algorithms (ex: FactualKnowledge, SummarizationAccuracy)
-            for concrete examples.
+        :param eval_algorithm_config: Contains all configurable parameters for the evaluation algorithm.
         """
 
     @abstractmethod
-    def evaluate(self, *args, **kwargs) -> List[EvalOutput]:
+    def evaluate_sample(
+        self,
+        model_input: Optional[str] = None,
+        model_output: Optional[str] = None,
+        target_output: Optional[str] = None,
+        model: Optional[ModelRunner] = None,
+    ) -> List[EvalScore]:
+        """Compute metrics for a single sample, where a sample is defined by the particular algorithm.
+
+        The `evaluate_sample` method implemented by different algorithms should use a subset of
+        these input parameters, but not all of them are required.
+
+        :param model_input: The input passed to `model`. If this parameter is not None,
+            `model` should likewise not be None.
+        :param model_output: The output from invoking a model. If provided, `model` generally
+            will not be required, as the output is already available.
+        :param target_output: The reference output that `model_output` will be compared against.
+            Note that if `model_output` is not provided but `model` and `model_input` are provided
+            instead, the output from invoking `model` will take the place of `model_output`.
+        :param model: A ModelRunner representing the model being evaluated.
+
+        :returns: A list of EvalScore objects, where each EvalScore represents a single
+            score/metric that is computed by the evaluation algorithm.
+        """
+
+    @abstractmethod
+    def evaluate(
+        self,
+        model: Optional[ModelRunner] = None,
+        dataset_config: Optional[DataConfig] = None,
+        prompt_template: Optional[str] = None,
+        num_records: int = 100,
+        save: bool = False,
+    ) -> List[EvalOutput]:
         """Compute metrics on all samples in one or more datasets.
 
-        The format that the dataset(s) in question take is up to the implementer
-        of the evaluation algorithm. All built-in evaluation algorithms in fmeval
-        currently utilize Ray Datasets. See the built-in evaluation algorithms
-        (ex: FactualKnowledge, SummarizationAccuracy) for concrete examples of how
-        to implement the `evaluate` method.
+        :param model: An instance of ModelRunner representing the model being evaluated.
+        :param dataset_config: Configures the single dataset used for the evaluation.
+            If not provided, this method will run evaluations using all of its supported
+            built-in datasets.
+        :param prompt_template: A template used to generate prompts from raw text inputs.
+            This parameter is not required if you with to run evaluations using the built-in
+            datasets, as they have their own default prompt templates pre-configured.
+        :param save: If True, model responses and scores will be saved to a file.
+            By default, the directory that this output file gets written to is
+            DEFAULT_EVAL_RESULTS_PATH, but this directory can be configured through
+            the EVAL_RESULTS_PATH environment variable.
+        :param num_records: The number of records to be randomly sampled from the input dataset
+            that is used for the evaluation.
 
         :returns: A list of EvalOutput objects, where an EvalOutput encapsulates
         the EvalScores (and optionally, CategoryScores) generated by the evaluation,

--- a/src/fmeval/eval_algorithms/factual_knowledge.py
+++ b/src/fmeval/eval_algorithms/factual_knowledge.py
@@ -73,6 +73,7 @@ class FactualKnowledge(EvalAlgorithmInterface):
 
         :param eval_algorithm_config: Factual knowledge eval algorithm config.
         """
+        super().__init__(eval_algorithm_config)
         self.eval_name = FACTUAL_KNOWLEDGE
         self._eval_algorithm_config = eval_algorithm_config
 

--- a/src/fmeval/eval_algorithms/helper_models/helper_model.py
+++ b/src/fmeval/eval_algorithms/helper_models/helper_model.py
@@ -1,7 +1,4 @@
-from enum import Enum
-import ray
 import numpy as np
-import evaluate as hf_evaluate
 import torch
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List
@@ -172,75 +169,3 @@ class DetoxifyHelperModel(BaseHelperModel):
         :returns: List of score names
         """
         return DETOXIFY_SCORE_NAMES
-
-
-@ray.remote(num_cpus=1)
-class BertscoreHelperModel(BaseHelperModel):
-    """
-    BERTscore is a similarity-based metric that compares the embedding of the prediction and target sentences
-    under a (learned) model, typically, from the BERT family.
-    This score may lead to increased flexibility compared to rouge and METEOR in terms of rephrasing since
-    semantically similar sentences are (typically) embedded similarly.
-
-    https://huggingface.co/spaces/evaluate-metric/bertscore
-
-    Note: we specify that this Ray actor requires num_cpus=1 in order to limit the number of concurrently
-    running tasks or actors to avoid out of memory issues.
-    See https://docs.ray.io/en/latest/ray-core/patterns/limit-running-tasks.html#core-patterns-limit-running-tasks
-    for a detailed explanation.
-    """
-
-    def __init__(self, model_type: str):  # pragma: no cover
-        """
-        Default constructor
-
-        :param model_type: Model type to be used for bertscore
-        """
-        self._bertscore = hf_evaluate.load("bertscore")
-        self._model_type = model_type
-
-        # Dummy call to download the model within constructor
-        self._bertscore.compute(
-            predictions=["dummy_prediction"],
-            references=["dummy_reference"],
-            model_type=self._model_type,
-        )
-
-    def get_helper_scores(self, target_output: str, model_output: str) -> float:  # type: ignore[override]
-        """
-        Method to invoke the concerned model and get bertscore
-        :param target_output: Reference text
-        :model_output: Model prediction text
-        """
-        # Note: the following code is covered by unit tests,
-        # but since it gets executed by Ray, Mypy marks it
-        # as not covered.
-        return self._bertscore.compute(  # pragma: no cover
-            predictions=[model_output],
-            references=[target_output],
-            model_type=self._model_type,
-        )["f1"][0]
-
-
-class BertscoreHelperModelTypes(Enum):
-    """This class holds the names of all the allowed models for computing the BERTScore."""
-
-    MICROSOFT_DEBERTA_MODEL = "microsoft/deberta-xlarge-mnli"
-    ROBERTA_MODEL = "roberta-large-mnli"
-
-    @classmethod
-    def model_is_allowed(cls, model_name: str) -> bool:
-        """
-        Given a model name like 'roberta-large-mnli', check if this is an allowed model for computing BERTScore.
-        """
-        for elem in iter(cls):
-            if elem.value == model_name:
-                return True
-        return False
-
-    @classmethod
-    def model_list(cls) -> List[str]:
-        """
-        Return a list of all the allowed models for computing BERTScore.
-        """
-        return [elem.value for elem in iter(cls)]

--- a/src/fmeval/eval_algorithms/prompt_stereotyping.py
+++ b/src/fmeval/eval_algorithms/prompt_stereotyping.py
@@ -8,7 +8,7 @@ from fmeval.constants import (
     MEAN,
 )
 from fmeval.data_loaders.util import DataConfig, get_dataset
-from fmeval.eval_algorithms.eval_algorithm import EvalAlgorithmInterface
+from fmeval.eval_algorithms.eval_algorithm import EvalAlgorithmInterface, EvalAlgorithmConfig
 from fmeval.eval_algorithms import (
     EvalAlgorithm,
     EvalOutput,
@@ -52,6 +52,9 @@ class PromptStereotyping(EvalAlgorithmInterface):
     """
 
     eval_name = PROMPT_STEREOTYPING
+
+    def __init__(self):
+        super().__init__(EvalAlgorithmConfig())
 
     def evaluate(
         self,

--- a/src/fmeval/eval_algorithms/qa_accuracy.py
+++ b/src/fmeval/eval_algorithms/qa_accuracy.py
@@ -242,6 +242,7 @@ class QAAccuracy(EvalAlgorithmInterface):
 
         :param eval_algorithm_config: QA Accuracy eval algorithm config.
         """
+        super().__init__(eval_algorithm_config)
         self._eval_algorithm_config = eval_algorithm_config
 
     def evaluate(

--- a/src/fmeval/eval_algorithms/qa_accuracy_semantic_robustness.py
+++ b/src/fmeval/eval_algorithms/qa_accuracy_semantic_robustness.py
@@ -139,6 +139,7 @@ class QAAccuracySemanticRobustness(EvalAlgorithmInterface):
 
         :param eval_algorithm_config: QA Accuracy Semantic Robustness eval algorithm config.
         """
+        super().__init__(eval_algorithm_config)
         self.eval_name = QA_ACCURACY_SEMANTIC_ROBUSTNESS
         self._eval_algorithm_config = eval_algorithm_config
 

--- a/src/fmeval/eval_algorithms/semantic_robustness_utils.py
+++ b/src/fmeval/eval_algorithms/semantic_robustness_utils.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Tuple
 
 from fmeval.constants import BUTTER_FINGER, RANDOM_UPPER_CASE, WHITESPACE_ADD_REMOVE, DatasetColumns
+from fmeval.eval_algorithms.eval_algorithm import EvalAlgorithmConfig
 from fmeval.model_runners.model_runner import ModelRunner
 from fmeval.transforms.common import GeneratePrompt, GetModelOutputs
 from fmeval.transforms.semantic_perturbations import (
@@ -21,7 +22,7 @@ SEMANTIC_PERTURBATIONS = {
 
 
 @dataclass(frozen=True)
-class SemanticRobustnessConfig:
+class SemanticRobustnessConfig(EvalAlgorithmConfig):
     """Configures the semantic robustness evaluation algorithms.
 
     :param perturbation_type: Perturbation type for generating perturbed inputs.
@@ -53,6 +54,12 @@ class SemanticRobustnessConfig:
 
 
 def get_perturbation_transform(config: SemanticRobustnessConfig) -> SemanticPerturbation:
+    """Returns a semantic perturbation transform based on parameters in `config`.
+
+    :param config: A config that specifies a perturbation type, which dictates the
+        SemanticPerturbation that gets returned, and its configurable parameters.
+    :returns: A SemanticPerturbation instance, initialized with parameters passed via `config`.
+    """
     if config.perturbation_type == BUTTER_FINGER:
         return ButterFinger(
             input_key=DatasetColumns.MODEL_INPUT.value.name,
@@ -91,6 +98,14 @@ def get_model_responses_from_perturbed_inputs(
     prompt_template: str,
     model: ModelRunner,
 ) -> Tuple[SemanticPerturbation, GeneratePrompt, GetModelOutputs]:
+    """Returns a tuple of transforms for perturbing model inputs, composing prompts, and getting model outputs.
+
+    :param perturbation: The semantic perturbation transform used to perturb inputs.
+    :param prompt_template: The template used for composing prompts out of the perturbed inputs.
+    :param model: The model that is invoked on the prompts constructed from perturbed inputs.
+    :returns: A tuple of three transforms, where the first is the same SemanticPerturbation
+        that was passed in, and the second two are created in this function.
+    """
     # Generate prompts from perturbed inputs
     gen_perturbed_prompts = GeneratePrompt(
         input_keys=perturbation.output_keys,

--- a/src/fmeval/eval_algorithms/summarization_accuracy.py
+++ b/src/fmeval/eval_algorithms/summarization_accuracy.py
@@ -235,5 +235,5 @@ class SummarizationAccuracy(EvalAlgorithmInterface):
             )
             eval_outputs.append(eval_output)
 
-        cleanup_shared_resource(bertscore_shared_resource)
+        # cleanup_shared_resource(bertscore_shared_resource)
         return eval_outputs

--- a/src/fmeval/eval_algorithms/summarization_accuracy.py
+++ b/src/fmeval/eval_algorithms/summarization_accuracy.py
@@ -235,5 +235,5 @@ class SummarizationAccuracy(EvalAlgorithmInterface):
             )
             eval_outputs.append(eval_output)
 
-        # cleanup_shared_resource(bertscore_shared_resource)
+        cleanup_shared_resource(bertscore_shared_resource)
         return eval_outputs

--- a/src/fmeval/eval_algorithms/summarization_accuracy.py
+++ b/src/fmeval/eval_algorithms/summarization_accuracy.py
@@ -89,20 +89,21 @@ class SummarizationAccuracy(EvalAlgorithmInterface):
 
     eval_name = EvalAlgorithm.SUMMARIZATION_ACCURACY.value
 
-    def __init__(self, config: SummarizationAccuracyConfig = SummarizationAccuracyConfig()):
+    def __init__(self, eval_algorithm_config: SummarizationAccuracyConfig = SummarizationAccuracyConfig()):
         """SummarizationAccuracy initializer.
 
-        :param config: Summarization Accuracy evaluation algorithm config.
+        :param eval_algorithm_config: Summarization Accuracy evaluation algorithm config.
         """
-        self.bertscore_model = BertscoreModel(config.model_type_for_bertscore)
+        super().__init__(eval_algorithm_config)
+        self.bertscore_model = BertscoreModel(eval_algorithm_config.model_type_for_bertscore)
         meteor_score, rouge_score, bert_score = SummarizationAccuracy._create_transforms(
             target_output_keys=[DatasetColumns.TARGET_OUTPUT.value.name],
             model_output_keys=[DatasetColumns.MODEL_OUTPUT.value.name],
             meteor_keys=[METEOR_SCORE],
             rouge_keys=[ROUGE_SCORE],
             bertscore_keys=[BERT_SCORE],
-            rouge_type=config.rouge_type,
-            use_stemmer_for_rouge=config.use_stemmer_for_rouge,
+            rouge_type=eval_algorithm_config.rouge_type,
+            use_stemmer_for_rouge=eval_algorithm_config.use_stemmer_for_rouge,
             bertscore_model=self.bertscore_model,
         )
         self.meteor_score = meteor_score
@@ -157,7 +158,7 @@ class SummarizationAccuracy(EvalAlgorithmInterface):
         )
         return meteor_transform, rouge_transform, bert_transform
 
-    def evaluate_sample(self, target_output: str, model_output: str) -> List[EvalScore]:
+    def evaluate_sample(self, target_output: str, model_output: str) -> List[EvalScore]:  # type: ignore[override]
         """Compute summarization accuracy metrics for a single sample.
 
         :param target_output: The expected/desired model output.

--- a/src/fmeval/eval_algorithms/summarization_accuracy_semantic_robustness.py
+++ b/src/fmeval/eval_algorithms/summarization_accuracy_semantic_robustness.py
@@ -46,7 +46,7 @@ from fmeval.transforms.summarization_accuracy_metrics import MeteorScore, RougeS
 from fmeval.transforms.transform_pipeline import TransformPipeline
 from fmeval.transforms.util import create_output_key
 from fmeval.model_runners.model_runner import ModelRunner
-from fmeval.util import require, create_shared_resource, get_eval_results_path, cleanup_shared_resource
+from fmeval.util import create_shared_resource, get_eval_results_path, require
 
 logger = logging.getLogger(__name__)
 
@@ -278,5 +278,5 @@ class SummarizationAccuracySemanticRobustness(EvalAlgorithmInterface):
             )
             eval_outputs.append(eval_output)
 
-        cleanup_shared_resource(bertscore_shared_resource)
+        # cleanup_shared_resource(bertscore_shared_resource)
         return eval_outputs

--- a/src/fmeval/eval_algorithms/summarization_accuracy_semantic_robustness.py
+++ b/src/fmeval/eval_algorithms/summarization_accuracy_semantic_robustness.py
@@ -46,7 +46,7 @@ from fmeval.transforms.summarization_accuracy_metrics import MeteorScore, RougeS
 from fmeval.transforms.transform_pipeline import TransformPipeline
 from fmeval.transforms.util import create_output_key
 from fmeval.model_runners.model_runner import ModelRunner
-from fmeval.util import create_shared_resource, get_eval_results_path, require
+from fmeval.util import create_shared_resource, get_eval_results_path, require, cleanup_shared_resource
 
 logger = logging.getLogger(__name__)
 
@@ -278,5 +278,5 @@ class SummarizationAccuracySemanticRobustness(EvalAlgorithmInterface):
             )
             eval_outputs.append(eval_output)
 
-        # cleanup_shared_resource(bertscore_shared_resource)
+        cleanup_shared_resource(bertscore_shared_resource)
         return eval_outputs

--- a/src/fmeval/eval_algorithms/summarization_accuracy_semantic_robustness.py
+++ b/src/fmeval/eval_algorithms/summarization_accuracy_semantic_robustness.py
@@ -110,6 +110,7 @@ class SummarizationAccuracySemanticRobustness(EvalAlgorithmInterface):
 
         :param eval_algorithm_config: Summarization accuracy semantic robustness evaluation algorithm config.
         """
+        super().__init__(eval_algorithm_config)
         self.config = eval_algorithm_config
         self.perturbation_transform = get_perturbation_transform(eval_algorithm_config)
         bertscore_model = BertscoreModel(eval_algorithm_config.model_type_for_bertscore)
@@ -203,7 +204,7 @@ class SummarizationAccuracySemanticRobustness(EvalAlgorithmInterface):
         target_output: str,
         model: ModelRunner,
         prompt_template: str = DEFAULT_PROMPT_TEMPLATE,
-    ) -> List[EvalScore]:
+    ) -> List[EvalScore]:  # type: ignore[override]
         """Compute summarization accuracy semantic robustness metrics for a single sample.
 
         A sample is defined as a model input and model output pair.

--- a/src/fmeval/eval_algorithms/toxicity.py
+++ b/src/fmeval/eval_algorithms/toxicity.py
@@ -75,6 +75,7 @@ class Toxicity(EvalAlgorithmInterface):
 
         :param eval_algorithm_config: Toxicity eval algorithm config
         """
+        super().__init__(eval_algorithm_config)
         self.eval_name = TOXICITY
         self._eval_algorithm_config = eval_algorithm_config
         self._helper_model = TOXICITY_HELPER_MODEL_MAPPING[self._eval_algorithm_config.model_type]()

--- a/src/fmeval/eval_algorithms/util.py
+++ b/src/fmeval/eval_algorithms/util.py
@@ -395,6 +395,14 @@ def verify_model_determinism(
 
 
 def create_model_invocation_pipeline(model: ModelRunner, prompt_template: str) -> TransformPipeline:
+    """Create a transform pipeline for performing the standard action of invoking a model on a prompt.
+
+    :param model: The model to be invoked.
+    :param prompt_template: The template used for constructing prompts (out of raw inputs)
+        that will be fed to the model.
+    :returns: A TransformPipeline instance containing a GeneratePrompt transform that uses `prompt_template`
+        and a GetModelOutputs transform for invoking the model on the generated prompts.
+    """
     gen_prompt = GeneratePrompt(
         input_keys=[DatasetColumns.MODEL_INPUT.value.name],
         output_keys=[DatasetColumns.PROMPT.value.name],

--- a/src/fmeval/eval_algorithms/util.py
+++ b/src/fmeval/eval_algorithms/util.py
@@ -33,7 +33,6 @@ from fmeval.perf_util import timed_block
 from fmeval.transforms.common import GeneratePrompt, GetModelOutputs
 from fmeval.transforms.transform_pipeline import TransformPipeline
 from fmeval.util import get_num_actors
-from fmeval.eval_algorithms.helper_models.helper_model import BertscoreHelperModel
 
 logger = logging.getLogger(__name__)
 
@@ -383,27 +382,6 @@ def verify_model_determinism(model: ModelRunner, dataset: Dataset, prompt_column
         if model.predict(original_prompt)[0] != original_model_output:
             return False
     return True
-
-
-def get_bert_score(
-    target_output: str, model_output: str, helper_model: Optional[BertscoreHelperModel] = None, **kwargs
-) -> float:
-    """
-    BERTscore is a similarity-based metric that compares the embedding of two texts under a learned model, typically,
-    from the BERT family. This score may lead to increased flexibility compared to ROUGE and METEOR since semantically
-    similar sentences are (typically) embedded similarly.
-
-    https://huggingface.co/spaces/evaluate-metric/bertscore
-
-    :param target_output: The expected responses from the model
-    :param model_output: The output of a model that we want to evaluate.
-    :param helper_model: The BertscoreHelperModel for computing the BERTScore.
-    :returns: bert score
-    """
-    assert (
-        helper_model is not None
-    ), "The helper_model parameter of get_bert_score expected a BertscoreHelperModel, instead received None."
-    return ray.get(helper_model.get_helper_scores.remote(target_output, model_output))
 
 
 def create_model_invocation_pipeline(model: ModelRunner, prompt_template: str) -> TransformPipeline:

--- a/src/fmeval/util.py
+++ b/src/fmeval/util.py
@@ -89,7 +89,7 @@ def create_shared_resource(resource: object, num_cpus: int = 1) -> ObjectRef:
     """Create a Ray actor out of `resource`.
 
     Typically, `resource` will be an object that consumes a significant amount of
-    memory (ex: a BertscoreHelperModel instance) that you do not want to create
+    memory (ex: a BertscoreModel instance) that you do not want to create
     on a per-transform (i.e. per-process) basis, but rather wish to have as a "global resource".
 
     Conceptually, the object that is returned from this function can be thought

--- a/src/fmeval/util.py
+++ b/src/fmeval/util.py
@@ -112,3 +112,17 @@ def create_shared_resource(resource: object, num_cpus: int = 1) -> ObjectRef:
     resource_cls, serialized_data = resource.__reduce__()  # type: ignore[misc]
     wrapped_resource_cls = ray.remote(num_cpus=num_cpus)(resource_cls)
     return wrapped_resource_cls.remote(*serialized_data)
+
+
+def cleanup_shared_resource(resource: ObjectRef) -> None:
+    """Removes the resource from shared memory.
+
+    Concretely, this function kills the Ray actor corresponding
+    to `resource`, which in most cases will be an actor created
+    via create_shared_resource.
+
+    :param resource: A Ray actor handle to a shared resource
+        (ex: a BertscoreModel).
+    :returns: None
+    """
+    ray.kill(resource)

--- a/test/integration/test_summarization_accuracy.py
+++ b/test/integration/test_summarization_accuracy.py
@@ -28,7 +28,7 @@ def format_input(input_str: str) -> str:
 class TestSummarizationAccuracy:
     def test_evaluate_sample_and_evaluate(self, integration_tests_dir):
         """
-        Instantiating a SummarizationAccuracy object will create a BertscoreHelperModel
+        Instantiating a SummarizationAccuracy object will create a BertscoreModel
         Ray actor. To avoid doing this twice (which would require us to shut down Ray
         in between tests due to Bert's high memory usage), we use a single SummarizationAccuracy
         object to test evaluate_sample and evaluate back-to-back (instead of following the

--- a/test/integration/test_summarization_accuracy_semantic_robustness.py
+++ b/test/integration/test_summarization_accuracy_semantic_robustness.py
@@ -1,9 +1,7 @@
 import json
 import os
-import time
 
 import pytest
-import ray
 
 from typing import NamedTuple, Dict
 from pytest import approx
@@ -88,7 +86,7 @@ class TestSummarizationAccuracySemanticRobustness:
         ],
     )
     def test_evaluate_sample(self, config, expected_scores, integration_tests_dir):
-        eval_algo = SummarizationAccuracySemanticRobustness(config, use_ray=False)
+        eval_algo = SummarizationAccuracySemanticRobustness(config)
         with open(os.path.join(integration_tests_dir, "datasets", "gigaword_sample.jsonl")) as fh:
             json_obj = json.loads(fh.readline())
             model_input = json_obj["document"]
@@ -140,7 +138,7 @@ class TestSummarizationAccuracySemanticRobustness:
         ],
     )
     def test_evaluate(self, config, expected_scores):
-        eval_algo = SummarizationAccuracySemanticRobustness(config, use_ray=True)
+        eval_algo = SummarizationAccuracySemanticRobustness(config)
         dataset_config = DATASET_CONFIGS[GIGAWORD]
         eval_output = eval_algo.evaluate(
             model=sm_model_runner,
@@ -150,7 +148,3 @@ class TestSummarizationAccuracySemanticRobustness:
         )[0]
         for eval_score in eval_output.dataset_scores:
             assert eval_score.value == approx(expected_scores[eval_score.name], abs=ABS_TOL)
-
-        # Explicitly kill the BertscoreModel actor
-        ray.kill(eval_algo.bertscore_model)
-        time.sleep(5)

--- a/test/integration/test_summarization_accuracy_semantic_robustness.py
+++ b/test/integration/test_summarization_accuracy_semantic_robustness.py
@@ -1,6 +1,9 @@
 import json
 import os
+import time
+
 import pytest
+import ray
 
 from typing import NamedTuple, Dict
 from pytest import approx
@@ -147,3 +150,7 @@ class TestSummarizationAccuracySemanticRobustness:
         )[0]
         for eval_score in eval_output.dataset_scores:
             assert eval_score.value == approx(expected_scores[eval_score.name], abs=ABS_TOL)
+
+        # Explicitly kill the BertscoreModel actor
+        ray.kill(eval_algo.bertscore_model)
+        time.sleep(5)

--- a/test/integration/test_summarization_accuracy_semantic_robustness.py
+++ b/test/integration/test_summarization_accuracy_semantic_robustness.py
@@ -4,6 +4,8 @@ import os
 import pytest
 
 from typing import NamedTuple, Dict
+
+import ray
 from pytest import approx
 
 from fmeval.eval_algorithms import DATASET_CONFIGS, GIGAWORD
@@ -148,3 +150,4 @@ class TestSummarizationAccuracySemanticRobustness:
         )[0]
         for eval_score in eval_output.dataset_scores:
             assert eval_score.value == approx(expected_scores[eval_score.name], abs=ABS_TOL)
+        ray.shutdown()

--- a/test/integration/test_summarization_accuracy_semantic_robustness.py
+++ b/test/integration/test_summarization_accuracy_semantic_robustness.py
@@ -71,6 +71,44 @@ class TestSummarizationAccuracySemanticRobustness:
                     DELTA_BERT_SCORE: 0.031421,
                 },
             ),
+            TestCase(
+                config=RANDOM_UPPER_CASE_CONFIG,
+                evaluate_sample_scores={
+                    ROUGE_SCORE: 0.0,
+                    METEOR_SCORE: 0.0,
+                    BERT_SCORE: 0.536162,
+                    DELTA_ROUGE_SCORE: 0.0,
+                    DELTA_METEOR_SCORE: 0.064103,
+                    DELTA_BERT_SCORE: 0.056435,
+                },
+                evaluate_scores={
+                    ROUGE_SCORE: 0.021908,
+                    METEOR_SCORE: 0.105540,
+                    BERT_SCORE: 0.559893,
+                    DELTA_ROUGE_SCORE: 0.032086,
+                    DELTA_METEOR_SCORE: 0.057150,
+                    DELTA_BERT_SCORE: 0.026943,
+                },
+            ),
+            TestCase(
+                config=WHITESPACE_CONFIG,
+                evaluate_sample_scores={
+                    ROUGE_SCORE: 0.0,
+                    METEOR_SCORE: 0.0,
+                    BERT_SCORE: 0.536162,
+                    DELTA_ROUGE_SCORE: 0.0,
+                    DELTA_METEOR_SCORE: 0.038462,
+                    DELTA_BERT_SCORE: 0.039566,
+                },
+                evaluate_scores={
+                    ROUGE_SCORE: 0.021908,
+                    METEOR_SCORE: 0.105540,
+                    BERT_SCORE: 0.559893,
+                    DELTA_ROUGE_SCORE: 0.020407,
+                    DELTA_METEOR_SCORE: 0.048702,
+                    DELTA_BERT_SCORE: 0.026193,
+                },
+            ),
         ],
     )
     def test_evaluate_sample_and_evaluate(self, config, evaluate_sample_scores, evaluate_scores, integration_tests_dir):

--- a/test/integration/test_summarization_accuracy_semantic_robustness.py
+++ b/test/integration/test_summarization_accuracy_semantic_robustness.py
@@ -71,44 +71,6 @@ class TestSummarizationAccuracySemanticRobustness:
                     DELTA_BERT_SCORE: 0.031421,
                 },
             ),
-            TestCase(
-                config=RANDOM_UPPER_CASE_CONFIG,
-                evaluate_sample_scores={
-                    ROUGE_SCORE: 0.0,
-                    METEOR_SCORE: 0.0,
-                    BERT_SCORE: 0.536162,
-                    DELTA_ROUGE_SCORE: 0.0,
-                    DELTA_METEOR_SCORE: 0.064103,
-                    DELTA_BERT_SCORE: 0.056435,
-                },
-                evaluate_scores={
-                    ROUGE_SCORE: 0.021908,
-                    METEOR_SCORE: 0.105540,
-                    BERT_SCORE: 0.559893,
-                    DELTA_ROUGE_SCORE: 0.032086,
-                    DELTA_METEOR_SCORE: 0.057150,
-                    DELTA_BERT_SCORE: 0.026943,
-                },
-            ),
-            TestCase(
-                config=WHITESPACE_CONFIG,
-                evaluate_sample_scores={
-                    ROUGE_SCORE: 0.0,
-                    METEOR_SCORE: 0.0,
-                    BERT_SCORE: 0.536162,
-                    DELTA_ROUGE_SCORE: 0.0,
-                    DELTA_METEOR_SCORE: 0.038462,
-                    DELTA_BERT_SCORE: 0.039566,
-                },
-                evaluate_scores={
-                    ROUGE_SCORE: 0.021908,
-                    METEOR_SCORE: 0.105540,
-                    BERT_SCORE: 0.559893,
-                    DELTA_ROUGE_SCORE: 0.020407,
-                    DELTA_METEOR_SCORE: 0.048702,
-                    DELTA_BERT_SCORE: 0.026193,
-                },
-            ),
         ],
     )
     def test_evaluate_sample_and_evaluate(self, config, evaluate_sample_scores, evaluate_scores, integration_tests_dir):

--- a/test/integration/test_summarization_accuracy_semantic_robustness.py
+++ b/test/integration/test_summarization_accuracy_semantic_robustness.py
@@ -5,6 +5,7 @@ import pytest
 
 from typing import NamedTuple, Dict
 
+import ray
 from pytest import approx
 
 from fmeval.eval_algorithms import DATASET_CONFIGS, GIGAWORD
@@ -137,3 +138,5 @@ class TestSummarizationAccuracySemanticRobustness:
         )[0]
         for eval_score in eval_output.dataset_scores:
             assert eval_score.value == approx(evaluate_scores[eval_score.name], abs=ABS_TOL)
+
+        ray.shutdown()

--- a/test/integration/test_summarization_accuracy_semantic_robustness.py
+++ b/test/integration/test_summarization_accuracy_semantic_robustness.py
@@ -1,11 +1,9 @@
 import json
 import os
-
+import ray
 import pytest
 
 from typing import NamedTuple, Dict
-
-import ray
 from pytest import approx
 
 from fmeval.eval_algorithms import DATASET_CONFIGS, GIGAWORD

--- a/test/unit/eval_algorithms/test_general_semantic_robustness.py
+++ b/test/unit/eval_algorithms/test_general_semantic_robustness.py
@@ -19,9 +19,8 @@ from fmeval.eval_algorithms.general_semantic_robustness import (
     UpdateRobustnessScores,
 )
 from fmeval.exceptions import EvalAlgorithmClientError
-from fmeval.helper_models import BertscoreModel
+from fmeval.helper_models import BertscoreModel, BertscoreModelTypes
 from fmeval.model_runners.model_runner import ModelRunner
-from fmeval.eval_algorithms.helper_models.helper_model import BertscoreHelperModelTypes
 from fmeval.transforms.common import GeneratePrompt, GetModelOutputs
 from fmeval.transforms.semantic_perturbations import (
     ButterFinger,
@@ -126,7 +125,7 @@ class TestGeneralSemanticRobustness:
         model_name = "my_model"
         expected_error_message = (
             f"Invalid model_type_for_bertscore: {model_name} requested in GeneralSemanticRobustnessConfig, "
-            f"please choose from acceptable values: {BertscoreHelperModelTypes.model_list()}."
+            f"please choose from acceptable values: {BertscoreModelTypes.model_list()}."
         )
         with pytest.raises(EvalAlgorithmClientError, match=re.escape(expected_error_message)):
             GeneralSemanticRobustnessConfig(model_type_for_bertscore=model_name)

--- a/test/unit/eval_algorithms/test_general_semantic_robustness.py
+++ b/test/unit/eval_algorithms/test_general_semantic_robustness.py
@@ -189,14 +189,14 @@ class TestGeneralSemanticRobustness:
     def test_build_pipeline(self, bertscore_model, is_deterministic, config):
         """
         GIVEN a deterministic model.
-        WHEN `build_pipeline` is called.
+        WHEN a GeneralSemanticRobustness' `_build_pipeline` method is called.
         THEN a TransformPipeline with the correct Transforms is returned.
         """
         # Mock BertscoreModel so that the actual model doesn't get loaded into memory during test.
         bertscore_model.return_value = Mock(spec=BertscoreModel)
 
         eval_algo = GeneralSemanticRobustness(config, use_ray=False)
-        pipeline = eval_algo.build_pipeline(
+        pipeline = eval_algo._build_pipeline(
             model=Mock(),
             prompt_template="$model_input",
             is_deterministic=is_deterministic,
@@ -392,7 +392,7 @@ class TestGeneralSemanticRobustness:
     )
     @patch("fmeval.eval_algorithms.general_semantic_robustness.get_eval_results_path")
     @patch("fmeval.eval_algorithms.general_semantic_robustness.evaluate_dataset")
-    @patch("fmeval.eval_algorithms.general_semantic_robustness.GeneralSemanticRobustness.build_pipeline")
+    @patch("fmeval.eval_algorithms.general_semantic_robustness.GeneralSemanticRobustness._build_pipeline")
     @patch("fmeval.eval_algorithms.general_semantic_robustness.verify_model_determinism")
     @patch("fmeval.eval_algorithms.general_semantic_robustness.get_dataset")
     @patch("fmeval.eval_algorithms.general_semantic_robustness.get_dataset_configs")

--- a/test/unit/eval_algorithms/test_general_semantic_robustness.py
+++ b/test/unit/eval_algorithms/test_general_semantic_robustness.py
@@ -9,7 +9,7 @@ from typing import NamedTuple, List, Optional, Tuple
 from unittest.mock import MagicMock, patch, Mock
 from _pytest.fixtures import fixture
 
-from fmeval.constants import BUTTER_FINGER, DatasetColumns, RANDOM_UPPER_CASE, WHITESPACE_ADD_REMOVE
+from fmeval.constants import BUTTER_FINGER, DatasetColumns, RANDOM_UPPER_CASE, WHITESPACE_ADD_REMOVE, MEAN
 from fmeval.eval_algorithms import EvalScore
 from fmeval.eval_algorithms.general_semantic_robustness import (
     WER_SCORE,
@@ -391,10 +391,9 @@ class TestGeneralSemanticRobustness:
         ],
     )
     @patch("fmeval.eval_algorithms.general_semantic_robustness.get_eval_results_path")
-    @patch("fmeval.eval_algorithms.general_semantic_robustness.compute_and_aggregate_metrics")
+    @patch("fmeval.eval_algorithms.general_semantic_robustness.evaluate_dataset")
     @patch("fmeval.eval_algorithms.general_semantic_robustness.GeneralSemanticRobustness.build_pipeline")
     @patch("fmeval.eval_algorithms.general_semantic_robustness.verify_model_determinism")
-    @patch("fmeval.eval_algorithms.general_semantic_robustness.create_model_invocation_pipeline")
     @patch("fmeval.eval_algorithms.general_semantic_robustness.get_dataset")
     @patch("fmeval.eval_algorithms.general_semantic_robustness.get_dataset_configs")
     @patch("fmeval.eval_algorithms.general_semantic_robustness.BertscoreModel")
@@ -403,10 +402,9 @@ class TestGeneralSemanticRobustness:
         mock_bertscore_model,
         mock_get_dataset_configs,
         mock_get_dataset,
-        mock_model_invocation_pipeline,
         mock_verify_model_determinism,
         mock_build_pipeline,
-        mock_compute_metrics,
+        mock_evaluate_dataset,
         mock_get_eval_results_path,
         test_case,
         config,
@@ -416,52 +414,46 @@ class TestGeneralSemanticRobustness:
         WHEN the GeneralSemanticRobustness evaluate method is called.
         THEN the relevant functions are called with correct arguments.
         """
-        eval_algo = GeneralSemanticRobustness(
-            config,
-            use_ray=False,
-        )
-
-        model_runner = Mock()
         mock_bertscore_model.return_value = Mock()
+        model_runner = Mock()
 
         dataset_config = Mock()
         dataset_config.dataset_name = "my_custom_dataset"
         mock_get_dataset_configs.return_value = [dataset_config]
 
         mock_dataset = Mock()
+        # So that validate_dataset does not error
         mock_dataset.columns = Mock(return_value=[DatasetColumns.MODEL_INPUT.value.name])
         mock_get_dataset.return_value = mock_dataset
 
-        dataset_with_model_outputs = Mock()
-        mock_model_invocation_pipeline.return_value = Mock()
-        mock_model_invocation_pipeline.return_value.execute = Mock(return_value=dataset_with_model_outputs)
-
         mock_verify_model_determinism.return_value = test_case.is_deterministic
-
-        final_pipeline = Mock()
-        mock_build_pipeline.return_value = final_pipeline
-
+        mock_build_pipeline.return_value = Mock()
         mock_get_eval_results_path.return_value = "/path/to/eval/results"
 
+        eval_algo = GeneralSemanticRobustness(config, use_ray=False)
         eval_outputs = eval_algo.evaluate(
             model=model_runner,
             dataset_config=dataset_config,
             prompt_template=test_case.user_provided_prompt_template,
+            num_records=200,
             save=test_case.save,
         )
 
+        mock_verify_model_determinism.assert_called_with(model_runner, mock_dataset, test_case.dataset_prompt_template)
         mock_build_pipeline.assert_called_with(
             model_runner, test_case.dataset_prompt_template, is_deterministic=test_case.is_deterministic
         )
-        mock_compute_metrics.assert_called_once_with(
-            pipeline=final_pipeline,
-            dataset=dataset_with_model_outputs,
+        mock_evaluate_dataset.assert_called_once_with(
+            dataset=mock_get_dataset.return_value,
+            pipeline=mock_build_pipeline.return_value,
             dataset_name=dataset_config.dataset_name,
             eval_name=GeneralSemanticRobustness.eval_name,
             metric_names=[BERT_SCORE_DISSIMILARITY, WER_SCORE],
             eval_results_path="/path/to/eval/results",
+            model=model_runner,
             prompt_template=test_case.dataset_prompt_template,
+            agg_method=MEAN,
             save=test_case.save,
         )
 
-        assert eval_outputs == [mock_compute_metrics.return_value]
+        assert eval_outputs == [mock_evaluate_dataset.return_value]

--- a/test/unit/eval_algorithms/test_helper_model.py
+++ b/test/unit/eval_algorithms/test_helper_model.py
@@ -1,11 +1,9 @@
 from unittest.mock import patch, PropertyMock
-import ray
 import numpy as np
 import pytest
 
 from fmeval.eval_algorithms.helper_models.helper_model import (
     ToxigenHelperModel,
-    BertscoreHelperModel,
     TOXIGEN_SCORE_NAME,
     DETOXIFY_SCORE_NAMES,
     DetoxifyHelperModel,
@@ -151,12 +149,3 @@ class TestHelperModel:
         """
         test_helper = DetoxifyHelperModel()
         assert test_helper.get_score_names() == DETOXIFY_SCORE_NAMES
-
-    def test_bertscore_helper_model_roberta(self):
-        """
-        Test bertscore helper model
-        """
-        bertscore = BertscoreHelperModel.remote("distilbert-base-uncased")
-        assert ray.get(
-            bertscore.get_helper_scores.remote("sample text reference", "sample text prediction")
-        ) == pytest.approx(0.902793288230896)

--- a/test/unit/eval_algorithms/test_summarization_accuracy_semantic_robustness.py
+++ b/test/unit/eval_algorithms/test_summarization_accuracy_semantic_robustness.py
@@ -1,30 +1,13 @@
 import re
 from typing import NamedTuple, List, Optional, Tuple
-from unittest.mock import patch, MagicMock
+from unittest.mock import Mock, call, patch
 
 import pytest
-import ray
 from _pytest.fixtures import fixture
-from ray.data import Dataset
 
-from fmeval.constants import (
-    DatasetColumns,
-    MIME_TYPE_JSON,
-)
-from fmeval.data_loaders.data_config import DataConfig
-from fmeval.eval_algorithms import (
-    EvalScore,
-    EvalOutput,
-    CategoryScore,
-    BUILT_IN_DATASET_DEFAULT_PROMPT_TEMPLATES,
-    DEFAULT_PROMPT_TEMPLATE,
-    GIGAWORD,
-    GOV_REPORT,
-)
-from fmeval.eval_algorithms.semantic_robustness_utils import (
-    RANDOM_UPPER_CASE,
-    WHITESPACE_ADD_REMOVE,
-)
+from fmeval.constants import DatasetColumns, BUTTER_FINGER, WHITESPACE_ADD_REMOVE
+from fmeval.eval_algorithms import EvalScore
+from fmeval.eval_algorithms.semantic_robustness_utils import RANDOM_UPPER_CASE, SEMANTIC_PERTURBATIONS
 from fmeval.eval_algorithms.summarization_accuracy import METEOR_SCORE, ROUGE_SCORE, BERT_SCORE
 from fmeval.eval_algorithms.summarization_accuracy_semantic_robustness import (
     SummarizationAccuracySemanticRobustnessConfig,
@@ -32,53 +15,12 @@ from fmeval.eval_algorithms.summarization_accuracy_semantic_robustness import (
     DELTA_METEOR_SCORE,
     DELTA_ROUGE_SCORE,
     DELTA_BERT_SCORE,
+    ORIGINAL_SCORES,
+    DELTA_SCORES,
 )
 from fmeval.exceptions import EvalAlgorithmClientError
+from fmeval.helper_models import BertscoreModel
 from fmeval.model_runners.model_runner import ModelRunner
-
-DATASET_WITH_SCORES = ray.data.from_items(
-    [
-        {
-            DatasetColumns.MODEL_INPUT.value.name: "Cake is so delicious, I really like cake. I want to open a bakery when I grow up.",
-            DatasetColumns.TARGET_OUTPUT.value.name: "I like cake.",
-            DatasetColumns.CATEGORY.value.name: "dummy_category_1",
-            DatasetColumns.MODEL_OUTPUT.value.name: "Some model output.",
-            ROUGE_SCORE: 0.0,
-            METEOR_SCORE: 0.0,
-            BERT_SCORE: 0.0,
-            DELTA_ROUGE_SCORE: 0.0,
-            DELTA_METEOR_SCORE: 0.0,
-            DELTA_BERT_SCORE: 0.0,
-        },
-        {
-            DatasetColumns.MODEL_INPUT.value.name: "The art metropolis of Berlin inspires locals and visitors with its famous "
-            "museum landscape and numerous UNESCO World Heritage sites."
-            " It is also an international exhibition venue. "
-            "You will find a selection of current and upcoming exhibitions here.",
-            DatasetColumns.TARGET_OUTPUT.value.name: "Berlin: an art metropolis.",
-            DatasetColumns.CATEGORY.value.name: "dummy_category_2",
-            DatasetColumns.MODEL_OUTPUT.value.name: "Some model output.",
-            ROUGE_SCORE: 0.0,
-            METEOR_SCORE: 0.0,
-            BERT_SCORE: 0.0,
-            DELTA_ROUGE_SCORE: 0.0,
-            DELTA_METEOR_SCORE: 0.0,
-            DELTA_BERT_SCORE: 0.0,
-        },
-    ]
-)
-
-DATASET_WITH_MODEL_OUTPUT = DATASET_WITH_SCORES.drop_columns(
-    cols=[DELTA_ROUGE_SCORE, DELTA_METEOR_SCORE, DELTA_BERT_SCORE]
-)
-
-DATASET = DATASET_WITH_MODEL_OUTPUT.drop_columns(cols=[DatasetColumns.MODEL_OUTPUT.value.name])
-
-DATASET_NO_CATEGORY_WITH_MODEL_OUTPUT = DATASET_WITH_MODEL_OUTPUT.drop_columns(
-    cols=[DatasetColumns.CATEGORY.value.name]
-)
-
-DATASET_NO_CATEGORY = DATASET.drop_columns(cols=[DatasetColumns.CATEGORY.value.name])
 
 
 class MockModelRunner(ModelRunner):
@@ -94,272 +36,7 @@ class TestSummarizationAccuracySemanticRobustness:
     def config(self) -> SummarizationAccuracySemanticRobustnessConfig:
         return SummarizationAccuracySemanticRobustnessConfig(num_perturbations=2)
 
-    class TestCaseSummarizationAccuracySemanticRobustnessEvaluateSample(NamedTuple):
-        model_input: str
-        target_output: str
-        original_model_output: str
-        perturbed_model_output_1: str
-        perturbed_model_output_2: str
-        sa_eval_score_original: List[EvalScore]
-        sa_eval_score_perturbed_1: List[EvalScore]
-        sa_eval_score_perturbed_2: List[EvalScore]
-        expected_response: List[EvalScore]
-        config: SummarizationAccuracySemanticRobustnessConfig
-
-    class TestCaseSummarizationAccuracySemanticRobustnessEvaluateSampleInvalid(NamedTuple):
-        model_input: str
-        target_output: str
-        model: ModelRunner
-        expected_error_message: str
-        config: SummarizationAccuracySemanticRobustnessConfig
-
-    @pytest.mark.parametrize(
-        "test_case",
-        [
-            TestCaseSummarizationAccuracySemanticRobustnessEvaluateSample(
-                model_input="Cake is so delicious, I really like cake. I want to open a bakery when I grow up.",
-                target_output="I like cake.",
-                original_model_output="Some model output.",
-                perturbed_model_output_1="Some other model output.",
-                perturbed_model_output_2="Some different model output.",
-                sa_eval_score_original=[
-                    EvalScore(name=METEOR_SCORE, value=1.0),
-                    EvalScore(name=ROUGE_SCORE, value=1.0),
-                    EvalScore(name=BERT_SCORE, value=0.5),
-                ],
-                sa_eval_score_perturbed_1=[
-                    EvalScore(name=METEOR_SCORE, value=0.75),
-                    EvalScore(name=ROUGE_SCORE, value=0.5),
-                    EvalScore(name=BERT_SCORE, value=1.0),
-                ],
-                sa_eval_score_perturbed_2=[
-                    EvalScore(name=METEOR_SCORE, value=0.5),
-                    EvalScore(name=ROUGE_SCORE, value=0.2),
-                    EvalScore(name=BERT_SCORE, value=0.5),
-                ],
-                expected_response=[
-                    EvalScore(name=METEOR_SCORE, value=1.0),
-                    EvalScore(name=ROUGE_SCORE, value=1.0),
-                    EvalScore(name=BERT_SCORE, value=0.5),
-                    EvalScore(name=DELTA_METEOR_SCORE, value=0.375),
-                    EvalScore(name=DELTA_ROUGE_SCORE, value=0.65),
-                    EvalScore(name=DELTA_BERT_SCORE, value=0.25),
-                ],
-                config=SummarizationAccuracySemanticRobustnessConfig(num_perturbations=2),
-            ),
-            TestCaseSummarizationAccuracySemanticRobustnessEvaluateSample(
-                model_input="Cake is so delicious, I really like cake. I want to open a bakery when I grow up.",
-                target_output="I like cake.",
-                original_model_output="Some model output.",
-                perturbed_model_output_1="Some other model output.",
-                perturbed_model_output_2="Some different model output.",
-                sa_eval_score_original=[
-                    EvalScore(name=METEOR_SCORE, value=1.0),
-                    EvalScore(name=ROUGE_SCORE, value=1.0),
-                    EvalScore(name=BERT_SCORE, value=0.5),
-                ],
-                sa_eval_score_perturbed_1=[
-                    EvalScore(name=METEOR_SCORE, value=0.75),
-                    EvalScore(name=ROUGE_SCORE, value=0.5),
-                    EvalScore(name=BERT_SCORE, value=1.0),
-                ],
-                sa_eval_score_perturbed_2=[
-                    EvalScore(name=METEOR_SCORE, value=0.5),
-                    EvalScore(name=ROUGE_SCORE, value=0.2),
-                    EvalScore(name=BERT_SCORE, value=0.5),
-                ],
-                expected_response=[
-                    EvalScore(name=METEOR_SCORE, value=1.0),
-                    EvalScore(name=ROUGE_SCORE, value=1.0),
-                    EvalScore(name=BERT_SCORE, value=0.5),
-                    EvalScore(name=DELTA_METEOR_SCORE, value=0.375),
-                    EvalScore(name=DELTA_ROUGE_SCORE, value=0.65),
-                    EvalScore(name=DELTA_BERT_SCORE, value=0.25),
-                ],
-                config=SummarizationAccuracySemanticRobustnessConfig(
-                    num_perturbations=2, perturbation_type=RANDOM_UPPER_CASE
-                ),
-            ),
-            TestCaseSummarizationAccuracySemanticRobustnessEvaluateSample(
-                model_input="Cake is so delicious, I really like cake. I want to open a bakery when I grow up.",
-                target_output="I like cake.",
-                original_model_output="Some model output.",
-                perturbed_model_output_1="Some other model output.",
-                perturbed_model_output_2="Some different model output.",
-                sa_eval_score_original=[
-                    EvalScore(name=METEOR_SCORE, value=1.0),
-                    EvalScore(name=ROUGE_SCORE, value=1.0),
-                    EvalScore(name=BERT_SCORE, value=0.5),
-                ],
-                sa_eval_score_perturbed_1=[
-                    EvalScore(name=METEOR_SCORE, value=0.75),
-                    EvalScore(name=ROUGE_SCORE, value=0.5),
-                    EvalScore(name=BERT_SCORE, value=1.0),
-                ],
-                sa_eval_score_perturbed_2=[
-                    EvalScore(name=METEOR_SCORE, value=0.5),
-                    EvalScore(name=ROUGE_SCORE, value=0.2),
-                    EvalScore(name=BERT_SCORE, value=0.5),
-                ],
-                expected_response=[
-                    EvalScore(name=METEOR_SCORE, value=1.0),
-                    EvalScore(name=ROUGE_SCORE, value=1.0),
-                    EvalScore(name=BERT_SCORE, value=0.5),
-                    EvalScore(name=DELTA_METEOR_SCORE, value=0.375),
-                    EvalScore(name=DELTA_ROUGE_SCORE, value=0.65),
-                    EvalScore(name=DELTA_BERT_SCORE, value=0.25),
-                ],
-                config=SummarizationAccuracySemanticRobustnessConfig(
-                    num_perturbations=2, perturbation_type=WHITESPACE_ADD_REMOVE
-                ),
-            ),
-        ],
-    )
-    @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.ray.get")
-    @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.SummarizationAccuracyActor")
-    def test_semantic_robustness_evaluate_sample(self, summarization_accuracy_actor_class, ray_get, test_case):
-        """
-        GIVEN valid inputs
-        WHEN SummarizationAccuracySemanticRobustness.evaluate_sample is called
-        THEN correct List of EvalScores is returned
-        """
-        model = MagicMock()
-        model.predict.side_effect = [
-            (test_case.original_model_output,),
-            (test_case.perturbed_model_output_1,),
-            (test_case.perturbed_model_output_2,),
-        ]
-
-        evaluate_sample_invocation_results = [
-            test_case.sa_eval_score_original,
-            test_case.sa_eval_score_perturbed_1,
-            test_case.sa_eval_score_perturbed_2,
-        ]
-
-        ray_get.side_effect = evaluate_sample_invocation_results
-        summarization_accuracy_actor = MagicMock()
-        summarization_accuracy_actor_class.return_value = summarization_accuracy_actor
-
-        eval_algorithm = SummarizationAccuracySemanticRobustness(test_case.config)
-        assert (
-            eval_algorithm.evaluate_sample(test_case.model_input, test_case.target_output, model)
-            == test_case.expected_response
-        )
-
-    @pytest.mark.parametrize(
-        "test_case",
-        [
-            TestCaseSummarizationAccuracySemanticRobustnessEvaluateSample(
-                model_input="Cake is so delicious, I really like cake. I want to open a bakery when I grow up.",
-                target_output="I like cake.",
-                original_model_output="Some model output.",
-                perturbed_model_output_1="Some other model output.",
-                perturbed_model_output_2="Some different model output.",
-                sa_eval_score_original=[
-                    EvalScore(name=METEOR_SCORE, value=1.0),
-                    EvalScore(name=ROUGE_SCORE, value=1.0),
-                    EvalScore(name=BERT_SCORE, value=0.5),
-                ],
-                sa_eval_score_perturbed_1=[
-                    EvalScore(name=METEOR_SCORE, value=0.75),
-                    EvalScore(name=ROUGE_SCORE, value=0.5),
-                    EvalScore(name=BERT_SCORE, value=1.0),
-                ],
-                sa_eval_score_perturbed_2=[
-                    EvalScore(name=METEOR_SCORE, value=0.5),
-                    EvalScore(name=ROUGE_SCORE, value=0.2),
-                    EvalScore(name=BERT_SCORE, value=0.5),
-                ],
-                expected_response=[
-                    EvalScore(name=METEOR_SCORE, value=1.0),
-                    EvalScore(name=ROUGE_SCORE, value=1.0),
-                    EvalScore(name=BERT_SCORE, value=0.5),
-                    EvalScore(name=DELTA_METEOR_SCORE, value=0.375),
-                    EvalScore(name=DELTA_ROUGE_SCORE, value=0.65),
-                    EvalScore(name=DELTA_BERT_SCORE, value=0.25),
-                ],
-                config=SummarizationAccuracySemanticRobustnessConfig(num_perturbations=2),
-            ),
-        ],
-    )
-    @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.ray.get")
-    @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.SummarizationAccuracyActor")
-    def test_semantic_robustness_evaluate_sample_with_model_output(
-        self, summarization_accuracy_actor_class, ray_get, test_case
-    ):
-        """
-        GIVEN valid inputs with model_output
-        WHEN SummarizationAccuracySemanticRobustness.evaluate_sample is called
-        THEN correct List of EvalScores is returned
-        """
-        model = MagicMock()
-        model.predict.side_effect = [
-            (test_case.perturbed_model_output_1,),
-            (test_case.perturbed_model_output_2,),
-        ]
-
-        evaluate_sample_invocation_results = [
-            test_case.sa_eval_score_original,
-            test_case.sa_eval_score_perturbed_1,
-            test_case.sa_eval_score_perturbed_2,
-        ]
-        ray_get.side_effect = evaluate_sample_invocation_results
-        summarization_accuracy_actor = MagicMock()
-        summarization_accuracy_actor_class.return_value = summarization_accuracy_actor
-
-        eval_algorithm = SummarizationAccuracySemanticRobustness(test_case.config)
-        assert (
-            eval_algorithm.evaluate_sample(
-                model_input=test_case.model_input,
-                model=model,
-                target_output=test_case.target_output,
-                model_output=test_case.original_model_output,
-            )
-            == test_case.expected_response
-        )
-        assert model.predict.call_count == 2
-
-    @pytest.mark.parametrize(
-        "test_case",
-        [
-            TestCaseSummarizationAccuracySemanticRobustnessEvaluateSampleInvalid(
-                model_input="I like cake.",
-                target_output="I like cake.",
-                model=None,
-                expected_error_message="Missing required input: model i.e. ModelRunner, for SummarizationAccuracySemanticRobustness "
-                "evaluate_sample",
-                config=SummarizationAccuracySemanticRobustnessConfig(num_perturbations=2),
-            ),
-            TestCaseSummarizationAccuracySemanticRobustnessEvaluateSampleInvalid(
-                model_input=None,
-                target_output="I like cake.",
-                model=MagicMock(),
-                expected_error_message="Missing required input: model_input, for SummarizationAccuracySemanticRobustness "
-                "evaluate_sample",
-                config=SummarizationAccuracySemanticRobustnessConfig(num_perturbations=2),
-            ),
-            TestCaseSummarizationAccuracySemanticRobustnessEvaluateSampleInvalid(
-                model_input="I like cake.",
-                target_output=None,
-                model=MagicMock(),
-                expected_error_message="Missing required input: target_output, for SummarizationAccuracySemanticRobustness "
-                "evaluate_sample",
-                config=SummarizationAccuracySemanticRobustnessConfig(num_perturbations=2),
-            ),
-        ],
-    )
-    def test_semantic_robustness_evaluate_sample_invalid_input(self, test_case):
-        """
-        GIVEN invalid inputs
-        WHEN SummarizationAccuracySemanticRobustness.evaluate_sample is called
-        THEN correct exception with proper message is raised
-        """
-
-        eval_algorithm = SummarizationAccuracySemanticRobustness(test_case.config, summ_acc_actor=MagicMock())
-        with pytest.raises(EvalAlgorithmClientError, match=test_case.expected_error_message):
-            eval_algorithm.evaluate_sample(test_case.model_input, test_case.target_output, test_case.model)
-
-    class TestCaseSemanticRobustnessInvalidConfig(NamedTuple):
+    class TestCaseInvalidConfig(NamedTuple):
         rouge_type: str
         model_type_for_bertscore: str
         perturbation_type: str
@@ -368,22 +45,22 @@ class TestSummarizationAccuracySemanticRobustness:
     @pytest.mark.parametrize(
         "test_case",
         [
-            TestCaseSemanticRobustnessInvalidConfig(
+            TestCaseInvalidConfig(
                 rouge_type="rouge3",
                 model_type_for_bertscore=None,
                 perturbation_type="butter_finger",
-                expected_error_message="Invalid rouge_type: rouge3 requested in SummarizationAccuracyConfig, "
-                "please choose from acceptable values: ['rouge1', 'rouge2', 'rougeL']",
+                expected_error_message="Invalid rouge_type: rouge3 requested in SummarizationAccuracySemanticRobustnessConfig. "
+                "Please choose from acceptable values: ['rouge1', 'rouge2', 'rougeL'].",
             ),
-            TestCaseSemanticRobustnessInvalidConfig(
+            TestCaseInvalidConfig(
                 rouge_type="rouge1",
                 model_type_for_bertscore="distilbert-base-uncased",
                 perturbation_type="butter_finger",
                 expected_error_message="Invalid model_type_for_bertscore: distilbert-base-uncased requested in "
-                "SummarizationAccuracyConfig, please choose from acceptable values: ["
-                "'microsoft/deberta-xlarge-mnli', 'roberta-large-mnli']",
+                "SummarizationAccuracySemanticRobustnessConfig. Please choose from acceptable values: ["
+                "'microsoft/deberta-xlarge-mnli', 'roberta-large-mnli'].",
             ),
-            TestCaseSemanticRobustnessInvalidConfig(
+            TestCaseInvalidConfig(
                 rouge_type="rouge1",
                 model_type_for_bertscore="distilbert-base-uncased",
                 perturbation_type="my_perturb",
@@ -400,321 +77,144 @@ class TestSummarizationAccuracySemanticRobustness:
                 model_type_for_bertscore=test_case.model_type_for_bertscore,
             )
 
-    class TestCaseSummarizationAccuracySemanticRobustnessEvaluate(NamedTuple):
-        input_dataset: Dataset
-        input_dataset_with_generated_model_output: Dataset
-        prompt_template: Optional[str]
-        dataset_config: Optional[DataConfig]
-        expected_response: List[EvalOutput]
-        save_data: bool
-        dataset_with_scores: Dataset
+    @pytest.mark.parametrize("use_ray", [True, False])
+    @pytest.mark.parametrize("perturbation_type", [BUTTER_FINGER, RANDOM_UPPER_CASE, WHITESPACE_ADD_REMOVE])
+    @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.create_shared_resource")
+    def test_init(self, mock_create_shared_resource, perturbation_type, use_ray):
+        """
+        GIVEN valid arguments.
+        WHEN a SummarizationAccuracySemanticRobustness is initialized.
+        THEN its instance attributes are of the correct type and create_shared_resource
+            is called (or not called) as appropriate.
+        """
+        config = SummarizationAccuracySemanticRobustnessConfig(perturbation_type=perturbation_type)
+        sasr = SummarizationAccuracySemanticRobustness(config, use_ray=use_ray)
+        assert isinstance(sasr.perturbation_transform, SEMANTIC_PERTURBATIONS[perturbation_type])
+        if use_ray:
+            mock_create_shared_resource.assert_called_once()
+            assert sasr.bertscore_model == mock_create_shared_resource.return_value
+        else:
+            mock_create_shared_resource.assert_not_called()
+            assert isinstance(sasr.bertscore_model, BertscoreModel)
+
+    class TestCaseEvaluateSample(NamedTuple):
+        original_meteor_score: float
+        original_rouge_score: float
+        original_bert_score: float
+        perturbed_meteor_scores: List[float]
+        perturbed_rouge_scores: List[float]
+        perturbed_bert_scores: List[float]
+        expected_response: List[EvalScore]
 
     @pytest.mark.parametrize(
         "test_case",
         [
-            # Built-in datasets evaluate for dataset without category
-            TestCaseSummarizationAccuracySemanticRobustnessEvaluate(
-                input_dataset=DATASET_NO_CATEGORY,
-                input_dataset_with_generated_model_output=DATASET_NO_CATEGORY_WITH_MODEL_OUTPUT,
-                dataset_config=None,
-                prompt_template=None,
-                save_data=True,
-                dataset_with_scores=DATASET_WITH_SCORES.drop_columns(cols=DatasetColumns.CATEGORY.value.name),
+            TestCaseEvaluateSample(
+                original_meteor_score=1.0,
+                original_rouge_score=1.0,
+                original_bert_score=0.5,
+                perturbed_meteor_scores=[0.75, 0.5],
+                perturbed_rouge_scores=[0.5, 0.2],
+                perturbed_bert_scores=[1.0, 0.5],
                 expected_response=[
-                    EvalOutput(
-                        eval_name="summarization_accuracy_semantic_robustness",
-                        dataset_name=GIGAWORD,
-                        dataset_scores=[
-                            EvalScore(name="rouge", value=0.0),
-                            EvalScore(name="bertscore", value=0.0),
-                            EvalScore(name="meteor", value=0.0),
-                            EvalScore(name="delta_rouge", value=0.0),
-                            EvalScore(name="delta_bertscore", value=0.0),
-                            EvalScore(name="delta_meteor", value=0.0),
-                        ],
-                        prompt_template=BUILT_IN_DATASET_DEFAULT_PROMPT_TEMPLATES[GIGAWORD],
-                        category_scores=None,
-                        output_path="/tmp/eval_results/summarization_accuracy_semantic_robustness_gigaword.jsonl",
-                    ),
-                    EvalOutput(
-                        eval_name="summarization_accuracy_semantic_robustness",
-                        dataset_name=GOV_REPORT,
-                        dataset_scores=[
-                            EvalScore(name="rouge", value=0.0),
-                            EvalScore(name="bertscore", value=0.0),
-                            EvalScore(name="meteor", value=0.0),
-                            EvalScore(name="delta_rouge", value=0.0),
-                            EvalScore(name="delta_bertscore", value=0.0),
-                            EvalScore(name="delta_meteor", value=0.0),
-                        ],
-                        prompt_template=BUILT_IN_DATASET_DEFAULT_PROMPT_TEMPLATES[GOV_REPORT],
-                        category_scores=None,
-                        output_path="/tmp/eval_results/summarization_accuracy_semantic_robustness_gov_report.jsonl",
-                    ),
-                ],
-            ),
-            # Built-in datasets evaluate for dataset with category
-            TestCaseSummarizationAccuracySemanticRobustnessEvaluate(
-                input_dataset=DATASET,
-                input_dataset_with_generated_model_output=DATASET_WITH_MODEL_OUTPUT,
-                dataset_config=None,
-                prompt_template=None,
-                save_data=True,
-                dataset_with_scores=DATASET_WITH_SCORES,
-                expected_response=[
-                    EvalOutput(
-                        eval_name="summarization_accuracy_semantic_robustness",
-                        dataset_name=GIGAWORD,
-                        dataset_scores=[
-                            EvalScore(name="rouge", value=0.0),
-                            EvalScore(name="bertscore", value=0.0),
-                            EvalScore(name="meteor", value=0.0),
-                            EvalScore(name="delta_rouge", value=0.0),
-                            EvalScore(name="delta_bertscore", value=0.0),
-                            EvalScore(name="delta_meteor", value=0.0),
-                        ],
-                        prompt_template=BUILT_IN_DATASET_DEFAULT_PROMPT_TEMPLATES[GIGAWORD],
-                        category_scores=[
-                            CategoryScore(
-                                name="dummy_category_1",
-                                scores=[
-                                    EvalScore(name="rouge", value=0.0),
-                                    EvalScore(name="bertscore", value=0.0),
-                                    EvalScore(name="meteor", value=0.0),
-                                    EvalScore(name="delta_rouge", value=0.0),
-                                    EvalScore(name="delta_bertscore", value=0.0),
-                                    EvalScore(name="delta_meteor", value=0.0),
-                                ],
-                            ),
-                            CategoryScore(
-                                name="dummy_category_2",
-                                scores=[
-                                    EvalScore(name="rouge", value=0.0),
-                                    EvalScore(name="bertscore", value=0.0),
-                                    EvalScore(name="meteor", value=0.0),
-                                    EvalScore(name="delta_rouge", value=0.0),
-                                    EvalScore(name="delta_bertscore", value=0.0),
-                                    EvalScore(name="delta_meteor", value=0.0),
-                                ],
-                            ),
-                        ],
-                        output_path="/tmp/eval_results/summarization_accuracy_semantic_robustness_gigaword.jsonl",
-                    ),
-                    EvalOutput(
-                        eval_name="summarization_accuracy_semantic_robustness",
-                        dataset_name=GOV_REPORT,
-                        dataset_scores=[
-                            EvalScore(name="rouge", value=0.0),
-                            EvalScore(name="bertscore", value=0.0),
-                            EvalScore(name="meteor", value=0.0),
-                            EvalScore(name="delta_rouge", value=0.0),
-                            EvalScore(name="delta_bertscore", value=0.0),
-                            EvalScore(name="delta_meteor", value=0.0),
-                        ],
-                        prompt_template=BUILT_IN_DATASET_DEFAULT_PROMPT_TEMPLATES[GOV_REPORT],
-                        category_scores=[
-                            CategoryScore(
-                                name="dummy_category_1",
-                                scores=[
-                                    EvalScore(name="rouge", value=0.0),
-                                    EvalScore(name="bertscore", value=0.0),
-                                    EvalScore(name="meteor", value=0.0),
-                                    EvalScore(name="delta_rouge", value=0.0),
-                                    EvalScore(name="delta_bertscore", value=0.0),
-                                    EvalScore(name="delta_meteor", value=0.0),
-                                ],
-                            ),
-                            CategoryScore(
-                                name="dummy_category_2",
-                                scores=[
-                                    EvalScore(name="rouge", value=0.0),
-                                    EvalScore(name="bertscore", value=0.0),
-                                    EvalScore(name="meteor", value=0.0),
-                                    EvalScore(name="delta_rouge", value=0.0),
-                                    EvalScore(name="delta_bertscore", value=0.0),
-                                    EvalScore(name="delta_meteor", value=0.0),
-                                ],
-                            ),
-                        ],
-                        output_path="/tmp/eval_results/summarization_accuracy_semantic_robustness_gov_report.jsonl",
-                    ),
-                ],
-            ),
-            # Custom dataset evaluate with input prompt template
-            TestCaseSummarizationAccuracySemanticRobustnessEvaluate(
-                input_dataset=DATASET_NO_CATEGORY,
-                input_dataset_with_generated_model_output=DATASET_NO_CATEGORY_WITH_MODEL_OUTPUT,
-                dataset_config=DataConfig(
-                    dataset_name="my_custom_dataset",
-                    dataset_uri="tba",
-                    dataset_mime_type=MIME_TYPE_JSON,
-                    model_input_location="tba",
-                    target_output_location="tba",
-                    model_output_location=None,
-                    category_location="tba",
-                ),
-                prompt_template="$model_input",
-                save_data=False,
-                dataset_with_scores=DATASET_WITH_SCORES.drop_columns(cols=DatasetColumns.CATEGORY.value.name),
-                expected_response=[
-                    EvalOutput(
-                        eval_name="summarization_accuracy_semantic_robustness",
-                        dataset_name="my_custom_dataset",
-                        dataset_scores=[
-                            EvalScore(name="rouge", value=0.0),
-                            EvalScore(name="bertscore", value=0.0),
-                            EvalScore(name="meteor", value=0.0),
-                            EvalScore(name="delta_rouge", value=0.0),
-                            EvalScore(name="delta_bertscore", value=0.0),
-                            EvalScore(name="delta_meteor", value=0.0),
-                        ],
-                        prompt_template="$model_input",
-                        category_scores=None,
-                        output_path="/tmp/eval_results/summarization_accuracy_semantic_robustness_my_custom_dataset.jsonl",
-                    ),
-                ],
-            ),
-            # Custom dataset evaluate without input prompt template
-            TestCaseSummarizationAccuracySemanticRobustnessEvaluate(
-                input_dataset=DATASET_NO_CATEGORY,
-                input_dataset_with_generated_model_output=DATASET_NO_CATEGORY_WITH_MODEL_OUTPUT,
-                dataset_config=DataConfig(
-                    dataset_name="my_custom_dataset",
-                    dataset_uri="tba",
-                    dataset_mime_type=MIME_TYPE_JSON,
-                    model_input_location="tba",
-                    target_output_location="tba",
-                    model_output_location=None,
-                    category_location="tba",
-                ),
-                prompt_template=None,
-                save_data=False,
-                dataset_with_scores=DATASET_WITH_SCORES.drop_columns(cols=DatasetColumns.CATEGORY.value.name),
-                expected_response=[
-                    EvalOutput(
-                        eval_name="summarization_accuracy_semantic_robustness",
-                        dataset_name="my_custom_dataset",
-                        dataset_scores=[
-                            EvalScore(name="rouge", value=0.0),
-                            EvalScore(name="bertscore", value=0.0),
-                            EvalScore(name="meteor", value=0.0),
-                            EvalScore(name="delta_rouge", value=0.0),
-                            EvalScore(name="delta_bertscore", value=0.0),
-                            EvalScore(name="delta_meteor", value=0.0),
-                        ],
-                        prompt_template=DEFAULT_PROMPT_TEMPLATE,
-                        category_scores=None,
-                        output_path="/tmp/eval_results/summarization_accuracy_semantic_robustness_my_custom_dataset.jsonl",
-                    ),
+                    EvalScore(name=METEOR_SCORE, value=1.0),
+                    EvalScore(name=ROUGE_SCORE, value=1.0),
+                    EvalScore(name=BERT_SCORE, value=0.5),
+                    EvalScore(name=DELTA_METEOR_SCORE, value=0.375),
+                    EvalScore(name=DELTA_ROUGE_SCORE, value=0.65),
+                    EvalScore(name=DELTA_BERT_SCORE, value=0.25),
                 ],
             ),
         ],
     )
-    @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.get_dataset")
-    @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.save_dataset")
-    @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.SummarizationAccuracyActor")
-    @patch.object(SummarizationAccuracySemanticRobustness, "_SummarizationAccuracySemanticRobustness__add_scores")
-    def test_semantic_robustness_evaluate(
+    @patch("fmeval.transforms.semantic_perturbations.RandomUppercase.perturb")
+    @patch("fmeval.transforms.summarization_accuracy_metrics.BertScore.compute_metric")
+    @patch("fmeval.transforms.summarization_accuracy_metrics.RougeScore.compute_metric")
+    @patch("fmeval.transforms.summarization_accuracy_metrics.MeteorScore.compute_metric")
+    def test_semantic_robustness_evaluate_sample(
         self,
-        add_scores,
-        summarization_accuracy_actor_class,
-        save_dataset,
-        get_dataset,
+        mock_meteor_metric,
+        mock_rouge_metric,
+        mock_bert_metric,
+        mock_random_uppercase_perturb,
         test_case,
         config,
     ):
         """
-        GIVEN valid inputs i.e. input data config for a dataset without model_outputs, an input ModelRunner
-            and request to save records with scores
-        WHEN SummarizationAccuracySemanticRobustness evaluate() method is called
-        THEN correct EvalOutput is returned
+        GIVEN a config with perturbation_type = RANDOM_UPPERCASE (wlog).
+        WHEN SummarizationAccuracySemanticRobustness.evaluate_sample is called.
+        THEN the correct list of EvalScores is returned, RandomUppercase.perturb is called,
+            prompts are created from the perturbed model inputs, and the model runner's
+            `predict` method is called on the original prompt (constructed from the
+             original model input) and perturbed prompts (constructed from the perturbed
+             model inputs).
         """
-        add_scores.return_value = test_case.dataset_with_scores
-        get_dataset.return_value = test_case.input_dataset
-        summarization_accuracy_actor_class.return_value = MagicMock()
+        mock_meteor_metric.side_effect = [test_case.original_meteor_score] + test_case.perturbed_meteor_scores
+        mock_rouge_metric.side_effect = [test_case.original_rouge_score] + test_case.perturbed_rouge_scores
+        mock_bert_metric.side_effect = [test_case.original_bert_score] + test_case.perturbed_bert_scores
 
-        eval_algorithm = SummarizationAccuracySemanticRobustness(config)
-        actual_response = eval_algorithm.evaluate(
-            model=MockModelRunner(),
-            dataset_config=test_case.dataset_config,
-            save=test_case.save_data,
-            prompt_template=test_case.prompt_template,
+        mock_random_uppercase_perturb.return_value = ["perturbed input 1", "perturbed input 2"]
+
+        model = Mock()
+        model.predict.side_effect = [("a", None), ("b", None), ("c", None)]
+
+        eval_algorithm = SummarizationAccuracySemanticRobustness(
+            SummarizationAccuracySemanticRobustnessConfig(
+                perturbation_type=RANDOM_UPPER_CASE,
+                num_perturbations=2,
+            ),
+            use_ray=False,
         )
-        assert save_dataset.called == test_case.save_data
-        assert actual_response == test_case.expected_response
+        assert (
+            eval_algorithm.evaluate_sample(
+                model_input="the model input", target_output="unused", model=model, prompt_template="Hi $model_input"
+            )
+            == test_case.expected_response
+        )
+        model.predict.assert_has_calls(
+            [call("Hi the model input"), call("Hi perturbed input 1"), call("Hi perturbed input 2")]
+        )
 
-    class TestCaseSummarizationAccuracySemanticRobustnessEvaluateInvalid(NamedTuple):
-        input_dataset: Dataset
-        dataset_config: Optional[DataConfig]
-        prompt_template: Optional[str]
-        model_provided: bool
-        expected_error_message: str
-
-    @pytest.mark.parametrize(
-        "test_case",
-        [
-            TestCaseSummarizationAccuracySemanticRobustnessEvaluateInvalid(
-                input_dataset=DATASET_NO_CATEGORY,
-                dataset_config=None,
-                prompt_template=None,
-                model_provided=False,
-                expected_error_message="Missing required input: model i.e. ModelRunner, for SummarizationAccuracySemanticRobustness "
-                "evaluate method",
-            ),
-            TestCaseSummarizationAccuracySemanticRobustnessEvaluateInvalid(
-                input_dataset=DATASET_NO_CATEGORY.drop_columns(cols=[DatasetColumns.MODEL_INPUT.value.name]),
-                dataset_config=DataConfig(
-                    dataset_name="my_custom_dataset",
-                    dataset_uri="tba",
-                    dataset_mime_type=MIME_TYPE_JSON,
-                    model_input_location="tba",
-                    target_output_location="tba",
-                    model_output_location=None,
-                    category_location="tba",
-                ),
-                prompt_template=None,
-                model_provided=True,
-                expected_error_message="Missing required column: model_input, for evaluate() method",
-            ),
-            TestCaseSummarizationAccuracySemanticRobustnessEvaluateInvalid(
-                input_dataset=DATASET_NO_CATEGORY.drop_columns(cols=[DatasetColumns.TARGET_OUTPUT.value.name]),
-                dataset_config=DataConfig(
-                    dataset_name="my_custom_dataset",
-                    dataset_uri="tba",
-                    dataset_mime_type=MIME_TYPE_JSON,
-                    model_input_location="tba",
-                    target_output_location="tba",
-                    model_output_location=None,
-                    category_location="tba",
-                ),
-                prompt_template=None,
-                model_provided=True,
-                expected_error_message="Missing required column: target_output, for evaluate() method",
-            ),
-        ],
+    @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.get_eval_results_path")
+    @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.evaluate_dataset")
+    @patch(
+        "fmeval.eval_algorithms.summarization_accuracy_semantic_robustness."
+        "SummarizationAccuracySemanticRobustness.build_pipeline"
     )
-    @patch("fmeval.model_runners.model_runner.ModelRunner")
-    @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.get_dataset")
-    @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.SummarizationAccuracyActor")
-    def test_semantic_robustness_evaluate_invalid_input(
-        self,
-        summarization_accuracy_actor_class,
-        get_dataset,
-        model,
-        test_case,
-        config,
+    @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.BertscoreModel")
+    def test_evaluate(
+        self, mock_bertscore_model_cls, mock_build_pipeline, mock_evaluate_dataset, mock_get_results_path
     ):
         """
-        GIVEN invalid inputs
-        WHEN SummarizationAccuracySemanticRobustness evaluate is called
-        THEN correct exception with proper message is raised
+        GIVEN a SummarizationAccuracy instance whose `use_ray` attribute is True.
+        WHEN its evaluate method is called with valid arguments.
+        THEN `util.evaluate_dataset` is called with the correct arguments.
         """
-        summarization_accuracy_actor_class.return_value = MagicMock()
-        eval_algorithm = SummarizationAccuracySemanticRobustness(config)
-        get_dataset.return_value = test_case.input_dataset
-        if not test_case.model_provided:
-            model = None
-        with pytest.raises(EvalAlgorithmClientError, match=re.escape(test_case.expected_error_message)):
-            eval_algorithm.evaluate(
-                model=model, dataset_config=test_case.dataset_config, prompt_template=test_case.prompt_template
-            )
+        mock_build_pipeline.return_value = Mock()
+        mock_get_results_path.return_value = "/path/to/results"
+        model_runner = Mock()
+        dataset_config = Mock()
+
+        sasr = SummarizationAccuracySemanticRobustness(use_ray=False)
+        output = sasr.evaluate(
+            model=model_runner,
+            dataset_config=dataset_config,
+            prompt_template="Summarize $model_input, please.",
+            num_records=162,
+            save=True,
+        )
+
+        mock_evaluate_dataset.assert_called_once_with(
+            dataset_config=dataset_config,
+            pipeline=mock_build_pipeline.return_value,
+            eval_name=sasr.eval_name,
+            metric_names=ORIGINAL_SCORES + DELTA_SCORES,
+            required_columns=[DatasetColumns.MODEL_INPUT.value.name, DatasetColumns.TARGET_OUTPUT.value.name],
+            eval_results_path="/path/to/results",
+            model=model_runner,
+            prompt_template="Summarize $model_input, please.",
+            num_records=162,
+            save=True,
+        )
+        mock_build_pipeline.assert_called_with(model_runner, "Summarize $model_input, please.", use_ray=True)
+        assert output == [mock_evaluate_dataset.return_value]

--- a/test/unit/eval_algorithms/test_summarization_accuracy_semantic_robustness.py
+++ b/test/unit/eval_algorithms/test_summarization_accuracy_semantic_robustness.py
@@ -189,7 +189,7 @@ class TestSummarizationAccuracySemanticRobustness:
     @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.create_shared_resource")
     @patch(
         "fmeval.eval_algorithms.summarization_accuracy_semantic_robustness."
-        "SummarizationAccuracySemanticRobustness.build_pipeline"
+        "SummarizationAccuracySemanticRobustness._build_pipeline"
     )
     @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.get_dataset")
     @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.get_dataset_configs")
@@ -250,6 +250,10 @@ class TestSummarizationAccuracySemanticRobustness:
             agg_method=MEAN,
             save=True,
         )
-        mock_build_pipeline.assert_called_with(model_runner, test_case.dataset_prompt_template)
+        mock_build_pipeline.assert_called_once_with(
+            model_runner,
+            test_case.dataset_prompt_template,
+            mock_create_shared_resource.return_value,
+        )
         mock_cleanup_shared_resource.assert_called_once_with(mock_create_shared_resource.return_value)
         assert output == [mock_evaluate_dataset.return_value]

--- a/test/unit/eval_algorithms/test_util.py
+++ b/test/unit/eval_algorithms/test_util.py
@@ -7,8 +7,8 @@ import pytest
 import ray
 
 from collections import OrderedDict
-from typing import Any, Dict, List, NamedTuple, Optional
-from unittest.mock import MagicMock, Mock, patch
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple
+from unittest.mock import Mock, call, patch
 from ray.data import Dataset
 
 from fmeval.constants import (
@@ -16,6 +16,7 @@ from fmeval.constants import (
     EVAL_OUTPUT_RECORDS_BATCH_SIZE,
     PARALLELIZATION_FACTOR,
     MEAN,
+    NUM_ROWS_DETERMINISTIC,
 )
 from fmeval.eval_algorithms import (
     EvalAlgorithm,
@@ -47,7 +48,6 @@ from fmeval.eval_algorithms.util import (
     generate_mean_delta_score,
     verify_model_determinism,
     get_dataset_configs,
-    compute_and_aggregate_metrics,
     aggregate_evaluation_scores,
     create_model_invocation_pipeline,
     evaluate_dataset,
@@ -559,128 +559,121 @@ def test_generate_mean_delta_score(test_case):
 
 
 class TestCaseVerifyModelDeterminism(NamedTuple):
-    dataset: Dataset
-    prompt_column_name: str
-    expect_num_predict_calls: int
-    predict_result: List
-    expect_response: bool
+    dataset: List[Dict]
+    predict_responses: List[Tuple]
+    expected_num_predict_calls: int
+    expected_result: bool
 
 
 @pytest.mark.parametrize(
     "test_case",
     [
-        # dataset fewer than 5 rows
+        # Dataset contains > NUM_ROWS_DETERMINISTIC rows, model is deterministic
         TestCaseVerifyModelDeterminism(
-            dataset=ray.data.from_items(
-                [
-                    {
-                        DatasetColumns.MODEL_INPUT.value.name: "Summarize: Cake is so delicious, I really like cake. I want to open a bakery when I grow up.",
-                        "another prompt column": "Cake is so delicious, I really like cake. I want to open a bakery when I grow up.",
-                        DatasetColumns.TARGET_OUTPUT.value.name: "I like cake.",
-                    },
-                    {
-                        DatasetColumns.MODEL_INPUT.value.name: "Summarize: The art metropolis of Berlin inspires locals and visitors with its famous "
-                        "museum landscape and numerous UNESCO World Heritage sites."
-                        " It is also an international exhibition venue. "
-                        "You will find a selection of current and upcoming exhibitions here.",
-                        "another prompt column": "Summarize: The art metropolis of Berlin inspires locals and visitors with its famous "
-                        "museum landscape and numerous UNESCO World Heritage sites."
-                        " It is also an international exhibition venue. "
-                        "You will find a selection of current and upcoming exhibitions here.",
-                        DatasetColumns.TARGET_OUTPUT.value.name: "Berlin: an art metropolis.",
-                    },
-                ]
-            ),
-            predict_result=[("model output 1",), ("model output 1",), ("model output 2",), ("model output 2",)],
-            expect_num_predict_calls=4,
-            prompt_column_name="another prompt column",
-            expect_response=True,
-        ),
-        # only test first 5 rows
-        TestCaseVerifyModelDeterminism(
-            dataset=ray.data.from_items(
-                [
-                    {
-                        DatasetColumns.PROMPT.value.name: "Answer: What is the capital of Italy?",
-                        DatasetColumns.TARGET_OUTPUT.value.name: "Rome",
-                    },
-                    {
-                        DatasetColumns.PROMPT.value.name: "Answer: When did Argentina win the FIFA World Cup?",
-                        DatasetColumns.TARGET_OUTPUT.value.name: "1978<OR>1986<OR>2022.",
-                    },
-                    {
-                        DatasetColumns.PROMPT.value.name: "Answer: What is the capital of England?",
-                        DatasetColumns.TARGET_OUTPUT.value.name: "London",
-                    },
-                    {
-                        DatasetColumns.PROMPT.value.name: "Answer: What is the color of blood?",
-                        DatasetColumns.TARGET_OUTPUT.value.name: "Red",
-                    },
-                    {
-                        DatasetColumns.PROMPT.value.name: "Answer: Who directed Pulp Fiction?",
-                        DatasetColumns.TARGET_OUTPUT.value.name: "Quentin Tarantino",
-                    },
-                    {
-                        DatasetColumns.PROMPT.value.name: "Answer: When did Argentina win the FIFA World Cup?",
-                        DatasetColumns.TARGET_OUTPUT.value.name: "1978<OR>1986<OR>2022",
-                    },
-                ]
-            ),
-            predict_result=[
-                ("model output 1",),
-                ("model output 1",),
-                ("model output 2",),
-                ("model output 2",),
-                ("model output 2",),
-                ("model output 2",),
-                ("model output 4",),
-                ("model output 4",),
-                ("model output 5",),
-                ("model output 5",),
+            dataset=[
+                {
+                    DatasetColumns.MODEL_INPUT.value.name: "What is the capital of Italy?",
+                    DatasetColumns.TARGET_OUTPUT.value.name: "Rome",
+                },
+                {
+                    DatasetColumns.MODEL_INPUT.value.name: "When did Argentina win the FIFA World Cup?",
+                    DatasetColumns.TARGET_OUTPUT.value.name: "1978<OR>1986<OR>2022.",
+                },
+                {
+                    DatasetColumns.MODEL_INPUT.value.name: "What is the capital of England?",
+                    DatasetColumns.TARGET_OUTPUT.value.name: "London",
+                },
+                {
+                    DatasetColumns.MODEL_INPUT.value.name: "What is the color of blood?",
+                    DatasetColumns.TARGET_OUTPUT.value.name: "Red",
+                },
+                {
+                    DatasetColumns.MODEL_INPUT.value.name: "Who directed Pulp Fiction?",
+                    DatasetColumns.TARGET_OUTPUT.value.name: "Quentin Tarantino",
+                },
+                {
+                    DatasetColumns.MODEL_INPUT.value.name: "When did Argentina win the FIFA World Cup?",
+                    DatasetColumns.TARGET_OUTPUT.value.name: "1978<OR>1986<OR>2022",
+                },
             ],
-            expect_num_predict_calls=10,
-            prompt_column_name=DatasetColumns.PROMPT.value.name,
-            expect_response=True,
+            predict_responses=[
+                ("model output 1", None),
+                ("model output 1", None),
+                ("model output 2", None),
+                ("model output 2", None),
+                ("model output 2", None),
+                ("model output 2", None),
+                ("model output 4", None),
+                ("model output 4", None),
+                ("model output 5", None),
+                ("model output 5", None),
+            ],
+            expected_num_predict_calls=10,
+            expected_result=True,
         ),
-        # dataset fewer than 5 rows
+        # Dataset contains fewer than NUM_ROWS_DETERMINISTIC rows, model is deterministic
         TestCaseVerifyModelDeterminism(
-            dataset=ray.data.from_items(
-                [
-                    {
-                        DatasetColumns.PROMPT.value.name: "Answer: What is the capital of Italy?",
-                        DatasetColumns.TARGET_OUTPUT.value.name: "Rome",
-                    },
-                    {
-                        DatasetColumns.PROMPT.value.name: "Answer: When did Argentina win the FIFA World Cup?",
-                        DatasetColumns.TARGET_OUTPUT.value.name: "1978<OR>1986<OR>2022.",
-                    },
-                ]
-            ),
-            predict_result=[
+            dataset=[
+                {
+                    DatasetColumns.MODEL_INPUT.value.name: "What is the capital of Italy?",
+                    DatasetColumns.TARGET_OUTPUT.value.name: "Rome",
+                },
+                {
+                    DatasetColumns.MODEL_INPUT.value.name: "When did Argentina win the FIFA World Cup?",
+                    DatasetColumns.TARGET_OUTPUT.value.name: "1978<OR>1986<OR>2022.",
+                },
+            ],
+            predict_responses=[
+                ("model output 1", None),
+                ("model output 1", None),
+                ("model output 2", None),
+                ("model output 2", None),
+            ],
+            expected_num_predict_calls=4,
+            expected_result=True,
+        ),
+        # Dataset contains fewer than NUM_ROWS_DETERMINISTIC rows, model is not deterministic
+        TestCaseVerifyModelDeterminism(
+            dataset=[
+                {
+                    DatasetColumns.MODEL_INPUT.value.name: "What is the capital of Italy?",
+                    DatasetColumns.TARGET_OUTPUT.value.name: "Rome",
+                },
+                {
+                    DatasetColumns.MODEL_INPUT.value.name: "When did Argentina win the FIFA World Cup?",
+                    DatasetColumns.TARGET_OUTPUT.value.name: "1978<OR>1986<OR>2022.",
+                },
+            ],
+            predict_responses=[
                 ("model output 1",),
                 ("different model output 1",),
-                ("model output 2",),
-                ("different model output 2",),
             ],
-            expect_num_predict_calls=2,
-            prompt_column_name=DatasetColumns.PROMPT.value.name,
-            expect_response=False,
+            expected_num_predict_calls=2,
+            expected_result=False,
         ),
     ],
 )
 def test_verify_model_determinism(test_case):
     """
-    GIVEN a deterministic model and other inputs
-    WHEN verify_model_determinism is called
-    THEN no Exception raised
+    GIVEN a model.
+    WHEN verify_model_determinism is called.
+    THEN the correct result is returned.
     """
-    model = MagicMock()
-    model.predict.side_effect = test_case.predict_result
+    model = Mock()
+    model.predict.side_effect = test_case.predict_responses
     result = verify_model_determinism(
-        model=model, dataset=test_case.dataset, prompt_column_name=test_case.prompt_column_name
+        model=model,
+        dataset=ray.data.from_items(test_case.dataset),
+        prompt_template="Answer: $model_input",
+        model_input_column_name=DatasetColumns.MODEL_INPUT.value.name,
     )
-    assert model.predict.call_count == test_case.expect_num_predict_calls
-    assert result == test_case.expect_response
+    assert model.predict.call_count == test_case.expected_num_predict_calls
+    assert result == test_case.expected_result
+    if test_case.expected_result:
+        expected_calls = []
+        for row in test_case.dataset[:NUM_ROWS_DETERMINISTIC]:
+            expected_calls += [call(f"Answer: {row[DatasetColumns.MODEL_INPUT.value.name]}")] * 2
+        model.predict.assert_has_calls(expected_calls)
 
 
 def test_get_dataset_configs_custom_dataset():
@@ -815,56 +808,96 @@ def test_model_invocation_pipeline():
     assert get_outputs.model_runner == model
 
 
-@pytest.mark.parametrize("save", [True, False])
+class TestCaseEvaluateDatasetWithModel(NamedTuple):
+    user_provided_prompt_template: Optional[str]
+    dataset_prompt_template: Optional[str]
+    save: bool
+    agg_method: str = MEAN
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCaseEvaluateDatasetWithModel(
+            user_provided_prompt_template=None,
+            dataset_prompt_template="$model_input",
+            save=True,
+        ),
+        TestCaseEvaluateDatasetWithModel(
+            user_provided_prompt_template="Do something with $model_input",
+            dataset_prompt_template="Do something with $model_input",
+            save=False,
+        ),
+    ],
+)
 @patch("fmeval.eval_algorithms.util.generate_output_dataset_path")
 @patch("fmeval.eval_algorithms.util.save_dataset")
 @patch("fmeval.eval_algorithms.util.aggregate_evaluation_scores")
-def test_compute_and_aggregate_metrics(mock_aggregate, mock_save, mock_generate_output_path, save):
+@patch("fmeval.eval_algorithms.util.TransformPipeline")
+@patch("fmeval.eval_algorithms.util.create_model_invocation_pipeline")
+def test_evaluate_dataset_with_model(
+    mock_create_invocation_pipeline,
+    mock_transform_pipeline_cls,
+    mock_aggregate,
+    mock_save,
+    mock_generate_output_path,
+    test_case,
+):
     """
-    GIVEN valid arguments.
-    WHEN compute_and_aggregate_metrics is called.
-    THEN expected function calls are made and the correct EvalOutput is returned.
+    GIVEN valid arguments and a `model` argument that is not None.
+    WHEN `evaluate_dataset` is called.
+    THEN a model invocation pipeline (created using `model`) is prepended
+        to the input pipeline and the correct EvalOutput is returned.
     """
+    mock_create_invocation_pipeline.return_value = Mock()
+    # The pipeline that has the GeneratePrompt and GetModelOutputs Transforms prepended.
+    final_pipeline = Mock()
+    mock_transform_pipeline_cls.return_value = final_pipeline
+    final_pipeline.execute = Mock()
+
     mock_aggregate.return_value = DATASET_SCORES, CATEGORY_SCORES
-    pipeline = Mock()
-    pipeline.execute = Mock(return_value=Mock())
     mock_generate_output_path.return_value = "path/to/output/dataset"
 
-    actual_eval_output = compute_and_aggregate_metrics(
-        pipeline=pipeline,
-        dataset=Mock(),
+    input_dataset = Mock()
+    input_pipeline = Mock()
+    model_runner = Mock()
+
+    eval_output = evaluate_dataset(
+        dataset=input_dataset,
+        pipeline=input_pipeline,
         dataset_name="my_dataset",
         eval_name="MyEvalAlgo",
         metric_names=[SCORE_1, SCORE_2],
         eval_results_path="/path/to/eval_results",
-        prompt_template="Do something with $model_input",
-        save=save,
+        model=model_runner,
+        prompt_template=test_case.user_provided_prompt_template,
+        save=test_case.save,
     )
 
+    mock_create_invocation_pipeline.assert_called_once_with(model_runner, test_case.dataset_prompt_template)
+    mock_transform_pipeline_cls.assert_called_once_with([mock_create_invocation_pipeline.return_value, input_pipeline])
+    final_pipeline.execute.assert_called_once_with(input_dataset)
     mock_aggregate.assert_called_once_with(
-        pipeline.execute.return_value,
+        final_pipeline.execute.return_value,
         [SCORE_1, SCORE_2],
-        agg_method=MEAN,
+        agg_method=test_case.agg_method,
     )
-
     mock_generate_output_path.assert_called_once_with(
         path_to_parent_dir="/path/to/eval_results",
         eval_name="MyEvalAlgo",
         dataset_name="my_dataset",
     )
-
-    assert actual_eval_output == EvalOutput(
+    assert eval_output == EvalOutput(
         eval_name="MyEvalAlgo",
         dataset_name="my_dataset",
-        prompt_template="Do something with $model_input",
+        prompt_template=test_case.dataset_prompt_template,
         dataset_scores=DATASET_SCORES,
         category_scores=CATEGORY_SCORES,
         output_path="path/to/output/dataset",
     )
-
-    if save:
+    if test_case.save:
         mock_save.assert_called_once_with(
-            dataset=pipeline.execute.return_value,
+            dataset=final_pipeline.execute.return_value,
             score_names=[SCORE_1, SCORE_2],
             path="path/to/output/dataset",
         )
@@ -872,121 +905,89 @@ def test_compute_and_aggregate_metrics(mock_aggregate, mock_save, mock_generate_
         mock_save.assert_not_called()
 
 
-class TestCaseEvaluateDataset(NamedTuple):
-    user_provided_prompt_template: Optional[str]
-    dataset_prompt_template: str
-    model_provided: bool
-    save: bool
-
-
 @pytest.mark.parametrize(
     "test_case",
     [
-        TestCaseEvaluateDataset(
-            user_provided_prompt_template="Answer: $model_input",
-            dataset_prompt_template="Answer: $model_input",
-            model_provided=True,
-            save=True,
-        ),
-        TestCaseEvaluateDataset(
-            user_provided_prompt_template=None,
-            dataset_prompt_template="$model_input",
-            model_provided=True,
-            save=False,
-        ),
-        TestCaseEvaluateDataset(
+        TestCaseEvaluateDatasetWithModel(
             user_provided_prompt_template=None,
             dataset_prompt_template=None,
-            model_provided=False,
-            save=False,
+            save=True,
         ),
     ],
 )
-@patch("fmeval.eval_algorithms.util.compute_and_aggregate_metrics")
-@patch("fmeval.eval_algorithms.util.create_model_invocation_pipeline")
+@patch("fmeval.eval_algorithms.util.generate_output_dataset_path")
+@patch("fmeval.eval_algorithms.util.save_dataset")
+@patch("fmeval.eval_algorithms.util.aggregate_evaluation_scores")
 @patch("fmeval.eval_algorithms.util.TransformPipeline")
-@patch("fmeval.eval_algorithms.util.validate_dataset")
-@patch("fmeval.eval_algorithms.util.get_dataset")
-def test_evaluate_dataset(
-    mock_get_dataset,
-    mock_validate_dataset,
-    mock_transform_pipeline_cls,
+@patch("fmeval.eval_algorithms.util.create_model_invocation_pipeline")
+def test_evaluate_dataset_no_model(
     mock_create_invocation_pipeline,
-    mock_compute_and_aggregate,
+    mock_transform_pipeline_cls,
+    mock_aggregate,
+    mock_save,
+    mock_generate_output_path,
     test_case,
 ):
     """
-    GIVEN a valid dataset config and valid combinations of a ModelRunner and prompt template.
-        (The invalid combination is when ModelRunner is None, but a non-null prompt template
-        is provided. This case is handled in another test).
-    WHEN the `evaluate_dataset` function is called.
-    THEN all expected functions are called with the correct arguments and an
-        EvalOutput generated by `compute_and_aggregate_metrics` is returned.
+    GIVEN valid arguments and a `model` argument that is not None.
+    WHEN `evaluate_dataset` is called.
+    THEN the pipeline that gets executed is the input pipeline (i.e.
+        no model invocation transforms are prepended)
+        and the correct EvalOutput is returned.
     """
-    # Inputs to evaluate_dataset
-    dataset_config = Mock()
-    pipeline = Mock()
-    model = Mock()
+    mock_aggregate.return_value = DATASET_SCORES, CATEGORY_SCORES
+    mock_generate_output_path.return_value = "path/to/output/dataset"
 
-    mock_get_dataset.return_value = Mock()
-    mock_create_invocation_pipeline.return_value = Mock()
-    # The pipeline that is passed to `compute_and_aggregate_metrics`
-    # (which has the GeneratePrompt and GetModelOutputs Transforms prepended).
-    mock_transform_pipeline_cls.return_value = Mock()
-
-    expected_eval_output = EvalOutput(
-        eval_name="my_eval",
-        dataset_name="my_dataset_1",
-        dataset_scores=[EvalScore(name=SCORE_1, value=0.162), EvalScore(name=SCORE_2, value=0.189)],
-    )
-    mock_compute_and_aggregate.return_value = expected_eval_output
+    input_dataset = Mock()
+    input_dataset.columns = Mock(return_value=[DatasetColumns.MODEL_OUTPUT.value.name])
+    input_pipeline = Mock()
 
     eval_output = evaluate_dataset(
-        dataset_config=dataset_config,
+        dataset=input_dataset,
+        pipeline=input_pipeline,
+        dataset_name="my_dataset",
         eval_name="MyEvalAlgo",
-        pipeline=pipeline,
         metric_names=[SCORE_1, SCORE_2],
-        required_columns=["required_1", "required_2"],
-        eval_results_path="/path/to/eval/results",
-        model=model if test_case.model_provided else None,
-        prompt_template=test_case.user_provided_prompt_template,
-        num_records=200,
+        eval_results_path="/path/to/eval_results",
+        model=None,
+        prompt_template=None,
         save=test_case.save,
     )
 
-    mock_get_dataset.assert_called_once_with(dataset_config, 200)
-    mock_validate_dataset.assert_called_once_with(mock_get_dataset.return_value, ["required_1", "required_2"])
-
-    if test_case.model_provided:
-        mock_create_invocation_pipeline.assert_called_once_with(model, test_case.dataset_prompt_template)
-        mock_transform_pipeline_cls.assert_called_once_with([mock_create_invocation_pipeline.return_value, pipeline])
-    else:
-        mock_create_invocation_pipeline.assert_not_called()
-        mock_transform_pipeline_cls.assert_not_called()
-
-    mock_compute_and_aggregate.assert_called_once_with(
-        pipeline=(mock_transform_pipeline_cls.return_value if test_case.model_provided else pipeline),
-        dataset=mock_get_dataset.return_value,
-        dataset_name=dataset_config.dataset_name,
+    mock_create_invocation_pipeline.assert_not_called()
+    mock_transform_pipeline_cls.assert_not_called()
+    input_pipeline.execute.assert_called_once_with(input_dataset)
+    mock_aggregate.assert_called_once_with(
+        input_pipeline.execute.return_value,
+        [SCORE_1, SCORE_2],
+        agg_method=test_case.agg_method,
+    )
+    mock_generate_output_path.assert_called_once_with(
+        path_to_parent_dir="/path/to/eval_results",
         eval_name="MyEvalAlgo",
-        metric_names=[SCORE_1, SCORE_2],
-        eval_results_path="/path/to/eval/results",
+        dataset_name="my_dataset",
+    )
+    assert eval_output == EvalOutput(
+        eval_name="MyEvalAlgo",
+        dataset_name="my_dataset",
         prompt_template=test_case.dataset_prompt_template,
-        agg_method=MEAN,
-        save=test_case.save,
+        dataset_scores=DATASET_SCORES,
+        category_scores=CATEGORY_SCORES,
+        output_path="path/to/output/dataset",
     )
+    if test_case.save:
+        mock_save.assert_called_once_with(
+            dataset=input_pipeline.execute.return_value,
+            score_names=[SCORE_1, SCORE_2],
+            path="path/to/output/dataset",
+        )
+    else:
+        mock_save.assert_not_called()
 
-    assert eval_output == expected_eval_output
 
-
-@patch("fmeval.eval_algorithms.util.validate_dataset")
-@patch("fmeval.eval_algorithms.util.get_dataset")
-def test_evaluate_dataset_invalid_args(
-    mock_get_dataset,
-    mock_validate_dataset,
-):
+def test_evaluate_dataset_with_prompt_template_without_model():
     """
-    GIVEN a dataset config, no ModelRunner, and a prompt template.
+    GIVEN invalid arguments: a non-Null prompt template, but no model.
     WHEN the `evaluate_dataset` function is called.
     THEN the correct exception is raised.
     """
@@ -994,14 +995,39 @@ def test_evaluate_dataset_invalid_args(
     err_msg = "A model must be provided as well if the provided prompt template is not None."
     with pytest.raises(EvalAlgorithmClientError, match=err_msg):
         evaluate_dataset(
-            dataset_config=Mock(),
+            dataset=Mock(),
             pipeline=Mock(),
+            dataset_name="my_dataset",
             eval_name="MyEvalAlgo",
             metric_names=[SCORE_1, SCORE_2],
-            required_columns=["required_1", "required_2"],
             eval_results_path="/path/to/eval/results",
             model=None,
             prompt_template=prompt_template,
-            num_records=200,
-            save=False,
+        )
+
+
+def test_evaluate_dataset_no_model_no_model_output_column():
+    """
+    GIVEN invalid arguments: a `model` that is None and a dataset
+        without a model output column.
+    WHEN the `evaluate_dataset` function is called.
+    THEN the correct exception is raised.
+    """
+    mock_dataset = Mock()
+    mock_dataset.columns = Mock(return_value=[])
+    err_msg = (
+        "evaluate_dataset has been given a dataset with no model output column "
+        "and no ModelRunner to obtain outputs from. Please either provide a model "
+        "or use a dataset that contains model outputs already."
+    )
+    with pytest.raises(EvalAlgorithmClientError, match=err_msg):
+        evaluate_dataset(
+            dataset=mock_dataset,
+            pipeline=Mock(),
+            dataset_name="my_dataset",
+            eval_name="MyEvalAlgo",
+            metric_names=[SCORE_1, SCORE_2],
+            eval_results_path="/path/to/eval/results",
+            model=None,
+            prompt_template=None,
         )

--- a/test/unit/eval_algorithms/test_util.py
+++ b/test/unit/eval_algorithms/test_util.py
@@ -55,7 +55,6 @@ from fmeval.eval_algorithms.util import (
 from fmeval.exceptions import EvalAlgorithmInternalError, EvalAlgorithmClientError
 from fmeval.transforms.common import GeneratePrompt, GetModelOutputs
 from fmeval.util import camel_to_snake, get_num_actors
-from fmeval.eval_algorithms.util import get_bert_score
 
 BERTSCORE_DUMMY_VALUE = (
     0.5  # we don't evaluate the real BERTScore inside unit tests because of runtime, so we hardcode a dummy value
@@ -682,16 +681,6 @@ def test_verify_model_determinism(test_case):
     )
     assert model.predict.call_count == test_case.expect_num_predict_calls
     assert result == test_case.expect_response
-
-
-@pytest.mark.parametrize(
-    "target_output,model_output",
-    [("I like cake.", "I like cake."), ("Berlin: Art, Heritage, Exhibitions Hub.", "Berlin: an art metropolis.")],
-)
-@patch("fmeval.eval_algorithms.util.ray.get")
-def test_get_bert_score(mock_ray_get, target_output, model_output):
-    mock_ray_get.return_value = BERTSCORE_DUMMY_VALUE
-    assert BERTSCORE_DUMMY_VALUE == get_bert_score(target_output, model_output, helper_model=MagicMock())
 
 
 def test_get_dataset_configs_custom_dataset():

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -6,7 +6,14 @@ from unittest.mock import patch, Mock
 
 from fmeval.constants import DEFAULT_EVAL_RESULTS_PATH
 from fmeval.exceptions import EvalAlgorithmClientError
-from fmeval.util import require, project_root, singleton, create_shared_resource, get_eval_results_path
+from fmeval.util import (
+    require,
+    project_root,
+    singleton,
+    create_shared_resource,
+    get_eval_results_path,
+    cleanup_shared_resource,
+)
 
 
 def test_require():
@@ -97,3 +104,15 @@ def test_create_shared_resource():
         mock_ray_remote.assert_called_once_with(num_cpus=num_cpus)
         mock_actor_class.assert_called_once_with(Dummy)
         mock_wrapped_resource_class.remote.assert_called_once_with("C", 2)
+
+
+@patch("fmeval.util.ray.kill")
+def test_cleanup_shared_resource(mock_ray_kill):
+    """
+    GIVEN a shared resource.
+    WHEN cleanup_shared_resource is called.
+    THEN ray.kill is called on this resource.
+    """
+    resource = Mock()
+    cleanup_shared_resource(resource)
+    mock_ray_kill.assert_called_once_with(resource)


### PR DESCRIPTION
*Description of changes:*

This PR updates SASR to use `Transform`s and also updates `evaluate_dataset` to take a `Dataset` instead of `DataConfig`. Because of this change, `compute_and_aggregate_metrics` doesn't really need to be a separate function, so I moved its code into `evaluate_dataset`.

Note that the diff looks scary, but this PR is very heavy on the code _deletion_ side. The main source code to be reviewed is the [new implementation of the SASR algo](https://github.com/aws/fmeval/pull/230/files#diff-b729e9410963bcfa0c3879d23c164478ffd00fc0c810045b26493e8c06b93a87).

Other large-diff files to note are:
1. [test_util.py](https://github.com/aws/fmeval/pull/230/files#diff-6282cdc551980a07e46909b316476a42d7a206059f61e93d69826741919fcddb). This seemingly has a lot of changes, but it's just due to refactoring `evaluate_dataset`. The unit tests for `verify_model_determinism` have also been updated, as I've changed the implementation slightly.
2. [test_summarization_accuracy_semantic_robustness.py](https://github.com/aws/fmeval/pull/230/files#diff-a12a0aa05d6b7ee1dc67e1d6cdf4f2ccdf18fb3d7af85c71f1e5a1790fcb3071). Note that a huge chunk of the unit tests have been deleted, as those tests were purely meant for testing that all of the relevant function calls in the `evaluate` workflow  were made (as opposed to concretely testing specific that specific scores are correct; you'll see that the expected outputs for these tests are all just `0.0`). Since there are unit tests for `evaluate_dataset` now, all of these old SASR unit tests can go. Note that if you use the side-by-side diff viewer on Github, it will look like I deleted all of the `evaluate_sample` test cases, but I didn't. They just got moved further down in the file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
