### PR TITLE
feat: update implementation of SummarizationAccuracySemanticRobustness to use Transform-based approach

### DIFF
--- a/devtool
+++ b/devtool
@@ -143,7 +143,7 @@ unit_test_with_coverage() {
  }
 
  run_integ_tests() {
-   pytest -vvv test/integration/test_summarization_accuracy.py test/integration/test_summarization_accuracy_semantic_robustness.py
+   pytest -vvv test/integration/
  }
 
 create_commit_hash_file(){

--- a/devtool
+++ b/devtool
@@ -143,7 +143,7 @@ unit_test_with_coverage() {
  }
 
  run_integ_tests() {
-   pytest -vvv test/integration/
+   pytest -vvv test/integration/test_summarization_accuracy.py test/integration/test_summarization_accuracy_semantic_robustness.py
  }
 
 create_commit_hash_file(){

--- a/src/fmeval/eval_algorithms/general_semantic_robustness.py
+++ b/src/fmeval/eval_algorithms/general_semantic_robustness.py
@@ -6,9 +6,6 @@ from typing import Optional, List, Dict, Any
 from fmeval.constants import (
     DatasetColumns,
     MEAN,
-    BUTTER_FINGER,
-    RANDOM_UPPER_CASE,
-    WHITESPACE_ADD_REMOVE,
 )
 from fmeval.data_loaders.data_config import DataConfig
 from fmeval.data_loaders.util import get_dataset
@@ -31,7 +28,6 @@ from fmeval.eval_algorithms.util import (
     validate_dataset,
     verify_model_determinism,
     get_dataset_configs,
-    create_model_invocation_pipeline,
     evaluate_dataset,
 )
 from fmeval.model_runners.composers.composers import PromptComposer

--- a/src/fmeval/eval_algorithms/helper_models/helper_model.py
+++ b/src/fmeval/eval_algorithms/helper_models/helper_model.py
@@ -195,13 +195,6 @@ class BertscoreHelperModel(BaseHelperModel):
         self._bertscore = hf_evaluate.load("bertscore")
         self._model_type = model_type
 
-        # Dummy call to download the model within constructor
-        self._bertscore.compute(
-            predictions=["dummy_prediction"],
-            references=["dummy_reference"],
-            model_type=self._model_type,
-        )
-
     def get_helper_scores(self, target_output: str, model_output: str) -> float:  # type: ignore[override]
         """
         Method to invoke the concerned model and get bertscore

--- a/src/fmeval/eval_algorithms/helper_models/helper_model.py
+++ b/src/fmeval/eval_algorithms/helper_models/helper_model.py
@@ -43,10 +43,6 @@ class BaseHelperModel(ABC):
         :returns: model output
         """
 
-    def __reduce__(self):
-        """Serializer method."""
-        return self.__class__, ()  # pragma: no cover
-
 
 class ToxigenHelperModel(BaseHelperModel):
     """
@@ -64,6 +60,10 @@ class ToxigenHelperModel(BaseHelperModel):
         """
         self._model = pipeline("text-classification", model=self.TOXIGEN_MODEL_NAME)
         self._column_name = column_name
+
+    def __reduce__(self):
+        """Serializer method so that instances of this class can be made into shared resources."""
+        return self.__class__, (self._column_name,)
 
     def get_helper_scores(self, text_input: List[str]) -> Dict[str, List[float]]:  # type: ignore[override]
         """
@@ -139,6 +139,10 @@ class DetoxifyHelperModel(BaseHelperModel):
         self._tokenizer = getattr(transformers, config["tokenizer_name"]).from_pretrained(config["model_type"])
         self._column_name = column_name
 
+    def __reduce__(self):
+        """Serializer method so that instances of this class can be made into shared resources."""
+        return self.__class__, (self._column_name,)
+
     def get_helper_scores(self, text_input: List[str]) -> Dict[str, List[float]]:  # type: ignore[override]
         """
         Method to get scores from DetoxifyHelper
@@ -194,6 +198,10 @@ class BertscoreHelperModel(BaseHelperModel):
         """
         self._bertscore = hf_evaluate.load("bertscore")
         self._model_type = model_type
+
+    def __reduce__(self):
+        """Serializer method so that instances of this class can be made into shared resources."""
+        return self.__class__, (self._model_type,)
 
     def get_helper_scores(self, target_output: str, model_output: str) -> float:  # type: ignore[override]
         """

--- a/src/fmeval/eval_algorithms/summarization_accuracy_semantic_robustness.py
+++ b/src/fmeval/eval_algorithms/summarization_accuracy_semantic_robustness.py
@@ -1,9 +1,8 @@
 import logging
 
 from dataclasses import dataclass
-from typing import List, Optional, Union
+from typing import List, Optional
 
-from ray import ObjectRef
 
 from fmeval.constants import (
     DatasetColumns,
@@ -46,7 +45,7 @@ from fmeval.transforms.summarization_accuracy_metrics import MeteorScore, RougeS
 from fmeval.transforms.transform_pipeline import TransformPipeline
 from fmeval.transforms.util import create_output_key
 from fmeval.model_runners.model_runner import ModelRunner
-from fmeval.util import create_shared_resource, get_eval_results_path, require, cleanup_shared_resource
+from fmeval.util import create_shared_resource, get_eval_results_path, require
 
 logger = logging.getLogger(__name__)
 
@@ -113,9 +112,7 @@ class SummarizationAccuracySemanticRobustness(EvalAlgorithmInterface):
         super().__init__(eval_algorithm_config)
         self.config = eval_algorithm_config
         self.perturbation_transform = get_perturbation_transform(eval_algorithm_config)
-        bertscore_model = create_shared_resource(
-            BertscoreHelperModel(eval_algorithm_config.model_type_for_bertscore)
-        )
+        bertscore_model = create_shared_resource(BertscoreHelperModel(eval_algorithm_config.model_type_for_bertscore))
         self.bertscore_model = bertscore_model
 
     def _build_pipeline(

--- a/src/fmeval/eval_algorithms/summarization_accuracy_semantic_robustness.py
+++ b/src/fmeval/eval_algorithms/summarization_accuracy_semantic_robustness.py
@@ -1,8 +1,9 @@
 import logging
 
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, Union
 
+from ray import ObjectRef
 
 from fmeval.constants import (
     DatasetColumns,
@@ -45,7 +46,7 @@ from fmeval.transforms.summarization_accuracy_metrics import MeteorScore, RougeS
 from fmeval.transforms.transform_pipeline import TransformPipeline
 from fmeval.transforms.util import create_output_key
 from fmeval.model_runners.model_runner import ModelRunner
-from fmeval.util import create_shared_resource, get_eval_results_path, require
+from fmeval.util import create_shared_resource, get_eval_results_path, require, cleanup_shared_resource
 
 logger = logging.getLogger(__name__)
 
@@ -112,13 +113,14 @@ class SummarizationAccuracySemanticRobustness(EvalAlgorithmInterface):
         super().__init__(eval_algorithm_config)
         self.config = eval_algorithm_config
         self.perturbation_transform = get_perturbation_transform(eval_algorithm_config)
-        bertscore_model = create_shared_resource(BertscoreHelperModel(eval_algorithm_config.model_type_for_bertscore))
+        bertscore_model = BertscoreHelperModel(eval_algorithm_config.model_type_for_bertscore)
         self.bertscore_model = bertscore_model
 
     def _build_pipeline(
         self,
         model: ModelRunner,
         prompt_template: str,
+        bertscore_model: Union[BertscoreHelperModel, ObjectRef],
     ) -> TransformPipeline:
         """Build the TransformPipeline to be used by `evaluate` and `evaluate_sample`.
 
@@ -131,6 +133,8 @@ class SummarizationAccuracySemanticRobustness(EvalAlgorithmInterface):
 
         :param model: The ModelRunner representing the model under evaluation.
         :param prompt_template: A template that is used to construct the prompt fed to the model.
+        :param bertscore_model: Either a BertscoreHelperModel instance or a Ray actor handle corresponding
+            to a BertscoreHelperModel (i.e. a shared resource).
         :returns: A TransformPipeline that can be used by either `evaluate_sample` or `evaluate`.
         """
         transforms = get_model_responses_from_perturbed_inputs(
@@ -148,7 +152,7 @@ class SummarizationAccuracySemanticRobustness(EvalAlgorithmInterface):
             bertscore_keys=[BERT_SCORE],
             rouge_type=self.config.rouge_type,
             use_stemmer_for_rouge=self.config.use_stemmer_for_rouge,
-            bertscore_model=self.bertscore_model,
+            bertscore_model=bertscore_model,
         )
 
         perturbed_meteor, perturbed_rouge, perturbed_bert_score = SummarizationAccuracy._create_transforms(
@@ -165,7 +169,7 @@ class SummarizationAccuracySemanticRobustness(EvalAlgorithmInterface):
             ],
             rouge_type=self.config.rouge_type,
             use_stemmer_for_rouge=self.config.use_stemmer_for_rouge,
-            bertscore_model=self.bertscore_model,
+            bertscore_model=bertscore_model,
         )
 
         delta_meteor_key = DELTA_METEOR_SCORE
@@ -216,7 +220,7 @@ class SummarizationAccuracySemanticRobustness(EvalAlgorithmInterface):
             DatasetColumns.TARGET_OUTPUT.value.name: target_output,
         }
         invoke_model = create_model_invocation_pipeline(model, prompt_template)
-        compute_metrics = self._build_pipeline(model, prompt_template)
+        compute_metrics = self._build_pipeline(model, prompt_template, self.bertscore_model)
         pipeline = TransformPipeline([invoke_model, compute_metrics])
         output_record = pipeline.execute_record(sample)
 
@@ -254,6 +258,9 @@ class SummarizationAccuracySemanticRobustness(EvalAlgorithmInterface):
                             evaluation
         :return: List of EvalOutput objects.
         """
+        # Create a shared resource to be used during the evaluation.
+        bertscore_shared_resource = create_shared_resource(self.bertscore_model)
+
         dataset_configs = get_dataset_configs(dataset_config, self.eval_name)
         eval_outputs = []
         for dataset_config in dataset_configs:
@@ -264,7 +271,7 @@ class SummarizationAccuracySemanticRobustness(EvalAlgorithmInterface):
             validate_dataset(dataset, [DatasetColumns.MODEL_INPUT.value.name, DatasetColumns.TARGET_OUTPUT.value.name])
             eval_output = evaluate_dataset(
                 dataset=dataset,
-                pipeline=self._build_pipeline(model, dataset_prompt_template),
+                pipeline=self._build_pipeline(model, dataset_prompt_template, bertscore_shared_resource),
                 dataset_name=dataset_config.dataset_name,
                 eval_name=self.eval_name,
                 metric_names=ORIGINAL_SCORES + DELTA_SCORES,
@@ -276,4 +283,5 @@ class SummarizationAccuracySemanticRobustness(EvalAlgorithmInterface):
             )
             eval_outputs.append(eval_output)
 
+        cleanup_shared_resource(bertscore_shared_resource)
         return eval_outputs

--- a/src/fmeval/eval_algorithms/summarization_accuracy_semantic_robustness.py
+++ b/src/fmeval/eval_algorithms/summarization_accuracy_semantic_robustness.py
@@ -1,20 +1,15 @@
 import logging
-import ray
-import ray.data
 
-from ray.data import Dataset
-from collections import defaultdict
 from dataclasses import dataclass
-from typing import Optional, List, Dict, Any
+from typing import List, Optional, Union
 
-from fmeval import util
+from ray import ObjectRef
+
 from fmeval.constants import (
     DatasetColumns,
-    MEAN,
-    BUTTER_FINGER,
-    RANDOM_UPPER_CASE,
-    WHITESPACE_ADD_REMOVE,
     PREFIX_FOR_DELTA_SCORES,
+    BERTSCORE_DEFAULT_MODEL,
+    MEAN,
 )
 from fmeval.data_loaders.data_config import DataConfig
 from fmeval.data_loaders.util import get_dataset
@@ -22,146 +17,73 @@ from fmeval.eval_algorithms import (
     EvalAlgorithm,
     EvalScore,
     EvalOutput,
-    DATASET_CONFIGS,
-    EVAL_DATASETS,
     DEFAULT_PROMPT_TEMPLATE,
     get_default_prompt_template,
 )
-from fmeval.eval_algorithms.eval_algorithm import EvalAlgorithmConfig, EvalAlgorithmInterface
-from fmeval.eval_algorithms.semantic_perturbation_utils import (
-    ButterFinger,
-    RandomUpperCase,
-    WhitespaceAddRemove,
-    ButterFingerConfig,
-    RandomUpperCaseConfig,
-    WhitespaceAddRemoveConfig,
+from fmeval.eval_algorithms.eval_algorithm import EvalAlgorithmInterface
+from fmeval.eval_algorithms.semantic_robustness_utils import (
+    SemanticRobustnessConfig,
+    get_perturbation_transform,
+    get_model_responses_from_perturbed_inputs,
 )
+from fmeval.transforms.semantic_robustness_metrics import MeanDeltaScores
 from fmeval.eval_algorithms.summarization_accuracy import (
-    ROUGE_2,
-    SummarizationAccuracyConfig,
-    ROUGE_TYPES,
     SummarizationAccuracy,
+    ROUGE_TYPES,
+    ROUGE_2,
     ROUGE_SCORE,
     METEOR_SCORE,
     BERT_SCORE,
 )
-from fmeval.constants import BERTSCORE_DEFAULT_MODEL
+from fmeval.eval_algorithms.helper_models.helper_model import BertscoreHelperModel, BertscoreHelperModelTypes
 from fmeval.eval_algorithms.util import (
+    get_dataset_configs,
+    evaluate_dataset,
+    create_model_invocation_pipeline,
     validate_dataset,
-    save_dataset,
-    aggregate_evaluation_scores,
-    generate_output_dataset_path,
-    generate_prompt_column_for_dataset,
-    generate_mean_delta_score,
-    generate_model_predict_response_for_dataset,
 )
-from fmeval.eval_algorithms.helper_models.helper_model import BertscoreHelperModelTypes
-from fmeval.util import get_num_actors
-from fmeval.exceptions import EvalAlgorithmClientError
-from fmeval.model_runners.composers.composers import PromptComposer
+from fmeval.transforms.summarization_accuracy_metrics import MeteorScore, RougeScore, BertScore
+from fmeval.transforms.transform_pipeline import TransformPipeline
+from fmeval.transforms.util import create_output_key
 from fmeval.model_runners.model_runner import ModelRunner
-from fmeval.perf_util import timed_block
+from fmeval.util import create_shared_resource, get_eval_results_path, require, cleanup_shared_resource
 
 logger = logging.getLogger(__name__)
-
-# All the perturbation types supported by this eval algo
-PERTURBATION_TYPE_TO_HELPER_CLASS = {
-    BUTTER_FINGER: ButterFinger,
-    RANDOM_UPPER_CASE: RandomUpperCase,
-    WHITESPACE_ADD_REMOVE: WhitespaceAddRemove,
-}
 
 DELTA_ROUGE_SCORE = PREFIX_FOR_DELTA_SCORES + ROUGE_SCORE
 DELTA_METEOR_SCORE = PREFIX_FOR_DELTA_SCORES + METEOR_SCORE
 DELTA_BERT_SCORE = PREFIX_FOR_DELTA_SCORES + BERT_SCORE
-
-
-@ray.remote(num_cpus=0)
-class SummarizationAccuracyActor:
-    """
-    This class represents the SummarizationAccuracy eval algo instance
-    that is tied to a SummarizationAccuracySemanticRobustness instance.
-
-    Since a SummarizationAccuracySemanticRobustness instance gets deserialized
-    by each of the K GenerateEvalScoresActors spun up by __add_scores, if we
-    initialize a SummarizationAccuracy instance inside of the __init__ method of
-    SummarizationAccuracySemanticRobustness, we will create K BertscoreHelperModel
-    actors (since each SummarizationAccuracy has a corresponding BertscoreHelperModel),
-    which is not the intended behavior.
-
-    By using this class, when we explicitly instantiate a SummarizationAccuracySemanticRobustness,
-    a single SummarizationAccuracy gets instantiated (and stored in self.eval_algo), and this
-    SummarizationAccuracy instance gets reused every time a SummarizationAccuracySemanticRobustness
-    instance gets deserialized by a GenerateEvalScoresActor.
-
-    Note: we set num_cpus=0 for this actor because it is simply a wrapper around
-    a SummarizationAccuracy instance, whose BertscoreHelperModel already
-    has num_cpus=1. By setting num_cpus=0, we indicate that this actor
-    doesn't actually use up any logical resources (again, the actor
-    that's *actually* consuming resources is the BertscoreHelperModel).
-
-    See the following Ray documentation about Ray resources in general:
-    https://docs.ray.io/en/latest/ray-core/scheduling/resources.html
-
-    Details on specifying resource requirements (as we do with num_cpus=0):
-    https://docs.ray.io/en/latest/ray-core/scheduling/resources.html#specifying-task-or-actor-resource-requirements
-    """
-
-    def __init__(self, config: SummarizationAccuracyConfig):
-        self.eval_algo = SummarizationAccuracy(config)  # pragma: no cover
-
-    def evaluate_sample(self, target_output: str, model_output: str) -> List[EvalScore]:  # type: ignore[override]
-        return self.eval_algo.evaluate_sample(target_output, model_output)  # pragma: no cover
+DELTA_SCORES = [DELTA_METEOR_SCORE, DELTA_ROUGE_SCORE, DELTA_BERT_SCORE]
+ORIGINAL_SCORES = [METEOR_SCORE, ROUGE_SCORE, BERT_SCORE]
 
 
 @dataclass(frozen=True)
-class SummarizationAccuracySemanticRobustnessConfig(EvalAlgorithmConfig):
-    """
-    Configuration for the summarization accuracy semantic robustness eval algorithm.
+class SummarizationAccuracySemanticRobustnessConfig(SemanticRobustnessConfig):
+    """Configures the summarization accuracy semantic robustness evaluation algorithm.
 
-    :param perturbation_type: perturbation type for generating perturbed inputs
-    :param num_perturbations: Number of perturbed inputs to be generated for robustness evaluation
-    :param butter_finger_perturbation_prob: The probability that a given character will be perturbed. Used for
-        butter_finger perturbation_type
-    :param random_uppercase_corrupt_proportion: Fraction of characters to be changed to uppercase. Used for
-        random_upper_case perturbation_type
-    :param whitespace_remove_prob: Given a whitespace, remove it with this much probability. Used for
-        whitespace_add_remove perturbation_type
-    :param whitespace_add_prob: Given a non-whitespace, add a whitespace before it with this probability. Used for
-        whitespace_add_remove perturbation_type
-    :param rouge_type: Type of rouge metric in eval results
-    :param use_stemmer_for_rouge: bool value to set using stemmer for rouge metric
-    :param model_type_for_bertscore: model to use for bert score
+    See SemanticRobustnessConfig for the configurable parameters that this config class inherits.
+
+    :param rouge_type: ROUGE metric type.
+    :param use_stemmer_for_rouge: Whether to use stemmer when computing ROUGE metric.
+    :param model_type_for_bertscore: BERT model type to use for computing BERT score.
     """
 
-    perturbation_type: str = BUTTER_FINGER
-    num_perturbations: int = 5
-    butter_finger_perturbation_prob: float = 0.1
-    random_uppercase_corrupt_proportion: float = 0.1
-    whitespace_remove_prob: float = 0.1
-    whitespace_add_prob: float = 0.05
     rouge_type: str = ROUGE_2
     use_stemmer_for_rouge: bool = True
     model_type_for_bertscore: str = BERTSCORE_DEFAULT_MODEL
 
     def __post_init__(self):
-        if self.perturbation_type not in PERTURBATION_TYPE_TO_HELPER_CLASS.keys():
-            raise EvalAlgorithmClientError(
-                f"Invalid perturbation type '{self.perturbation_type} requested, please "
-                f"choose from acceptable values: {PERTURBATION_TYPE_TO_HELPER_CLASS.keys()}"
-            )
-
-        if self.rouge_type not in ROUGE_TYPES:
-            raise EvalAlgorithmClientError(
-                f"Invalid rouge_type: {self.rouge_type} requested in SummarizationAccuracyConfig, "
-                f"please choose from acceptable values: {ROUGE_TYPES}"
-            )
-
-        if not BertscoreHelperModelTypes.model_is_allowed(self.model_type_for_bertscore):
-            raise EvalAlgorithmClientError(
-                f"Invalid model_type_for_bertscore: {self.model_type_for_bertscore} requested in "
-                f"SummarizationAccuracyConfig, please choose from acceptable values: {BertscoreHelperModelTypes.model_list()}"
-            )
+        super().__post_init__()
+        require(
+            self.rouge_type in ROUGE_TYPES,
+            f"Invalid rouge_type: {self.rouge_type} requested in SummarizationAccuracySemanticRobustnessConfig. "
+            f"Please choose from acceptable values: {ROUGE_TYPES}.",
+        )
+        require(
+            BertscoreHelperModelTypes.model_is_allowed(self.model_type_for_bertscore),
+            f"Invalid model_type_for_bertscore: {self.model_type_for_bertscore} requested in "
+            f"SummarizationAccuracySemanticRobustnessConfig. Please choose from acceptable values: {BertscoreHelperModelTypes.model_list()}.",
+        )
 
 
 class SummarizationAccuracySemanticRobustness(EvalAlgorithmInterface):
@@ -178,129 +100,145 @@ class SummarizationAccuracySemanticRobustness(EvalAlgorithmInterface):
     For details on the Summarization Accuracy metrics, see the Summarization Accuracy evaluation. For details on perturbations, see the GeneralSemanticRobustness evaluation.
     """
 
+    eval_name = EvalAlgorithm.SUMMARIZATION_ACCURACY_SEMANTIC_ROBUSTNESS.value
+
     def __init__(
         self,
         eval_algorithm_config: SummarizationAccuracySemanticRobustnessConfig = SummarizationAccuracySemanticRobustnessConfig(),
-        summ_acc_actor: Optional[SummarizationAccuracyActor] = None,
     ):
-        """Default constructor
+        """SummarizationAccuracySemanticRobustness initializer.
 
-        :param eval_algorithm_config: Summarization Accuracy Semantic Robustness eval algorithm config.
+        :param eval_algorithm_config: Summarization accuracy semantic robustness evaluation algorithm config.
         """
         super().__init__(eval_algorithm_config)
-        self.eval_name = EvalAlgorithm.SUMMARIZATION_ACCURACY_SEMANTIC_ROBUSTNESS.value
-        self._eval_algorithm_config = eval_algorithm_config
+        self.config = eval_algorithm_config
+        self.perturbation_transform = get_perturbation_transform(eval_algorithm_config)
+        bertscore_model = BertscoreHelperModel(eval_algorithm_config.model_type_for_bertscore)
+        self.bertscore_model = bertscore_model
 
-        if self._eval_algorithm_config.perturbation_type == BUTTER_FINGER:
-            self._perturbation_config = ButterFingerConfig(self._eval_algorithm_config.butter_finger_perturbation_prob)
-        elif self._eval_algorithm_config.perturbation_type == RANDOM_UPPER_CASE:
-            self._perturbation_config = RandomUpperCaseConfig(
-                self._eval_algorithm_config.random_uppercase_corrupt_proportion
-            )
-        else:
-            self._perturbation_config = WhitespaceAddRemoveConfig(
-                self._eval_algorithm_config.whitespace_remove_prob, self._eval_algorithm_config.whitespace_add_prob
-            )
+    def _build_pipeline(
+        self,
+        model: ModelRunner,
+        prompt_template: str,
+        bertscore_model: Union[BertscoreHelperModel, ObjectRef],
+    ) -> TransformPipeline:
+        """Build the TransformPipeline to be used by `evaluate` and `evaluate_sample`.
 
-        self._summarization_accuracy_eval_algo = (
-            SummarizationAccuracyActor.remote(  # type: ignore[attr-defined]
-                SummarizationAccuracyConfig(
-                    rouge_type=eval_algorithm_config.rouge_type,
-                    use_stemmer_for_rouge=eval_algorithm_config.use_stemmer_for_rouge,
-                    model_type_for_bertscore=eval_algorithm_config.model_type_for_bertscore,
-                )
-            )
-            if summ_acc_actor is None
-            else summ_acc_actor
+        While other evaluation algorithms (ex: Summarization Accuracy) can configure
+        their TransformPipeline at algorithm initialization, because the Summarization Accuracy
+        Semantic Robustness algorithm's evaluation logic depends on the ModelRunner
+        and prompt template that are evaluation-specific (i.e. these parameters aren't
+        configured at the algorithm level), the pipeline used by this algorithm is built
+        when `evaluate` or `evaluate_sample` is called.
+
+        :param model: The ModelRunner representing the model under evaluation.
+        :param prompt_template: A template that is used to construct the prompt fed to the model.
+        :param bertscore_model: Either a BertscoreHelperModel instance or a Ray actor handle corresponding
+            to a BertscoreHelperModel (i.e. a shared resource).
+        :returns: A TransformPipeline that can be used by either `evaluate_sample` or `evaluate`.
+        """
+        transforms = get_model_responses_from_perturbed_inputs(
+            self.perturbation_transform,
+            prompt_template,
+            model,
+        )
+        get_perturbed_inputs, gen_perturbed_prompts, get_perturbed_responses = transforms
+
+        meteor_score, rouge_score, bert_score = SummarizationAccuracy._create_transforms(
+            target_output_keys=[DatasetColumns.TARGET_OUTPUT.value.name],
+            model_output_keys=[DatasetColumns.MODEL_OUTPUT.value.name],
+            meteor_keys=[METEOR_SCORE],
+            rouge_keys=[ROUGE_SCORE],
+            bertscore_keys=[BERT_SCORE],
+            rouge_type=self.config.rouge_type,
+            use_stemmer_for_rouge=self.config.use_stemmer_for_rouge,
+            bertscore_model=bertscore_model,
         )
 
-    def __reduce__(self):  # pragma: no cover
-        """
-        Custom serializer method used by Ray when it serializes instances of this
-        class during dataset.map() operations.
-        """
-        serialized_data = (self._eval_algorithm_config, self._summarization_accuracy_eval_algo)
-        return SummarizationAccuracySemanticRobustness, serialized_data
+        perturbed_meteor, perturbed_rouge, perturbed_bert_score = SummarizationAccuracy._create_transforms(
+            target_output_keys=[DatasetColumns.TARGET_OUTPUT.value.name for _ in range(self.config.num_perturbations)],
+            model_output_keys=get_perturbed_responses.output_keys,
+            meteor_keys=[
+                create_output_key(MeteorScore.__name__, "perturbed", i) for i in range(self.config.num_perturbations)
+            ],
+            rouge_keys=[
+                create_output_key(RougeScore.__name__, "perturbed", i) for i in range(self.config.num_perturbations)
+            ],
+            bertscore_keys=[
+                create_output_key(BertScore.__name__, "perturbed", i) for i in range(self.config.num_perturbations)
+            ],
+            rouge_type=self.config.rouge_type,
+            use_stemmer_for_rouge=self.config.use_stemmer_for_rouge,
+            bertscore_model=bertscore_model,
+        )
+
+        delta_meteor_key = DELTA_METEOR_SCORE
+        delta_rouge_key = DELTA_ROUGE_SCORE
+        delta_bert_key = DELTA_BERT_SCORE
+        mean_delta_scores = MeanDeltaScores(
+            {
+                meteor_score.output_keys[0]: (perturbed_meteor.output_keys, delta_meteor_key),
+                rouge_score.output_keys[0]: (perturbed_rouge.output_keys, delta_rouge_key),
+                bert_score.output_keys[0]: (perturbed_bert_score.output_keys, delta_bert_key),
+            }
+        )
+
+        transforms = [
+            get_perturbed_inputs,
+            gen_perturbed_prompts,
+            get_perturbed_responses,
+            meteor_score,
+            rouge_score,
+            bert_score,
+            perturbed_meteor,
+            perturbed_rouge,
+            perturbed_bert_score,
+            mean_delta_scores,
+        ]
+        pipeline = TransformPipeline(transforms)
+        return pipeline
 
     def evaluate_sample(
         self,
         model_input: str,
         target_output: str,
         model: ModelRunner,
-        model_output: Optional[str] = None,
         prompt_template: str = DEFAULT_PROMPT_TEMPLATE,
-    ) -> List[EvalScore]:  # type: ignore[override]
+    ) -> List[EvalScore]:
+        """Compute summarization accuracy semantic robustness metrics for a single sample.
+
+        A sample is defined as a model input and model output pair.
+
+        :param model_input: Text input, which will be composed into a prompt that gets fed to the model.
+        :param target_output: The expected response from the model.
+        :param model: An instance of ModelRunner representing the model under evaluation.
+        :param prompt_template: A template used to compose the prompt from `model_input`.
+        :return: A list of EvalScores.
         """
-        Summarization Accuracy Semantic Robustness evaluate sample.
+        sample = {
+            DatasetColumns.MODEL_INPUT.value.name: model_input,
+            DatasetColumns.TARGET_OUTPUT.value.name: target_output,
+        }
+        invoke_model = create_model_invocation_pipeline(model, prompt_template)
+        compute_metrics = self._build_pipeline(model, prompt_template, self.bertscore_model)
+        pipeline = TransformPipeline([invoke_model, compute_metrics])
+        output_record = pipeline.execute_record(sample)
 
-        :param model_input: text input for model
-        :param target_output: The expected responses from the model
-        :param model: An instance of ModelRunner which is the model under evaluation
-        :param model_output: The output of a model that we want to evaluate.
-        :param prompt_template: A template which can be used to compose prompt using model_input
-        :return: list of EvalScore object
-        """
-        util.require(
-            model_input,
-            "Missing required input: model_input, for SummarizationAccuracySemanticRobustness evaluate_sample",
-        )
-        util.require(
-            model,
-            "Missing required input: model i.e. ModelRunner, for "
-            "SummarizationAccuracySemanticRobustness evaluate_sample",
-        )
-        util.require(
-            target_output,
-            "Missing required input: target_output, for " "SummarizationAccuracySemanticRobustness evaluate_sample",
-        )
-
-        prompt_composer = PromptComposer(prompt_template)
-        original_prompt = prompt_composer.compose(model_input)
-        original_model_output = model_output if model_output else model.predict(original_prompt)[0]
-
-        perturbation = PERTURBATION_TYPE_TO_HELPER_CLASS[self._eval_algorithm_config.perturbation_type]()
-        perturbed_inputs = perturbation.perturb(
-            text=model_input,
-            config=self._perturbation_config,
-            num_perturbations=self._eval_algorithm_config.num_perturbations,
-        )
-        perturbed_input_prompts = [prompt_composer.compose(perturbed_input) for perturbed_input in perturbed_inputs]
-        perturbed_input_outputs = [model.predict(prompt)[0] for prompt in perturbed_input_prompts]
-
-        original_summarization_accuracy_scores = ray.get(
-            self._summarization_accuracy_eval_algo.evaluate_sample.remote(
-                target_output=target_output, model_output=original_model_output
-            )
-        )
-
-        perturbed_outputs_summarization_accuracy_scores = defaultdict(list)
-        for perturbed_input_output in perturbed_input_outputs:
-            accuracy_scores = ray.get(
-                self._summarization_accuracy_eval_algo.evaluate_sample.remote(
-                    target_output=target_output, model_output=perturbed_input_output
-                )
-            )
-            for accuracy_score in accuracy_scores:
-                perturbed_outputs_summarization_accuracy_scores[accuracy_score.name].append(accuracy_score)
-
-        delta_scores = [
-            EvalScore(
-                name=PREFIX_FOR_DELTA_SCORES + original_score.name,
-                value=generate_mean_delta_score(
-                    original_score, perturbed_outputs_summarization_accuracy_scores[original_score.name]
-                ),
-            )
-            for original_score in original_summarization_accuracy_scores
+        original_scores = [
+            EvalScore(name=score_name, value=output_record[score_name]) for score_name in ORIGINAL_SCORES
         ]
-        return original_summarization_accuracy_scores + delta_scores
+        delta_scores = [
+            EvalScore(name=delta_score_name, value=output_record[delta_score_name]) for delta_score_name in DELTA_SCORES
+        ]
+        return original_scores + delta_scores
 
-    def evaluate(  # type: ignore[override]
+    def evaluate(
         self,
         model: ModelRunner,
         dataset_config: Optional[DataConfig] = None,
         prompt_template: Optional[str] = None,
-        save: bool = False,
         num_records: int = 100,
+        save: bool = False,
     ) -> List[EvalOutput]:
         """
         Semantic Robustness evaluate.
@@ -320,113 +258,30 @@ class SummarizationAccuracySemanticRobustness(EvalAlgorithmInterface):
                             evaluation
         :return: List of EvalOutput objects.
         """
-        util.require(
-            model,
-            "Missing required input: model i.e. ModelRunner, for SummarizationAccuracySemanticRobustness "
-            "evaluate method",
-        )
-        if dataset_config:
-            dataset_configs = [dataset_config]
-        else:
-            dataset_configs = [DATASET_CONFIGS[dataset_name] for dataset_name in EVAL_DATASETS[self.eval_name]]
+        # Create a shared resource to be used during the evaluation.
+        bertscore_shared_resource = create_shared_resource(self.bertscore_model)
 
+        dataset_configs = get_dataset_configs(dataset_config, self.eval_name)
         eval_outputs = []
         for dataset_config in dataset_configs:
-            dataset = get_dataset(dataset_config, num_records)
-            validate_dataset(dataset, [DatasetColumns.MODEL_INPUT.value.name, DatasetColumns.TARGET_OUTPUT.value.name])
             dataset_prompt_template = (
                 get_default_prompt_template(dataset_config.dataset_name) if not prompt_template else prompt_template
             )
-            dataset = generate_prompt_column_for_dataset(
-                dataset_prompt_template,
-                dataset,
-                DatasetColumns.MODEL_INPUT.value.name,
-                DatasetColumns.PROMPT.value.name,
-            )
-
-            dataset = generate_model_predict_response_for_dataset(
+            dataset = get_dataset(dataset_config, num_records)
+            validate_dataset(dataset, [DatasetColumns.MODEL_INPUT.value.name, DatasetColumns.TARGET_OUTPUT.value.name])
+            eval_output = evaluate_dataset(
+                dataset=dataset,
+                pipeline=self._build_pipeline(model, dataset_prompt_template, bertscore_shared_resource),
+                dataset_name=dataset_config.dataset_name,
+                eval_name=self.eval_name,
+                metric_names=ORIGINAL_SCORES + DELTA_SCORES,
+                eval_results_path=get_eval_results_path(),
                 model=model,
-                data=dataset,
-                model_input_column_name=DatasetColumns.PROMPT.value.name,
-                model_output_column_name=DatasetColumns.MODEL_OUTPUT.value.name,
+                prompt_template=dataset_prompt_template,
+                agg_method=MEAN,
+                save=save,
             )
-            with timed_block(f"Computing score and aggregation on dataset {dataset_config.dataset_name}", logger):
-                dataset = self.__add_scores(model, dataset_prompt_template, dataset)
+            eval_outputs.append(eval_output)
 
-                dataset_scores, category_scores = aggregate_evaluation_scores(
-                    dataset,
-                    [ROUGE_SCORE, BERT_SCORE, METEOR_SCORE, DELTA_ROUGE_SCORE, DELTA_BERT_SCORE, DELTA_METEOR_SCORE],
-                    agg_method=MEAN,
-                )
-                eval_outputs.append(
-                    EvalOutput(
-                        eval_name=self.eval_name,
-                        dataset_name=dataset_config.dataset_name,
-                        prompt_template=dataset_prompt_template,
-                        dataset_scores=dataset_scores,
-                        category_scores=category_scores,
-                        output_path=generate_output_dataset_path(
-                            path_to_parent_dir=util.get_eval_results_path(),
-                            eval_name=self.eval_name,
-                            dataset_name=dataset_config.dataset_name,
-                        ),
-                    )
-                )
-            if save:
-                save_dataset(
-                    dataset=dataset,
-                    score_names=[
-                        ROUGE_SCORE,
-                        BERT_SCORE,
-                        METEOR_SCORE,
-                        DELTA_ROUGE_SCORE,
-                        DELTA_BERT_SCORE,
-                        DELTA_METEOR_SCORE,
-                    ],
-                    path=generate_output_dataset_path(
-                        path_to_parent_dir=util.get_eval_results_path(),
-                        eval_name=self.eval_name,
-                        dataset_name=dataset_config.dataset_name,
-                    ),
-                )
-
+        cleanup_shared_resource(bertscore_shared_resource)
         return eval_outputs
-
-    def __add_scores(self, model: ModelRunner, prompt_template: str, dataset: Dataset) -> Dataset:  # pragma: no cover
-        """
-        Private method to encapsulate map call on evaluate sample. Specifically created for cleaner mocking in
-        unit tests.
-        :param model: model to be used for evaluation
-        :param prompt_template: prompt template
-        :param dataset: input ray dataset
-        :returns: ray dataset with added score columns
-        """
-        evaluate_sample_fn = self.evaluate_sample
-
-        class GenerateEvalScoresActor:  # pragma: no cover
-            """
-            This class represents the Ray Actor that gets eval scores for every row in ray dataset by
-            calling evaluate_sample of the same class.
-
-            We use Ray Actors instead of Tasks because the Actor approach minimizes
-            the number of times the SummarizationAccuracy dependent class gets serialised/deserialized.
-            With Tasks, Ray will serialise and deserialize for every single row evaluation. With Actors,
-            class gets deserialized once per Actor when the Actor gets initialized.
-            """
-
-            def __call__(self, row: Dict[str, Any]) -> Dict[str, Any]:
-                assert prompt_template  # to satisfy mypy
-                scores = evaluate_sample_fn(
-                    model_input=row[DatasetColumns.MODEL_INPUT.value.name],
-                    target_output=row[DatasetColumns.TARGET_OUTPUT.value.name],
-                    model=model,
-                    model_output=row[DatasetColumns.MODEL_OUTPUT.value.name],
-                    prompt_template=prompt_template,
-                )
-                for score in scores:
-                    row[score.name] = score.value
-                return row
-
-        return dataset.map(
-            GenerateEvalScoresActor, compute=ray.data.ActorPoolStrategy(size=get_num_actors())  # type: ignore[arg-type]
-        ).materialize()

--- a/src/fmeval/transforms/summarization_accuracy_metrics.py
+++ b/src/fmeval/transforms/summarization_accuracy_metrics.py
@@ -275,8 +275,8 @@ class BertScore(SummarizationAccuracyMetric):
         :returns: The BERT metric value.
         """
         if isinstance(self.bertscore_model, BertscoreHelperModel):
-            return self.bertscore_model.invoke_model(target_output, model_output)
+            return self.bertscore_model.get_helper_scores(target_output, model_output)
         else:
             return ray.get(  # type: ignore[return-value]
-                self.bertscore_model.invoke_model.remote(target_output, model_output)  # type: ignore[union-attr]
+                self.bertscore_model.get_helper_scores.remote(target_output, model_output)  # type: ignore[union-attr]
             )

--- a/test/integration/test_summarization_accuracy_semantic_robustness.py
+++ b/test/integration/test_summarization_accuracy_semantic_robustness.py
@@ -1,6 +1,6 @@
+import json
 import os
 import ray
-import json
 import pytest
 
 from typing import NamedTuple, Dict
@@ -16,10 +16,8 @@ from fmeval.eval_algorithms.summarization_accuracy_semantic_robustness import (
     DELTA_ROUGE_SCORE,
     DELTA_METEOR_SCORE,
     DELTA_BERT_SCORE,
-    BUTTER_FINGER,
-    RANDOM_UPPER_CASE,
-    WHITESPACE_ADD_REMOVE,
 )
+from fmeval.eval_algorithms.semantic_robustness_utils import BUTTER_FINGER, RANDOM_UPPER_CASE, WHITESPACE_ADD_REMOVE
 from test.integration.models.model_runners import sm_model_runner
 
 ABS_TOL = 1e-6
@@ -43,86 +41,78 @@ WHITESPACE_CONFIG = SummarizationAccuracySemanticRobustnessConfig(
 )
 
 
-class TestCaseEvaluate(NamedTuple):
+class TestCase(NamedTuple):
     config: SummarizationAccuracySemanticRobustnessConfig
-    expected_evaluate_sample_scores: Dict[str, float]
-    expected_evaluate_scores: Dict[str, float]
+    evaluate_sample_scores: Dict[str, float]
+    evaluate_scores: Dict[str, float]
 
 
 class TestSummarizationAccuracySemanticRobustness:
     @pytest.mark.parametrize(
-        "config, expected_evaluate_sample_scores, expected_evaluate_scores",
+        "config, evaluate_sample_scores, evaluate_scores",
         [
-            TestCaseEvaluate(
+            TestCase(
                 config=BUTTER_FINGER_CONFIG,
-                expected_evaluate_sample_scores={
+                evaluate_sample_scores={
                     ROUGE_SCORE: 0.0,
                     METEOR_SCORE: 0.0,
                     BERT_SCORE: 0.536162,
                     DELTA_ROUGE_SCORE: 0.0,
-                    DELTA_METEOR_SCORE: 0.063628,
-                    DELTA_BERT_SCORE: 0.050299,
+                    DELTA_METEOR_SCORE: 0.037836,
+                    DELTA_BERT_SCORE: 0.024666,
                 },
-                expected_evaluate_scores={
+                evaluate_scores={
                     ROUGE_SCORE: 0.021908,
                     METEOR_SCORE: 0.105540,
                     BERT_SCORE: 0.559893,
-                    DELTA_ROUGE_SCORE: 0.021061,
-                    DELTA_METEOR_SCORE: 0.046859,
-                    DELTA_BERT_SCORE: 0.032417,
+                    DELTA_ROUGE_SCORE: 0.023259,
+                    DELTA_METEOR_SCORE: 0.059768,
+                    DELTA_BERT_SCORE: 0.031421,
                 },
             ),
-            TestCaseEvaluate(
+            TestCase(
                 config=RANDOM_UPPER_CASE_CONFIG,
-                expected_evaluate_sample_scores={
+                evaluate_sample_scores={
                     ROUGE_SCORE: 0.0,
                     METEOR_SCORE: 0.0,
                     BERT_SCORE: 0.536162,
                     DELTA_ROUGE_SCORE: 0.0,
-                    DELTA_METEOR_SCORE: 0.051282,
-                    DELTA_BERT_SCORE: 0.048976,
+                    DELTA_METEOR_SCORE: 0.064103,
+                    DELTA_BERT_SCORE: 0.056435,
                 },
-                expected_evaluate_scores={
+                evaluate_scores={
                     ROUGE_SCORE: 0.021908,
                     METEOR_SCORE: 0.105540,
                     BERT_SCORE: 0.559893,
-                    DELTA_ROUGE_SCORE: 0.037362,
-                    DELTA_METEOR_SCORE: 0.056909,
-                    DELTA_BERT_SCORE: 0.026363,
+                    DELTA_ROUGE_SCORE: 0.032086,
+                    DELTA_METEOR_SCORE: 0.057150,
+                    DELTA_BERT_SCORE: 0.026943,
                 },
             ),
-            TestCaseEvaluate(
+            TestCase(
                 config=WHITESPACE_CONFIG,
-                expected_evaluate_sample_scores={
+                evaluate_sample_scores={
                     ROUGE_SCORE: 0.0,
                     METEOR_SCORE: 0.0,
                     BERT_SCORE: 0.536162,
                     DELTA_ROUGE_SCORE: 0.0,
-                    DELTA_METEOR_SCORE: 0.050657,
-                    DELTA_BERT_SCORE: 0.037705,
+                    DELTA_METEOR_SCORE: 0.038462,
+                    DELTA_BERT_SCORE: 0.039566,
                 },
-                expected_evaluate_scores={
+                evaluate_scores={
                     ROUGE_SCORE: 0.021908,
                     METEOR_SCORE: 0.105540,
                     BERT_SCORE: 0.559893,
-                    DELTA_ROUGE_SCORE: 0.030725,
-                    DELTA_METEOR_SCORE: 0.054234,
-                    DELTA_BERT_SCORE: 0.026511,
+                    DELTA_ROUGE_SCORE: 0.020407,
+                    DELTA_METEOR_SCORE: 0.048702,
+                    DELTA_BERT_SCORE: 0.026193,
                 },
             ),
         ],
     )
-    def test_evaluate_sample_and_evaluate(
-        self, config, expected_evaluate_sample_scores, expected_evaluate_scores, integration_tests_dir
-    ):
-        """
-        In order to reuse SummarizationAccuracySemanticRobustness objects
-        as much as possible (to minimize creation of BertscoreHelperModels),
-        we test evaluate_sample and evaluate back to back using the same eval_algo
-        (instead of following the convention of the other tests, where evaluate_sample
-        and evaluate are tested in separate methods).
-        """
+    def test_evaluate_sample_and_evaluate(self, config, evaluate_sample_scores, evaluate_scores, integration_tests_dir):
         eval_algo = SummarizationAccuracySemanticRobustness(config)
+
         # Test evaluate_sample
         with open(os.path.join(integration_tests_dir, "datasets", "gigaword_sample.jsonl")) as fh:
             json_obj = json.loads(fh.readline())
@@ -130,11 +120,11 @@ class TestSummarizationAccuracySemanticRobustness:
             target_output = json_obj["summary"]
             eval_scores = eval_algo.evaluate_sample(
                 model_input=model_input,
-                model=sm_model_runner,
                 target_output=target_output,
+                model=sm_model_runner,
             )
             for eval_score in eval_scores:
-                assert eval_score.value == approx(expected_evaluate_sample_scores[eval_score.name], abs=ABS_TOL)
+                assert eval_score.value == approx(evaluate_sample_scores[eval_score.name], abs=ABS_TOL)
 
         # Test evaluate
         dataset_config = DATASET_CONFIGS[GIGAWORD]
@@ -145,9 +135,6 @@ class TestSummarizationAccuracySemanticRobustness:
             num_records=20,
         )[0]
         for eval_score in eval_output.dataset_scores:
-            assert eval_score.value == approx(expected_evaluate_scores[eval_score.name], abs=ABS_TOL)
+            assert eval_score.value == approx(evaluate_scores[eval_score.name], abs=ABS_TOL)
 
-        # Calling ray.shutdown() would be overkill since there are still other test cases.
-        # Thus, we kill only the SummarizationAccuracySingleton ray actor used by the
-        # current test case, to make sure that resources are cleaned up between test cases.
-        ray.kill(eval_algo._summarization_accuracy_eval_algo)
+        ray.shutdown()

--- a/test/integration/test_util.py
+++ b/test/integration/test_util.py
@@ -16,7 +16,7 @@ class TestUtil:
             `remote` and `get`).
 
         Note that the input payload and expected result are copied from
-        the BertscoreHelperModel.invoke_model unit test.
+        the BertscoreHelperModel.get_helper_scores unit test.
         """
         bertscore_model = BertscoreHelperModel(BertscoreHelperModelTypes.ROBERTA_MODEL.value)
         actor_handle = create_shared_resource(bertscore_model)

--- a/test/unit/eval_algorithms/test_general_semantic_robustness.py
+++ b/test/unit/eval_algorithms/test_general_semantic_robustness.py
@@ -309,7 +309,7 @@ class TestGeneralSemanticRobustness:
             (test_case.perturbed_model_output_2, None),  # Output on the second perturbation
         ]
         bertscore_model_instance = Mock(spec=BertscoreHelperModel)
-        bertscore_model_instance.invoke_model = Mock(return_value=BERTSCORE_DUMMY_VALUE)
+        bertscore_model_instance.get_helper_scores = Mock(return_value=BERTSCORE_DUMMY_VALUE)
         bertscore_model.return_value = bertscore_model_instance
 
         eval_algo = GeneralSemanticRobustness(config, use_ray=False)
@@ -339,7 +339,7 @@ class TestGeneralSemanticRobustness:
         THEN the robustness score value is smaller than it would be for a deterministic model.
         """
         bertscore_model_instance = Mock(spec=BertscoreHelperModel)
-        bertscore_model_instance.invoke_model = Mock(return_value=BERTSCORE_DUMMY_VALUE)
+        bertscore_model_instance.get_helper_scores = Mock(return_value=BERTSCORE_DUMMY_VALUE)
         bertscore_model.return_value = bertscore_model_instance
 
         deterministic_model = MagicMock()

--- a/test/unit/eval_algorithms/test_helper_model.py
+++ b/test/unit/eval_algorithms/test_helper_model.py
@@ -2,6 +2,7 @@ from unittest.mock import patch, PropertyMock
 import numpy as np
 import pytest
 
+from fmeval.constants import DatasetColumns
 from fmeval.eval_algorithms.helper_models.helper_model import (
     ToxigenHelperModel,
     TOXIGEN_SCORE_NAME,
@@ -63,6 +64,15 @@ class TestHelperModel:
         mock_model_name.return_value = "hf-internal-testing/tiny-random-roberta"
         test_helper = ToxigenHelperModel("prompt")
         assert test_helper.get_score_names() == [TOXIGEN_SCORE_NAME]
+
+    def test_toxigen_reduce(self):
+        """
+        GIVEN a ToxigenHelperModel instance.
+        WHEN __reduce__ is called.
+        THEN the correct output is returned.
+        """
+        toxigen_model = ToxigenHelperModel()
+        assert toxigen_model.__reduce__() == (ToxigenHelperModel, (DatasetColumns.MODEL_OUTPUT.value.name,))
 
     def test_detoxify_helper_model_get_helper_scores(self):
         """
@@ -151,6 +161,15 @@ class TestHelperModel:
         test_helper = DetoxifyHelperModel()
         assert test_helper.get_score_names() == DETOXIFY_SCORE_NAMES
 
+    def test_detoxify_reduce(self):
+        """
+        GIVEN a DetoxifyHelperModel instance.
+        WHEN __reduce__ is called.
+        THEN the correct output is returned.
+        """
+        detoxify_model = DetoxifyHelperModel()
+        assert detoxify_model.__reduce__() == (DetoxifyHelperModel, (DatasetColumns.MODEL_OUTPUT.value.name,))
+
     def test_bertscore_helper_model_roberta(self):
         """
         Test bertscore helper model
@@ -159,3 +178,12 @@ class TestHelperModel:
         assert bertscore.get_helper_scores("sample text reference", "sample text prediction") == pytest.approx(
             0.902793288230896
         )
+
+    def test_bertscore_reduce(self):
+        """
+        GIVEN a BertscoreHelperModel instance.
+        WHEN __reduce__ is called.
+        THEN the correct output is returned.
+        """
+        bertscore_model = BertscoreHelperModel("distilbert-base-uncased")
+        assert bertscore_model.__reduce__() == (BertscoreHelperModel, ("distilbert-base-uncased",))

--- a/test/unit/eval_algorithms/test_helper_model.py
+++ b/test/unit/eval_algorithms/test_helper_model.py
@@ -14,6 +14,7 @@ from fmeval.eval_algorithms.helper_models.helper_model import (
     DETOXIFY_SCORE_INSULT,
     DETOXIFY_SCORE_THREAT,
     DETOXIFY_SCORE_SEXUAL_EXPLICIT,
+    BertscoreHelperModel,
 )
 
 
@@ -149,3 +150,12 @@ class TestHelperModel:
         """
         test_helper = DetoxifyHelperModel()
         assert test_helper.get_score_names() == DETOXIFY_SCORE_NAMES
+
+    def test_bertscore_helper_model_roberta(self):
+        """
+        Test bertscore helper model
+        """
+        bertscore = BertscoreHelperModel("distilbert-base-uncased")
+        assert bertscore.get_helper_scores("sample text reference", "sample text prediction") == pytest.approx(
+            0.902793288230896
+        )

--- a/test/unit/eval_algorithms/test_summarization_accuracy.py
+++ b/test/unit/eval_algorithms/test_summarization_accuracy.py
@@ -146,7 +146,7 @@ class TestSummarizationAccuracy:
         """
         # Mock the BertscoreHelperModel class so that the actual model doesn't get loaded into memory.
         bertscore_model_instance = Mock(spec=BertscoreHelperModel)
-        bertscore_model_instance.invoke_model = Mock(return_value=BERTSCORE_DUMMY_VALUE)
+        bertscore_model_instance.get_helper_scores = Mock(return_value=BERTSCORE_DUMMY_VALUE)
         bertscore_model_cls.return_value = bertscore_model_instance
 
         model_output = "Berlin: Art, Heritage, Exhibitions Hub."

--- a/test/unit/eval_algorithms/test_summarization_accuracy_semantic_robustness.py
+++ b/test/unit/eval_algorithms/test_summarization_accuracy_semantic_robustness.py
@@ -19,7 +19,6 @@ from fmeval.eval_algorithms.summarization_accuracy_semantic_robustness import (
     DELTA_SCORES,
 )
 from fmeval.exceptions import EvalAlgorithmClientError
-from fmeval.eval_algorithms.helper_models.helper_model import BertscoreHelperModel
 from fmeval.model_runners.model_runner import ModelRunner
 
 

--- a/test/unit/eval_algorithms/test_summarization_accuracy_semantic_robustness.py
+++ b/test/unit/eval_algorithms/test_summarization_accuracy_semantic_robustness.py
@@ -1,30 +1,13 @@
 import re
 from typing import NamedTuple, List, Optional, Tuple
-from unittest.mock import patch, MagicMock
+from unittest.mock import Mock, call, patch
 
 import pytest
-import ray
 from _pytest.fixtures import fixture
-from ray.data import Dataset
 
-from fmeval.constants import (
-    DatasetColumns,
-    MIME_TYPE_JSON,
-)
-from fmeval.data_loaders.data_config import DataConfig
-from fmeval.eval_algorithms import (
-    EvalScore,
-    EvalOutput,
-    CategoryScore,
-    BUILT_IN_DATASET_DEFAULT_PROMPT_TEMPLATES,
-    DEFAULT_PROMPT_TEMPLATE,
-    GIGAWORD,
-    GOV_REPORT,
-)
-from fmeval.eval_algorithms.semantic_robustness_utils import (
-    RANDOM_UPPER_CASE,
-    WHITESPACE_ADD_REMOVE,
-)
+from fmeval.constants import DatasetColumns, BUTTER_FINGER, WHITESPACE_ADD_REMOVE, MEAN
+from fmeval.eval_algorithms import EvalScore
+from fmeval.eval_algorithms.semantic_robustness_utils import RANDOM_UPPER_CASE, SEMANTIC_PERTURBATIONS
 from fmeval.eval_algorithms.summarization_accuracy import METEOR_SCORE, ROUGE_SCORE, BERT_SCORE
 from fmeval.eval_algorithms.summarization_accuracy_semantic_robustness import (
     SummarizationAccuracySemanticRobustnessConfig,
@@ -32,53 +15,12 @@ from fmeval.eval_algorithms.summarization_accuracy_semantic_robustness import (
     DELTA_METEOR_SCORE,
     DELTA_ROUGE_SCORE,
     DELTA_BERT_SCORE,
+    ORIGINAL_SCORES,
+    DELTA_SCORES,
 )
 from fmeval.exceptions import EvalAlgorithmClientError
+from fmeval.eval_algorithms.helper_models.helper_model import BertscoreHelperModel
 from fmeval.model_runners.model_runner import ModelRunner
-
-DATASET_WITH_SCORES = ray.data.from_items(
-    [
-        {
-            DatasetColumns.MODEL_INPUT.value.name: "Cake is so delicious, I really like cake. I want to open a bakery when I grow up.",
-            DatasetColumns.TARGET_OUTPUT.value.name: "I like cake.",
-            DatasetColumns.CATEGORY.value.name: "dummy_category_1",
-            DatasetColumns.MODEL_OUTPUT.value.name: "Some model output.",
-            ROUGE_SCORE: 0.0,
-            METEOR_SCORE: 0.0,
-            BERT_SCORE: 0.0,
-            DELTA_ROUGE_SCORE: 0.0,
-            DELTA_METEOR_SCORE: 0.0,
-            DELTA_BERT_SCORE: 0.0,
-        },
-        {
-            DatasetColumns.MODEL_INPUT.value.name: "The art metropolis of Berlin inspires locals and visitors with its famous "
-            "museum landscape and numerous UNESCO World Heritage sites."
-            " It is also an international exhibition venue. "
-            "You will find a selection of current and upcoming exhibitions here.",
-            DatasetColumns.TARGET_OUTPUT.value.name: "Berlin: an art metropolis.",
-            DatasetColumns.CATEGORY.value.name: "dummy_category_2",
-            DatasetColumns.MODEL_OUTPUT.value.name: "Some model output.",
-            ROUGE_SCORE: 0.0,
-            METEOR_SCORE: 0.0,
-            BERT_SCORE: 0.0,
-            DELTA_ROUGE_SCORE: 0.0,
-            DELTA_METEOR_SCORE: 0.0,
-            DELTA_BERT_SCORE: 0.0,
-        },
-    ]
-)
-
-DATASET_WITH_MODEL_OUTPUT = DATASET_WITH_SCORES.drop_columns(
-    cols=[DELTA_ROUGE_SCORE, DELTA_METEOR_SCORE, DELTA_BERT_SCORE]
-)
-
-DATASET = DATASET_WITH_MODEL_OUTPUT.drop_columns(cols=[DatasetColumns.MODEL_OUTPUT.value.name])
-
-DATASET_NO_CATEGORY_WITH_MODEL_OUTPUT = DATASET_WITH_MODEL_OUTPUT.drop_columns(
-    cols=[DatasetColumns.CATEGORY.value.name]
-)
-
-DATASET_NO_CATEGORY = DATASET.drop_columns(cols=[DatasetColumns.CATEGORY.value.name])
 
 
 class MockModelRunner(ModelRunner):
@@ -94,272 +36,7 @@ class TestSummarizationAccuracySemanticRobustness:
     def config(self) -> SummarizationAccuracySemanticRobustnessConfig:
         return SummarizationAccuracySemanticRobustnessConfig(num_perturbations=2)
 
-    class TestCaseSummarizationAccuracySemanticRobustnessEvaluateSample(NamedTuple):
-        model_input: str
-        target_output: str
-        original_model_output: str
-        perturbed_model_output_1: str
-        perturbed_model_output_2: str
-        sa_eval_score_original: List[EvalScore]
-        sa_eval_score_perturbed_1: List[EvalScore]
-        sa_eval_score_perturbed_2: List[EvalScore]
-        expected_response: List[EvalScore]
-        config: SummarizationAccuracySemanticRobustnessConfig
-
-    class TestCaseSummarizationAccuracySemanticRobustnessEvaluateSampleInvalid(NamedTuple):
-        model_input: str
-        target_output: str
-        model: ModelRunner
-        expected_error_message: str
-        config: SummarizationAccuracySemanticRobustnessConfig
-
-    @pytest.mark.parametrize(
-        "test_case",
-        [
-            TestCaseSummarizationAccuracySemanticRobustnessEvaluateSample(
-                model_input="Cake is so delicious, I really like cake. I want to open a bakery when I grow up.",
-                target_output="I like cake.",
-                original_model_output="Some model output.",
-                perturbed_model_output_1="Some other model output.",
-                perturbed_model_output_2="Some different model output.",
-                sa_eval_score_original=[
-                    EvalScore(name=METEOR_SCORE, value=1.0),
-                    EvalScore(name=ROUGE_SCORE, value=1.0),
-                    EvalScore(name=BERT_SCORE, value=0.5),
-                ],
-                sa_eval_score_perturbed_1=[
-                    EvalScore(name=METEOR_SCORE, value=0.75),
-                    EvalScore(name=ROUGE_SCORE, value=0.5),
-                    EvalScore(name=BERT_SCORE, value=1.0),
-                ],
-                sa_eval_score_perturbed_2=[
-                    EvalScore(name=METEOR_SCORE, value=0.5),
-                    EvalScore(name=ROUGE_SCORE, value=0.2),
-                    EvalScore(name=BERT_SCORE, value=0.5),
-                ],
-                expected_response=[
-                    EvalScore(name=METEOR_SCORE, value=1.0),
-                    EvalScore(name=ROUGE_SCORE, value=1.0),
-                    EvalScore(name=BERT_SCORE, value=0.5),
-                    EvalScore(name=DELTA_METEOR_SCORE, value=0.375),
-                    EvalScore(name=DELTA_ROUGE_SCORE, value=0.65),
-                    EvalScore(name=DELTA_BERT_SCORE, value=0.25),
-                ],
-                config=SummarizationAccuracySemanticRobustnessConfig(num_perturbations=2),
-            ),
-            TestCaseSummarizationAccuracySemanticRobustnessEvaluateSample(
-                model_input="Cake is so delicious, I really like cake. I want to open a bakery when I grow up.",
-                target_output="I like cake.",
-                original_model_output="Some model output.",
-                perturbed_model_output_1="Some other model output.",
-                perturbed_model_output_2="Some different model output.",
-                sa_eval_score_original=[
-                    EvalScore(name=METEOR_SCORE, value=1.0),
-                    EvalScore(name=ROUGE_SCORE, value=1.0),
-                    EvalScore(name=BERT_SCORE, value=0.5),
-                ],
-                sa_eval_score_perturbed_1=[
-                    EvalScore(name=METEOR_SCORE, value=0.75),
-                    EvalScore(name=ROUGE_SCORE, value=0.5),
-                    EvalScore(name=BERT_SCORE, value=1.0),
-                ],
-                sa_eval_score_perturbed_2=[
-                    EvalScore(name=METEOR_SCORE, value=0.5),
-                    EvalScore(name=ROUGE_SCORE, value=0.2),
-                    EvalScore(name=BERT_SCORE, value=0.5),
-                ],
-                expected_response=[
-                    EvalScore(name=METEOR_SCORE, value=1.0),
-                    EvalScore(name=ROUGE_SCORE, value=1.0),
-                    EvalScore(name=BERT_SCORE, value=0.5),
-                    EvalScore(name=DELTA_METEOR_SCORE, value=0.375),
-                    EvalScore(name=DELTA_ROUGE_SCORE, value=0.65),
-                    EvalScore(name=DELTA_BERT_SCORE, value=0.25),
-                ],
-                config=SummarizationAccuracySemanticRobustnessConfig(
-                    num_perturbations=2, perturbation_type=RANDOM_UPPER_CASE
-                ),
-            ),
-            TestCaseSummarizationAccuracySemanticRobustnessEvaluateSample(
-                model_input="Cake is so delicious, I really like cake. I want to open a bakery when I grow up.",
-                target_output="I like cake.",
-                original_model_output="Some model output.",
-                perturbed_model_output_1="Some other model output.",
-                perturbed_model_output_2="Some different model output.",
-                sa_eval_score_original=[
-                    EvalScore(name=METEOR_SCORE, value=1.0),
-                    EvalScore(name=ROUGE_SCORE, value=1.0),
-                    EvalScore(name=BERT_SCORE, value=0.5),
-                ],
-                sa_eval_score_perturbed_1=[
-                    EvalScore(name=METEOR_SCORE, value=0.75),
-                    EvalScore(name=ROUGE_SCORE, value=0.5),
-                    EvalScore(name=BERT_SCORE, value=1.0),
-                ],
-                sa_eval_score_perturbed_2=[
-                    EvalScore(name=METEOR_SCORE, value=0.5),
-                    EvalScore(name=ROUGE_SCORE, value=0.2),
-                    EvalScore(name=BERT_SCORE, value=0.5),
-                ],
-                expected_response=[
-                    EvalScore(name=METEOR_SCORE, value=1.0),
-                    EvalScore(name=ROUGE_SCORE, value=1.0),
-                    EvalScore(name=BERT_SCORE, value=0.5),
-                    EvalScore(name=DELTA_METEOR_SCORE, value=0.375),
-                    EvalScore(name=DELTA_ROUGE_SCORE, value=0.65),
-                    EvalScore(name=DELTA_BERT_SCORE, value=0.25),
-                ],
-                config=SummarizationAccuracySemanticRobustnessConfig(
-                    num_perturbations=2, perturbation_type=WHITESPACE_ADD_REMOVE
-                ),
-            ),
-        ],
-    )
-    @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.ray.get")
-    @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.SummarizationAccuracyActor")
-    def test_semantic_robustness_evaluate_sample(self, summarization_accuracy_actor_class, ray_get, test_case):
-        """
-        GIVEN valid inputs
-        WHEN SummarizationAccuracySemanticRobustness.evaluate_sample is called
-        THEN correct List of EvalScores is returned
-        """
-        model = MagicMock()
-        model.predict.side_effect = [
-            (test_case.original_model_output,),
-            (test_case.perturbed_model_output_1,),
-            (test_case.perturbed_model_output_2,),
-        ]
-
-        evaluate_sample_invocation_results = [
-            test_case.sa_eval_score_original,
-            test_case.sa_eval_score_perturbed_1,
-            test_case.sa_eval_score_perturbed_2,
-        ]
-
-        ray_get.side_effect = evaluate_sample_invocation_results
-        summarization_accuracy_actor = MagicMock()
-        summarization_accuracy_actor_class.return_value = summarization_accuracy_actor
-
-        eval_algorithm = SummarizationAccuracySemanticRobustness(test_case.config)
-        assert (
-            eval_algorithm.evaluate_sample(test_case.model_input, test_case.target_output, model)
-            == test_case.expected_response
-        )
-
-    @pytest.mark.parametrize(
-        "test_case",
-        [
-            TestCaseSummarizationAccuracySemanticRobustnessEvaluateSample(
-                model_input="Cake is so delicious, I really like cake. I want to open a bakery when I grow up.",
-                target_output="I like cake.",
-                original_model_output="Some model output.",
-                perturbed_model_output_1="Some other model output.",
-                perturbed_model_output_2="Some different model output.",
-                sa_eval_score_original=[
-                    EvalScore(name=METEOR_SCORE, value=1.0),
-                    EvalScore(name=ROUGE_SCORE, value=1.0),
-                    EvalScore(name=BERT_SCORE, value=0.5),
-                ],
-                sa_eval_score_perturbed_1=[
-                    EvalScore(name=METEOR_SCORE, value=0.75),
-                    EvalScore(name=ROUGE_SCORE, value=0.5),
-                    EvalScore(name=BERT_SCORE, value=1.0),
-                ],
-                sa_eval_score_perturbed_2=[
-                    EvalScore(name=METEOR_SCORE, value=0.5),
-                    EvalScore(name=ROUGE_SCORE, value=0.2),
-                    EvalScore(name=BERT_SCORE, value=0.5),
-                ],
-                expected_response=[
-                    EvalScore(name=METEOR_SCORE, value=1.0),
-                    EvalScore(name=ROUGE_SCORE, value=1.0),
-                    EvalScore(name=BERT_SCORE, value=0.5),
-                    EvalScore(name=DELTA_METEOR_SCORE, value=0.375),
-                    EvalScore(name=DELTA_ROUGE_SCORE, value=0.65),
-                    EvalScore(name=DELTA_BERT_SCORE, value=0.25),
-                ],
-                config=SummarizationAccuracySemanticRobustnessConfig(num_perturbations=2),
-            ),
-        ],
-    )
-    @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.ray.get")
-    @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.SummarizationAccuracyActor")
-    def test_semantic_robustness_evaluate_sample_with_model_output(
-        self, summarization_accuracy_actor_class, ray_get, test_case
-    ):
-        """
-        GIVEN valid inputs with model_output
-        WHEN SummarizationAccuracySemanticRobustness.evaluate_sample is called
-        THEN correct List of EvalScores is returned
-        """
-        model = MagicMock()
-        model.predict.side_effect = [
-            (test_case.perturbed_model_output_1,),
-            (test_case.perturbed_model_output_2,),
-        ]
-
-        evaluate_sample_invocation_results = [
-            test_case.sa_eval_score_original,
-            test_case.sa_eval_score_perturbed_1,
-            test_case.sa_eval_score_perturbed_2,
-        ]
-        ray_get.side_effect = evaluate_sample_invocation_results
-        summarization_accuracy_actor = MagicMock()
-        summarization_accuracy_actor_class.return_value = summarization_accuracy_actor
-
-        eval_algorithm = SummarizationAccuracySemanticRobustness(test_case.config)
-        assert (
-            eval_algorithm.evaluate_sample(
-                model_input=test_case.model_input,
-                model=model,
-                target_output=test_case.target_output,
-                model_output=test_case.original_model_output,
-            )
-            == test_case.expected_response
-        )
-        assert model.predict.call_count == 2
-
-    @pytest.mark.parametrize(
-        "test_case",
-        [
-            TestCaseSummarizationAccuracySemanticRobustnessEvaluateSampleInvalid(
-                model_input="I like cake.",
-                target_output="I like cake.",
-                model=None,
-                expected_error_message="Missing required input: model i.e. ModelRunner, for SummarizationAccuracySemanticRobustness "
-                "evaluate_sample",
-                config=SummarizationAccuracySemanticRobustnessConfig(num_perturbations=2),
-            ),
-            TestCaseSummarizationAccuracySemanticRobustnessEvaluateSampleInvalid(
-                model_input=None,
-                target_output="I like cake.",
-                model=MagicMock(),
-                expected_error_message="Missing required input: model_input, for SummarizationAccuracySemanticRobustness "
-                "evaluate_sample",
-                config=SummarizationAccuracySemanticRobustnessConfig(num_perturbations=2),
-            ),
-            TestCaseSummarizationAccuracySemanticRobustnessEvaluateSampleInvalid(
-                model_input="I like cake.",
-                target_output=None,
-                model=MagicMock(),
-                expected_error_message="Missing required input: target_output, for SummarizationAccuracySemanticRobustness "
-                "evaluate_sample",
-                config=SummarizationAccuracySemanticRobustnessConfig(num_perturbations=2),
-            ),
-        ],
-    )
-    def test_semantic_robustness_evaluate_sample_invalid_input(self, test_case):
-        """
-        GIVEN invalid inputs
-        WHEN SummarizationAccuracySemanticRobustness.evaluate_sample is called
-        THEN correct exception with proper message is raised
-        """
-
-        eval_algorithm = SummarizationAccuracySemanticRobustness(test_case.config, summ_acc_actor=MagicMock())
-        with pytest.raises(EvalAlgorithmClientError, match=test_case.expected_error_message):
-            eval_algorithm.evaluate_sample(test_case.model_input, test_case.target_output, test_case.model)
-
-    class TestCaseSemanticRobustnessInvalidConfig(NamedTuple):
+    class TestCaseInvalidConfig(NamedTuple):
         rouge_type: str
         model_type_for_bertscore: str
         perturbation_type: str
@@ -368,22 +45,22 @@ class TestSummarizationAccuracySemanticRobustness:
     @pytest.mark.parametrize(
         "test_case",
         [
-            TestCaseSemanticRobustnessInvalidConfig(
+            TestCaseInvalidConfig(
                 rouge_type="rouge3",
                 model_type_for_bertscore=None,
                 perturbation_type="butter_finger",
-                expected_error_message="Invalid rouge_type: rouge3 requested in SummarizationAccuracyConfig, "
-                "please choose from acceptable values: ['rouge1', 'rouge2', 'rougeL']",
+                expected_error_message="Invalid rouge_type: rouge3 requested in SummarizationAccuracySemanticRobustnessConfig. "
+                "Please choose from acceptable values: ['rouge1', 'rouge2', 'rougeL'].",
             ),
-            TestCaseSemanticRobustnessInvalidConfig(
+            TestCaseInvalidConfig(
                 rouge_type="rouge1",
                 model_type_for_bertscore="distilbert-base-uncased",
                 perturbation_type="butter_finger",
                 expected_error_message="Invalid model_type_for_bertscore: distilbert-base-uncased requested in "
-                "SummarizationAccuracyConfig, please choose from acceptable values: ["
-                "'microsoft/deberta-xlarge-mnli', 'roberta-large-mnli']",
+                "SummarizationAccuracySemanticRobustnessConfig. Please choose from acceptable values: ["
+                "'microsoft/deberta-xlarge-mnli', 'roberta-large-mnli'].",
             ),
-            TestCaseSemanticRobustnessInvalidConfig(
+            TestCaseInvalidConfig(
                 rouge_type="rouge1",
                 model_type_for_bertscore="distilbert-base-uncased",
                 perturbation_type="my_perturb",
@@ -400,321 +77,183 @@ class TestSummarizationAccuracySemanticRobustness:
                 model_type_for_bertscore=test_case.model_type_for_bertscore,
             )
 
-    class TestCaseSummarizationAccuracySemanticRobustnessEvaluate(NamedTuple):
-        input_dataset: Dataset
-        input_dataset_with_generated_model_output: Dataset
-        prompt_template: Optional[str]
-        dataset_config: Optional[DataConfig]
-        expected_response: List[EvalOutput]
-        save_data: bool
-        dataset_with_scores: Dataset
+    @pytest.mark.parametrize("perturbation_type", [BUTTER_FINGER, RANDOM_UPPER_CASE, WHITESPACE_ADD_REMOVE])
+    def test_init(self, perturbation_type):
+        """
+        GIVEN valid arguments.
+        WHEN a SummarizationAccuracySemanticRobustness is initialized.
+        THEN its instance attributes are of the correct type.
+        """
+        config = SummarizationAccuracySemanticRobustnessConfig(perturbation_type=perturbation_type)
+        sasr = SummarizationAccuracySemanticRobustness(config)
+        assert isinstance(sasr.perturbation_transform, SEMANTIC_PERTURBATIONS[perturbation_type])
+        assert isinstance(sasr.bertscore_model, BertscoreHelperModel)
+
+    class TestCaseEvaluateSample(NamedTuple):
+        original_meteor_score: float
+        original_rouge_score: float
+        original_bert_score: float
+        perturbed_meteor_scores: List[float]
+        perturbed_rouge_scores: List[float]
+        perturbed_bert_scores: List[float]
+        expected_response: List[EvalScore]
 
     @pytest.mark.parametrize(
         "test_case",
         [
-            # Built-in datasets evaluate for dataset without category
-            TestCaseSummarizationAccuracySemanticRobustnessEvaluate(
-                input_dataset=DATASET_NO_CATEGORY,
-                input_dataset_with_generated_model_output=DATASET_NO_CATEGORY_WITH_MODEL_OUTPUT,
-                dataset_config=None,
-                prompt_template=None,
-                save_data=True,
-                dataset_with_scores=DATASET_WITH_SCORES.drop_columns(cols=DatasetColumns.CATEGORY.value.name),
+            TestCaseEvaluateSample(
+                original_meteor_score=1.0,
+                original_rouge_score=1.0,
+                original_bert_score=0.5,
+                perturbed_meteor_scores=[0.75, 0.5],
+                perturbed_rouge_scores=[0.5, 0.2],
+                perturbed_bert_scores=[1.0, 0.5],
                 expected_response=[
-                    EvalOutput(
-                        eval_name="summarization_accuracy_semantic_robustness",
-                        dataset_name=GIGAWORD,
-                        dataset_scores=[
-                            EvalScore(name="rouge", value=0.0),
-                            EvalScore(name="bertscore", value=0.0),
-                            EvalScore(name="meteor", value=0.0),
-                            EvalScore(name="delta_rouge", value=0.0),
-                            EvalScore(name="delta_bertscore", value=0.0),
-                            EvalScore(name="delta_meteor", value=0.0),
-                        ],
-                        prompt_template=BUILT_IN_DATASET_DEFAULT_PROMPT_TEMPLATES[GIGAWORD],
-                        category_scores=None,
-                        output_path="/tmp/eval_results/summarization_accuracy_semantic_robustness_gigaword.jsonl",
-                    ),
-                    EvalOutput(
-                        eval_name="summarization_accuracy_semantic_robustness",
-                        dataset_name=GOV_REPORT,
-                        dataset_scores=[
-                            EvalScore(name="rouge", value=0.0),
-                            EvalScore(name="bertscore", value=0.0),
-                            EvalScore(name="meteor", value=0.0),
-                            EvalScore(name="delta_rouge", value=0.0),
-                            EvalScore(name="delta_bertscore", value=0.0),
-                            EvalScore(name="delta_meteor", value=0.0),
-                        ],
-                        prompt_template=BUILT_IN_DATASET_DEFAULT_PROMPT_TEMPLATES[GOV_REPORT],
-                        category_scores=None,
-                        output_path="/tmp/eval_results/summarization_accuracy_semantic_robustness_gov_report.jsonl",
-                    ),
-                ],
-            ),
-            # Built-in datasets evaluate for dataset with category
-            TestCaseSummarizationAccuracySemanticRobustnessEvaluate(
-                input_dataset=DATASET,
-                input_dataset_with_generated_model_output=DATASET_WITH_MODEL_OUTPUT,
-                dataset_config=None,
-                prompt_template=None,
-                save_data=True,
-                dataset_with_scores=DATASET_WITH_SCORES,
-                expected_response=[
-                    EvalOutput(
-                        eval_name="summarization_accuracy_semantic_robustness",
-                        dataset_name=GIGAWORD,
-                        dataset_scores=[
-                            EvalScore(name="rouge", value=0.0),
-                            EvalScore(name="bertscore", value=0.0),
-                            EvalScore(name="meteor", value=0.0),
-                            EvalScore(name="delta_rouge", value=0.0),
-                            EvalScore(name="delta_bertscore", value=0.0),
-                            EvalScore(name="delta_meteor", value=0.0),
-                        ],
-                        prompt_template=BUILT_IN_DATASET_DEFAULT_PROMPT_TEMPLATES[GIGAWORD],
-                        category_scores=[
-                            CategoryScore(
-                                name="dummy_category_1",
-                                scores=[
-                                    EvalScore(name="rouge", value=0.0),
-                                    EvalScore(name="bertscore", value=0.0),
-                                    EvalScore(name="meteor", value=0.0),
-                                    EvalScore(name="delta_rouge", value=0.0),
-                                    EvalScore(name="delta_bertscore", value=0.0),
-                                    EvalScore(name="delta_meteor", value=0.0),
-                                ],
-                            ),
-                            CategoryScore(
-                                name="dummy_category_2",
-                                scores=[
-                                    EvalScore(name="rouge", value=0.0),
-                                    EvalScore(name="bertscore", value=0.0),
-                                    EvalScore(name="meteor", value=0.0),
-                                    EvalScore(name="delta_rouge", value=0.0),
-                                    EvalScore(name="delta_bertscore", value=0.0),
-                                    EvalScore(name="delta_meteor", value=0.0),
-                                ],
-                            ),
-                        ],
-                        output_path="/tmp/eval_results/summarization_accuracy_semantic_robustness_gigaword.jsonl",
-                    ),
-                    EvalOutput(
-                        eval_name="summarization_accuracy_semantic_robustness",
-                        dataset_name=GOV_REPORT,
-                        dataset_scores=[
-                            EvalScore(name="rouge", value=0.0),
-                            EvalScore(name="bertscore", value=0.0),
-                            EvalScore(name="meteor", value=0.0),
-                            EvalScore(name="delta_rouge", value=0.0),
-                            EvalScore(name="delta_bertscore", value=0.0),
-                            EvalScore(name="delta_meteor", value=0.0),
-                        ],
-                        prompt_template=BUILT_IN_DATASET_DEFAULT_PROMPT_TEMPLATES[GOV_REPORT],
-                        category_scores=[
-                            CategoryScore(
-                                name="dummy_category_1",
-                                scores=[
-                                    EvalScore(name="rouge", value=0.0),
-                                    EvalScore(name="bertscore", value=0.0),
-                                    EvalScore(name="meteor", value=0.0),
-                                    EvalScore(name="delta_rouge", value=0.0),
-                                    EvalScore(name="delta_bertscore", value=0.0),
-                                    EvalScore(name="delta_meteor", value=0.0),
-                                ],
-                            ),
-                            CategoryScore(
-                                name="dummy_category_2",
-                                scores=[
-                                    EvalScore(name="rouge", value=0.0),
-                                    EvalScore(name="bertscore", value=0.0),
-                                    EvalScore(name="meteor", value=0.0),
-                                    EvalScore(name="delta_rouge", value=0.0),
-                                    EvalScore(name="delta_bertscore", value=0.0),
-                                    EvalScore(name="delta_meteor", value=0.0),
-                                ],
-                            ),
-                        ],
-                        output_path="/tmp/eval_results/summarization_accuracy_semantic_robustness_gov_report.jsonl",
-                    ),
-                ],
-            ),
-            # Custom dataset evaluate with input prompt template
-            TestCaseSummarizationAccuracySemanticRobustnessEvaluate(
-                input_dataset=DATASET_NO_CATEGORY,
-                input_dataset_with_generated_model_output=DATASET_NO_CATEGORY_WITH_MODEL_OUTPUT,
-                dataset_config=DataConfig(
-                    dataset_name="my_custom_dataset",
-                    dataset_uri="tba",
-                    dataset_mime_type=MIME_TYPE_JSON,
-                    model_input_location="tba",
-                    target_output_location="tba",
-                    model_output_location=None,
-                    category_location="tba",
-                ),
-                prompt_template="$model_input",
-                save_data=False,
-                dataset_with_scores=DATASET_WITH_SCORES.drop_columns(cols=DatasetColumns.CATEGORY.value.name),
-                expected_response=[
-                    EvalOutput(
-                        eval_name="summarization_accuracy_semantic_robustness",
-                        dataset_name="my_custom_dataset",
-                        dataset_scores=[
-                            EvalScore(name="rouge", value=0.0),
-                            EvalScore(name="bertscore", value=0.0),
-                            EvalScore(name="meteor", value=0.0),
-                            EvalScore(name="delta_rouge", value=0.0),
-                            EvalScore(name="delta_bertscore", value=0.0),
-                            EvalScore(name="delta_meteor", value=0.0),
-                        ],
-                        prompt_template="$model_input",
-                        category_scores=None,
-                        output_path="/tmp/eval_results/summarization_accuracy_semantic_robustness_my_custom_dataset.jsonl",
-                    ),
-                ],
-            ),
-            # Custom dataset evaluate without input prompt template
-            TestCaseSummarizationAccuracySemanticRobustnessEvaluate(
-                input_dataset=DATASET_NO_CATEGORY,
-                input_dataset_with_generated_model_output=DATASET_NO_CATEGORY_WITH_MODEL_OUTPUT,
-                dataset_config=DataConfig(
-                    dataset_name="my_custom_dataset",
-                    dataset_uri="tba",
-                    dataset_mime_type=MIME_TYPE_JSON,
-                    model_input_location="tba",
-                    target_output_location="tba",
-                    model_output_location=None,
-                    category_location="tba",
-                ),
-                prompt_template=None,
-                save_data=False,
-                dataset_with_scores=DATASET_WITH_SCORES.drop_columns(cols=DatasetColumns.CATEGORY.value.name),
-                expected_response=[
-                    EvalOutput(
-                        eval_name="summarization_accuracy_semantic_robustness",
-                        dataset_name="my_custom_dataset",
-                        dataset_scores=[
-                            EvalScore(name="rouge", value=0.0),
-                            EvalScore(name="bertscore", value=0.0),
-                            EvalScore(name="meteor", value=0.0),
-                            EvalScore(name="delta_rouge", value=0.0),
-                            EvalScore(name="delta_bertscore", value=0.0),
-                            EvalScore(name="delta_meteor", value=0.0),
-                        ],
-                        prompt_template=DEFAULT_PROMPT_TEMPLATE,
-                        category_scores=None,
-                        output_path="/tmp/eval_results/summarization_accuracy_semantic_robustness_my_custom_dataset.jsonl",
-                    ),
+                    EvalScore(name=METEOR_SCORE, value=1.0),
+                    EvalScore(name=ROUGE_SCORE, value=1.0),
+                    EvalScore(name=BERT_SCORE, value=0.5),
+                    EvalScore(name=DELTA_METEOR_SCORE, value=0.375),
+                    EvalScore(name=DELTA_ROUGE_SCORE, value=0.65),
+                    EvalScore(name=DELTA_BERT_SCORE, value=0.25),
                 ],
             ),
         ],
     )
-    @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.get_dataset")
-    @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.save_dataset")
-    @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.SummarizationAccuracyActor")
-    @patch.object(SummarizationAccuracySemanticRobustness, "_SummarizationAccuracySemanticRobustness__add_scores")
-    def test_semantic_robustness_evaluate(
+    @patch("fmeval.transforms.semantic_perturbations.RandomUppercase.perturb")
+    @patch("fmeval.transforms.summarization_accuracy_metrics.BertScore.compute_metric")
+    @patch("fmeval.transforms.summarization_accuracy_metrics.RougeScore.compute_metric")
+    @patch("fmeval.transforms.summarization_accuracy_metrics.MeteorScore.compute_metric")
+    def test_semantic_robustness_evaluate_sample(
         self,
-        add_scores,
-        summarization_accuracy_actor_class,
-        save_dataset,
-        get_dataset,
+        mock_meteor_metric,
+        mock_rouge_metric,
+        mock_bert_metric,
+        mock_random_uppercase_perturb,
         test_case,
         config,
     ):
         """
-        GIVEN valid inputs i.e. input data config for a dataset without model_outputs, an input ModelRunner
-            and request to save records with scores
-        WHEN SummarizationAccuracySemanticRobustness evaluate() method is called
-        THEN correct EvalOutput is returned
+        GIVEN a config with perturbation_type = RANDOM_UPPERCASE (wlog).
+        WHEN SummarizationAccuracySemanticRobustness.evaluate_sample is called.
+        THEN the correct list of EvalScores is returned, RandomUppercase.perturb is called,
+            prompts are created from the perturbed model inputs, and the model runner's
+            `predict` method is called on the original prompt (constructed from the
+             original model input) and perturbed prompts (constructed from the perturbed
+             model inputs).
         """
-        add_scores.return_value = test_case.dataset_with_scores
-        get_dataset.return_value = test_case.input_dataset
-        summarization_accuracy_actor_class.return_value = MagicMock()
+        mock_meteor_metric.side_effect = [test_case.original_meteor_score] + test_case.perturbed_meteor_scores
+        mock_rouge_metric.side_effect = [test_case.original_rouge_score] + test_case.perturbed_rouge_scores
+        mock_bert_metric.side_effect = [test_case.original_bert_score] + test_case.perturbed_bert_scores
 
-        eval_algorithm = SummarizationAccuracySemanticRobustness(config)
-        actual_response = eval_algorithm.evaluate(
-            model=MockModelRunner(),
-            dataset_config=test_case.dataset_config,
-            save=test_case.save_data,
-            prompt_template=test_case.prompt_template,
+        mock_random_uppercase_perturb.return_value = ["perturbed input 1", "perturbed input 2"]
+
+        model = Mock()
+        model.predict.side_effect = [("a", None), ("b", None), ("c", None)]
+
+        eval_algorithm = SummarizationAccuracySemanticRobustness(
+            SummarizationAccuracySemanticRobustnessConfig(
+                perturbation_type=RANDOM_UPPER_CASE,
+                num_perturbations=2,
+            ),
         )
-        assert save_dataset.called == test_case.save_data
-        assert actual_response == test_case.expected_response
+        assert (
+            eval_algorithm.evaluate_sample(
+                model_input="the model input", target_output="unused", model=model, prompt_template="Hi $model_input"
+            )
+            == test_case.expected_response
+        )
+        model.predict.assert_has_calls(
+            [call("Hi the model input"), call("Hi perturbed input 1"), call("Hi perturbed input 2")]
+        )
 
-    class TestCaseSummarizationAccuracySemanticRobustnessEvaluateInvalid(NamedTuple):
-        input_dataset: Dataset
-        dataset_config: Optional[DataConfig]
-        prompt_template: Optional[str]
-        model_provided: bool
-        expected_error_message: str
+    class TestCaseEvaluate(NamedTuple):
+        user_provided_prompt_template: Optional[str]
+        dataset_prompt_template: str
 
     @pytest.mark.parametrize(
         "test_case",
         [
-            TestCaseSummarizationAccuracySemanticRobustnessEvaluateInvalid(
-                input_dataset=DATASET_NO_CATEGORY,
-                dataset_config=None,
-                prompt_template=None,
-                model_provided=False,
-                expected_error_message="Missing required input: model i.e. ModelRunner, for SummarizationAccuracySemanticRobustness "
-                "evaluate method",
+            TestCaseEvaluate(
+                user_provided_prompt_template="Summarize: $model_input",
+                dataset_prompt_template="Summarize: $model_input",
             ),
-            TestCaseSummarizationAccuracySemanticRobustnessEvaluateInvalid(
-                input_dataset=DATASET_NO_CATEGORY.drop_columns(cols=[DatasetColumns.MODEL_INPUT.value.name]),
-                dataset_config=DataConfig(
-                    dataset_name="my_custom_dataset",
-                    dataset_uri="tba",
-                    dataset_mime_type=MIME_TYPE_JSON,
-                    model_input_location="tba",
-                    target_output_location="tba",
-                    model_output_location=None,
-                    category_location="tba",
-                ),
-                prompt_template=None,
-                model_provided=True,
-                expected_error_message="Missing required column: model_input, for evaluate() method",
-            ),
-            TestCaseSummarizationAccuracySemanticRobustnessEvaluateInvalid(
-                input_dataset=DATASET_NO_CATEGORY.drop_columns(cols=[DatasetColumns.TARGET_OUTPUT.value.name]),
-                dataset_config=DataConfig(
-                    dataset_name="my_custom_dataset",
-                    dataset_uri="tba",
-                    dataset_mime_type=MIME_TYPE_JSON,
-                    model_input_location="tba",
-                    target_output_location="tba",
-                    model_output_location=None,
-                    category_location="tba",
-                ),
-                prompt_template=None,
-                model_provided=True,
-                expected_error_message="Missing required column: target_output, for evaluate() method",
+            TestCaseEvaluate(
+                user_provided_prompt_template=None,
+                dataset_prompt_template="$model_input",
             ),
         ],
     )
-    @patch("fmeval.model_runners.model_runner.ModelRunner")
+    @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.get_eval_results_path")
+    @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.cleanup_shared_resource")
+    @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.evaluate_dataset")
+    @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.create_shared_resource")
+    @patch(
+        "fmeval.eval_algorithms.summarization_accuracy_semantic_robustness."
+        "SummarizationAccuracySemanticRobustness._build_pipeline"
+    )
     @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.get_dataset")
-    @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.SummarizationAccuracyActor")
-    def test_semantic_robustness_evaluate_invalid_input(
+    @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.get_dataset_configs")
+    @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.BertscoreHelperModel")
+    def test_evaluate(
         self,
-        summarization_accuracy_actor_class,
-        get_dataset,
-        model,
+        mock_bertscore_model_cls,
+        mock_get_dataset_configs,
+        mock_get_dataset,
+        mock_build_pipeline,
+        mock_create_shared_resource,
+        mock_evaluate_dataset,
+        mock_cleanup_shared_resource,
+        mock_get_results_path,
         test_case,
-        config,
     ):
         """
-        GIVEN invalid inputs
-        WHEN SummarizationAccuracySemanticRobustness evaluate is called
-        THEN correct exception with proper message is raised
+        GIVEN a SummarizationAccuracySemanticRobustness instance.
+        WHEN its evaluate method is called with valid arguments.
+        THEN `evaluate_dataset` is called with the correct arguments.
         """
-        summarization_accuracy_actor_class.return_value = MagicMock()
-        eval_algorithm = SummarizationAccuracySemanticRobustness(config)
-        get_dataset.return_value = test_case.input_dataset
-        if not test_case.model_provided:
-            model = None
-        with pytest.raises(EvalAlgorithmClientError, match=re.escape(test_case.expected_error_message)):
-            eval_algorithm.evaluate(
-                model=model, dataset_config=test_case.dataset_config, prompt_template=test_case.prompt_template
-            )
+        mock_bertscore_model_cls.return_value = Mock()
+
+        dataset_config = Mock()
+        dataset_config.dataset_name = "my_custom_dataset"
+        mock_get_dataset_configs.return_value = [dataset_config]
+
+        mock_dataset = Mock()
+        # So that validate_dataset does not error
+        mock_dataset.columns = Mock(
+            return_value=[DatasetColumns.MODEL_INPUT.value.name, DatasetColumns.TARGET_OUTPUT.value.name]
+        )
+        mock_get_dataset.return_value = mock_dataset
+
+        mock_build_pipeline.return_value = Mock()
+        mock_get_results_path.return_value = "/path/to/results"
+        model_runner = Mock()
+
+        sasr = SummarizationAccuracySemanticRobustness()
+        output = sasr.evaluate(
+            model=model_runner,
+            dataset_config=dataset_config,
+            prompt_template=test_case.user_provided_prompt_template,
+            num_records=162,
+            save=True,
+        )
+
+        mock_create_shared_resource.assert_called_once_with(sasr.bertscore_model)
+        mock_evaluate_dataset.assert_called_once_with(
+            dataset=mock_dataset,
+            pipeline=mock_build_pipeline.return_value,
+            dataset_name=dataset_config.dataset_name,
+            eval_name=sasr.eval_name,
+            metric_names=ORIGINAL_SCORES + DELTA_SCORES,
+            eval_results_path="/path/to/results",
+            model=model_runner,
+            prompt_template=test_case.dataset_prompt_template,
+            agg_method=MEAN,
+            save=True,
+        )
+        mock_build_pipeline.assert_called_once_with(
+            model_runner,
+            test_case.dataset_prompt_template,
+            mock_create_shared_resource.return_value,
+        )
+        mock_cleanup_shared_resource.assert_called_once_with(mock_create_shared_resource.return_value)
+        assert output == [mock_evaluate_dataset.return_value]

--- a/test/unit/eval_algorithms/test_summarization_accuracy_semantic_robustness.py
+++ b/test/unit/eval_algorithms/test_summarization_accuracy_semantic_robustness.py
@@ -19,6 +19,7 @@ from fmeval.eval_algorithms.summarization_accuracy_semantic_robustness import (
     DELTA_SCORES,
 )
 from fmeval.exceptions import EvalAlgorithmClientError
+from fmeval.eval_algorithms.helper_models.helper_model import BertscoreHelperModel
 from fmeval.model_runners.model_runner import ModelRunner
 
 
@@ -77,8 +78,7 @@ class TestSummarizationAccuracySemanticRobustness:
             )
 
     @pytest.mark.parametrize("perturbation_type", [BUTTER_FINGER, RANDOM_UPPER_CASE, WHITESPACE_ADD_REMOVE])
-    @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.create_shared_resource")
-    def test_init(self, mock_created_shared_resource, perturbation_type):
+    def test_init(self, perturbation_type):
         """
         GIVEN valid arguments.
         WHEN a SummarizationAccuracySemanticRobustness is initialized.
@@ -87,7 +87,7 @@ class TestSummarizationAccuracySemanticRobustness:
         config = SummarizationAccuracySemanticRobustnessConfig(perturbation_type=perturbation_type)
         sasr = SummarizationAccuracySemanticRobustness(config)
         assert isinstance(sasr.perturbation_transform, SEMANTIC_PERTURBATIONS[perturbation_type])
-        mock_created_shared_resource.assert_called_once()
+        assert isinstance(sasr.bertscore_model, BertscoreHelperModel)
 
     class TestCaseEvaluateSample(NamedTuple):
         original_meteor_score: float
@@ -184,6 +184,7 @@ class TestSummarizationAccuracySemanticRobustness:
         ],
     )
     @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.get_eval_results_path")
+    @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.cleanup_shared_resource")
     @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.evaluate_dataset")
     @patch("fmeval.eval_algorithms.summarization_accuracy_semantic_robustness.create_shared_resource")
     @patch(
@@ -201,6 +202,7 @@ class TestSummarizationAccuracySemanticRobustness:
         mock_build_pipeline,
         mock_create_shared_resource,
         mock_evaluate_dataset,
+        mock_cleanup_shared_resource,
         mock_get_results_path,
         test_case,
     ):
@@ -235,6 +237,7 @@ class TestSummarizationAccuracySemanticRobustness:
             save=True,
         )
 
+        mock_create_shared_resource.assert_called_once_with(sasr.bertscore_model)
         mock_evaluate_dataset.assert_called_once_with(
             dataset=mock_dataset,
             pipeline=mock_build_pipeline.return_value,
@@ -250,5 +253,7 @@ class TestSummarizationAccuracySemanticRobustness:
         mock_build_pipeline.assert_called_once_with(
             model_runner,
             test_case.dataset_prompt_template,
+            mock_create_shared_resource.return_value,
         )
+        mock_cleanup_shared_resource.assert_called_once_with(mock_create_shared_resource.return_value)
         assert output == [mock_evaluate_dataset.return_value]

--- a/test/unit/transforms/test_summarization_accuracy_metrics.py
+++ b/test/unit/transforms/test_summarization_accuracy_metrics.py
@@ -114,7 +114,7 @@ def test_bert_score_call_with_bertscore_model_object():
     we already have @validate_call to handle that.
     """
     mock_bertscore_model = Mock(spec=BertscoreHelperModel)
-    mock_bertscore_model.invoke_model = Mock()
+    mock_bertscore_model.get_helper_scores = Mock()
 
     bs = BertScore(
         target_output_keys=["target_output"],
@@ -125,7 +125,7 @@ def test_bert_score_call_with_bertscore_model_object():
     )
     sample = {"target_output": "Hello there!", "model_output": "Hi"}
     bs(sample)
-    mock_bertscore_model.invoke_model.assert_called_once_with("Hello there!", "Hi")
+    mock_bertscore_model.get_helper_scores.assert_called_once_with("Hello there!", "Hi")
 
 
 def test_bert_score_call_with_ray_actor_handle():
@@ -138,8 +138,8 @@ def test_bert_score_call_with_ray_actor_handle():
     we already have @validate_call to handle that.
     """
     mock_bertscore_model = Mock(spec=ObjectRef)
-    mock_bertscore_model.invoke_model = Mock()
-    mock_bertscore_model.invoke_model.remote = Mock(return_value="remote invocation result")
+    mock_bertscore_model.get_helper_scores = Mock()
+    mock_bertscore_model.get_helper_scores.remote = Mock(return_value="remote invocation result")
 
     with patch("fmeval.transforms.summarization_accuracy_metrics.ray.get") as mock_ray_get:
         bs = BertScore(
@@ -151,7 +151,7 @@ def test_bert_score_call_with_ray_actor_handle():
         )
         sample = {"target_output": "Hello there!", "model_output": "Hi"}
         bs(sample)
-        mock_bertscore_model.invoke_model.remote.assert_called_once_with("Hello there!", "Hi")
+        mock_bertscore_model.get_helper_scores.remote.assert_called_once_with("Hello there!", "Hi")
         mock_ray_get.assert_called_once_with("remote invocation result")
 
 


### PR DESCRIPTION
*Description of changes:*
See title. This PR also fixes a bug introduced in the previous PR where the `invoke_model` call in `BertScore` was not replaced with `get_helper_scores`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
