### PR TITLE
fix: set default region for boto3 client to access built-in datasets

### DIFF
--- a/src/fmeval/constants.py
+++ b/src/fmeval/constants.py
@@ -16,6 +16,10 @@ PARTITION_MULTIPLIER = 5
 SAGEMAKER_SERVICE_ENDPOINT_URL = "SAGEMAKER_SERVICE_ENDPOINT_URL"
 SAGEMAKER_RUNTIME_ENDPOINT_URL = "SAGEMAKER_RUNTIME_ENDPOINT_URL"
 
+# We default the boto3 client region to us-west-2 as the dataset bucket cannot be accessed from opt-in regions.
+BUILT_IN_DATASET_PREFIX = "s3://fmeval/datasets"
+BUILT_IN_DATASET_DEFAULT_REGION = "us-west-2"
+
 
 @dataclass(frozen=True)
 class Column:

--- a/src/fmeval/data_loaders/util.py
+++ b/src/fmeval/data_loaders/util.py
@@ -7,7 +7,15 @@ import urllib.parse
 
 from typing import Type, Optional
 from fmeval import util
-from fmeval.constants import MIME_TYPE_JSON, MIME_TYPE_JSONLINES, PARTITION_MULTIPLIER, SEED, MAX_ROWS_TO_TAKE
+from fmeval.constants import (
+    MIME_TYPE_JSON,
+    MIME_TYPE_JSONLINES,
+    PARTITION_MULTIPLIER,
+    SEED,
+    MAX_ROWS_TO_TAKE,
+    BUILT_IN_DATASET_PREFIX,
+    BUILT_IN_DATASET_DEFAULT_REGION,
+)
 from fmeval.data_loaders.data_sources import DataSource, LocalDataFile, S3DataFile, DataFile, S3Uri
 from fmeval.data_loaders.json_data_loader import JsonDataLoaderConfig, JsonDataLoader
 from fmeval.data_loaders.json_parser import JsonParser
@@ -147,8 +155,13 @@ def _get_s3_data_source(dataset_uri) -> S3DataFile:
     :param dataset_uri: s3 dataset uri
     :return: S3DataFile object with dataset uri
     """
+    s3_client = (
+        boto3.client("s3", region_name=BUILT_IN_DATASET_DEFAULT_REGION)
+        if dataset_uri.startswith(BUILT_IN_DATASET_PREFIX)
+        else client
+    )
     s3_uri = S3Uri(dataset_uri)
-    s3_obj = client.get_object(Bucket=s3_uri.bucket, Key=s3_uri.key)
+    s3_obj = s3_client.get_object(Bucket=s3_uri.bucket, Key=s3_uri.key)
     if "application/x-directory" in s3_obj["ContentType"]:
         # TODO: extend support to directories
         raise EvalAlgorithmClientError("Please provide a s3 file path instead of a directory path.")


### PR DESCRIPTION
*Description of changes:*

Set s3 boto3 client region to `us-west-2` when accessing built-in datasets to fix invalid dataset path issue in opt-in regions. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
