### PR TITLE
fix: fix s3 uri validation for built-in datasets

### DIFF
--- a/src/fmeval/data_loaders/data_sources.py
+++ b/src/fmeval/data_loaders/data_sources.py
@@ -1,11 +1,11 @@
+import boto3
 import botocore.response
 import botocore.errorfactory
 import urllib.parse
 from typing import IO
 from abc import ABC, abstractmethod
-from fmeval.exceptions import EvalAlgorithmClientError
 from fmeval.constants import BUILT_IN_DATASET_PREFIX, BUILT_IN_DATASET_DEFAULT_REGION
-import boto3
+from fmeval.exceptions import EvalAlgorithmClientError
 
 
 class DataSource(ABC):

--- a/src/fmeval/data_loaders/data_sources.py
+++ b/src/fmeval/data_loaders/data_sources.py
@@ -1,10 +1,11 @@
-import boto3
 import botocore.response
 import botocore.errorfactory
 import urllib.parse
 from typing import IO
 from abc import ABC, abstractmethod
 from fmeval.exceptions import EvalAlgorithmClientError
+from fmeval.constants import BUILT_IN_DATASET_PREFIX, BUILT_IN_DATASET_DEFAULT_REGION
+import boto3
 
 
 class DataSource(ABC):
@@ -85,7 +86,7 @@ class S3DataFile(DataFile):
     def __init__(self, file_path: str):
         # We cannot inject the client b/c
         # it is not serializable by Ray.
-        self._client = boto3.client("s3")
+        self._client = get_s3_client(file_path)
         super().__init__(file_path)
 
     def open(self, mode="r") -> botocore.response.StreamingBody:  # type: ignore
@@ -105,3 +106,18 @@ class S3DataFile(DataFile):
         """
         serialized_data = (self.uri,)
         return S3DataFile, serialized_data
+
+
+def get_s3_client(uri: str) -> boto3.client:
+    """
+    Util method to return boto3 s3 client. For built-in datasets, the boto3 client region is default to us-west-2 as
+        the bucket is not accessible in opt-in regions.
+    :param uri: s3 dataset uri
+    :return: boto3 s3 client
+    """
+    s3_client = (
+        boto3.client("s3", region_name=BUILT_IN_DATASET_DEFAULT_REGION)
+        if uri.startswith(BUILT_IN_DATASET_PREFIX)
+        else boto3.client("s3")
+    )
+    return s3_client

--- a/src/fmeval/data_loaders/util.py
+++ b/src/fmeval/data_loaders/util.py
@@ -180,8 +180,13 @@ def _is_valid_s3_uri(uri: str) -> bool:
     if parsed_url.scheme.lower() not in ["s3", "s3n", "s3a"]:
         return False
     try:
+        s3_client = (
+            boto3.client("s3", region_name=BUILT_IN_DATASET_DEFAULT_REGION)
+            if uri.startswith(BUILT_IN_DATASET_PREFIX)
+            else client
+        )
         s3_uri = S3Uri(uri)
-        client.get_object(Bucket=s3_uri.bucket, Key=s3_uri.key)
+        s3_client.get_object(Bucket=s3_uri.bucket, Key=s3_uri.key)
         return True
     except botocore.errorfactory.ClientError:
         return False

--- a/src/fmeval/data_loaders/util.py
+++ b/src/fmeval/data_loaders/util.py
@@ -13,10 +13,8 @@ from fmeval.constants import (
     PARTITION_MULTIPLIER,
     SEED,
     MAX_ROWS_TO_TAKE,
-    BUILT_IN_DATASET_PREFIX,
-    BUILT_IN_DATASET_DEFAULT_REGION,
 )
-from fmeval.data_loaders.data_sources import DataSource, LocalDataFile, S3DataFile, DataFile, S3Uri
+from fmeval.data_loaders.data_sources import DataSource, LocalDataFile, S3DataFile, DataFile, S3Uri, get_s3_client
 from fmeval.data_loaders.json_data_loader import JsonDataLoaderConfig, JsonDataLoader
 from fmeval.data_loaders.json_parser import JsonParser
 from fmeval.data_loaders.data_config import DataConfig
@@ -155,11 +153,7 @@ def _get_s3_data_source(dataset_uri) -> S3DataFile:
     :param dataset_uri: s3 dataset uri
     :return: S3DataFile object with dataset uri
     """
-    s3_client = (
-        boto3.client("s3", region_name=BUILT_IN_DATASET_DEFAULT_REGION)
-        if dataset_uri.startswith(BUILT_IN_DATASET_PREFIX)
-        else client
-    )
+    s3_client = get_s3_client(dataset_uri)
     s3_uri = S3Uri(dataset_uri)
     s3_obj = s3_client.get_object(Bucket=s3_uri.bucket, Key=s3_uri.key)
     if "application/x-directory" in s3_obj["ContentType"]:
@@ -180,11 +174,7 @@ def _is_valid_s3_uri(uri: str) -> bool:
     if parsed_url.scheme.lower() not in ["s3", "s3n", "s3a"]:
         return False
     try:
-        s3_client = (
-            boto3.client("s3", region_name=BUILT_IN_DATASET_DEFAULT_REGION)
-            if uri.startswith(BUILT_IN_DATASET_PREFIX)
-            else client
-        )
+        s3_client = get_s3_client(uri)
         s3_uri = S3Uri(uri)
         s3_client.get_object(Bucket=s3_uri.bucket, Key=s3_uri.key)
         return True

--- a/test/unit/data_loaders/test_util.py
+++ b/test/unit/data_loaders/test_util.py
@@ -279,10 +279,10 @@ class TestDataLoaderUtil:
         WHEN _is_valid_s3_uri is called
         THEN False is returned
         """
-        with patch(
-            "fmeval.data_loaders.util.client.get_object",
-            side_effect=botocore.errorfactory.ClientError({"error": "blah"}, "blah"),
-        ):
+        with patch("src.fmeval.data_loaders.data_sources.boto3.client") as mock_s3_client:
+            mock_s3_client.return_value.get_object = Mock(
+                side_effect=botocore.errorfactory.ClientError({"error": "blah"}, "blah")
+            )
             assert not _is_valid_s3_uri("s3://non/existent/object")
 
     @pytest.mark.parametrize("file_path", ["path/to/file", "file://path/to/file"])

--- a/test/unit/data_loaders/test_util.py
+++ b/test/unit/data_loaders/test_util.py
@@ -191,7 +191,7 @@ class TestDataLoaderUtil:
         WHEN get_data_source is called
         THEN an S3DataFile with the correct URI is returned
         """
-        with patch("fmeval.data_loaders.util.client") as mock_s3_client:
+        with patch("src.fmeval.data_loaders.data_sources.boto3.client") as mock_s3_client:
             mock_s3_client.get_object = Mock(return_value={"ContentType": "binary/octet-stream"})
             dataset_uri = S3_PREFIX + DATASET_URI
             data_source = get_data_source(dataset_uri)
@@ -221,8 +221,10 @@ class TestDataLoaderUtil:
         WHEN get_data_source is called
         THEN the correct exception is raised
         """
-        with patch("fmeval.data_loaders.util.client") as mock_s3_client:
-            mock_s3_client.get_object = Mock(return_value={"ContentType": "application/x-directory; charset=UTF-8"})
+        with patch("src.fmeval.data_loaders.data_sources.boto3.client") as mock_s3_client:
+            mock_s3_client.return_value.get_object = Mock(
+                return_value={"ContentType": "application/x-directory; charset=UTF-8"}
+            )
             dataset_uri = S3_PREFIX + DIRECTORY_URI
             with pytest.raises(
                 EvalAlgorithmClientError, match="Please provide a s3 file path instead of a directory path."
@@ -257,7 +259,8 @@ class TestDataLoaderUtil:
         THEN True is returned
         """
         dataset_uri = S3_PREFIX + DATASET_URI
-        with patch("fmeval.data_loaders.util.client.get_object", return_value=Mock()):
+        with patch("src.fmeval.data_loaders.data_sources.boto3.client") as mock_s3_client:
+            mock_s3_client.return_value.get_object.return_value = Mock()
             assert _is_valid_s3_uri(dataset_uri)
 
     def test_is_valid_s3_uri_invalid_scheme(self):
@@ -276,10 +279,8 @@ class TestDataLoaderUtil:
         WHEN _is_valid_s3_uri is called
         THEN False is returned
         """
-        with patch(
-            "fmeval.data_loaders.util.client.get_object",
-            side_effect=botocore.errorfactory.ClientError({"error": "blah"}, "blah"),
-        ):
+        with patch("fmeval.data_loaders.util.boto3") as mock_boto3:
+            mock_boto3.client.get_object.side_effect = botocore.errorfactory.ClientError({"error": "blah"}, "blah")
             assert not _is_valid_s3_uri("s3://non/existent/object")
 
     @pytest.mark.parametrize("file_path", ["path/to/file", "file://path/to/file"])

--- a/test/unit/data_loaders/test_util.py
+++ b/test/unit/data_loaders/test_util.py
@@ -279,8 +279,10 @@ class TestDataLoaderUtil:
         WHEN _is_valid_s3_uri is called
         THEN False is returned
         """
-        with patch("fmeval.data_loaders.util.boto3") as mock_boto3:
-            mock_boto3.client.get_object.side_effect = botocore.errorfactory.ClientError({"error": "blah"}, "blah")
+        with patch(
+            "fmeval.data_loaders.util.client.get_object",
+            side_effect=botocore.errorfactory.ClientError({"error": "blah"}, "blah"),
+        ):
             assert not _is_valid_s3_uri("s3://non/existent/object")
 
     @pytest.mark.parametrize("file_path", ["path/to/file", "file://path/to/file"])


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- fix s3 uri validation for built-in datasets by creating boto3 client with  `us-west-2` region.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
