### PR TITLE
fix: update output record key validation logic in validate_call

### DIFF
--- a/src/fmeval/transforms/util.py
+++ b/src/fmeval/transforms/util.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Set, Callable, Tuple
+from typing import Any, Callable, Dict, List, Tuple
 from fmeval.util import assert_condition
 
 

--- a/test/unit/transforms/test_common.py
+++ b/test/unit/transforms/test_common.py
@@ -55,9 +55,10 @@ def test_get_model_outputs_init_success():
         assert get_model_outputs.model_runner == mock_model_runner
 
 
+@pytest.mark.parametrize("sample", [{"input": "Hello"}, {"input": "Hello", "model_output": "original output"}])
 @pytest.mark.parametrize("model_output", [None, "some output"])
 @pytest.mark.parametrize("log_prob", [None, -0.162])
-def test_get_model_outputs_call_success(model_output, log_prob):
+def test_get_model_outputs_call_success(model_output, log_prob, sample):
     """
     GIVEN a GetModelOutputs instance.
     WHEN its __call__ method is called on a record.
@@ -70,7 +71,6 @@ def test_get_model_outputs_call_success(model_output, log_prob):
         get_model_outputs = GetModelOutputs(
             input_to_output_keys={"input": ["model_output"]}, model_runner=mock_model_runner
         )
-        sample = {"input": "Hello"}
         result = get_model_outputs(sample)
         assert result == {"input": "Hello", "model_output": model_output}
 

--- a/test/unit/transforms/test_util.py
+++ b/test/unit/transforms/test_util.py
@@ -4,7 +4,6 @@ from unittest.mock import Mock
 import pytest
 from typing import NamedTuple, Set, Dict, Any, Optional, List, Tuple
 from fmeval.transforms.util import (
-    validate_added_keys,
     validate_existing_keys,
     validate_key_uniqueness,
     validate_call,
@@ -62,49 +61,6 @@ def test_validate_existing_keys_failure():
         ),
     ):
         validate_existing_keys(record, keys)
-
-
-def test_validate_added_keys_success():
-    """
-    GIVEN arguments that should not raise an exception.
-    WHEN validate_added_keys is called.
-    THEN no exception is raised.
-    """
-    current_keys = {"a", "b", "c", "d"}
-    original_keys = {"a", "c"}
-    keys_to_add = {"b", "d"}
-    validate_added_keys(current_keys, original_keys, keys_to_add)
-
-
-class TestCaseValidateAddedKeys(NamedTuple):
-    current_keys: Set[str]
-    original_keys: Set[str]
-    keys_to_add: Set[str]
-
-
-@pytest.mark.parametrize(
-    "current_keys, original_keys, keys_to_add",
-    [
-        TestCaseValidateAddedKeys(
-            current_keys={"a", "b", "c", "d"},
-            original_keys={"a", "c"},
-            keys_to_add={"b"},
-        ),
-        TestCaseValidateAddedKeys(
-            current_keys={"a", "b", "c"},
-            original_keys={"a", "c"},
-            keys_to_add={"b", "d"},
-        ),
-    ],
-)
-def test_validate_added_keys_failure(current_keys, original_keys, keys_to_add):
-    """
-    GIVEN arguments that should raise an exception.
-    WHEN validate_added_keys is called.
-    THEN an EvalAlgorithmInternalError is raised.
-    """
-    with pytest.raises(EvalAlgorithmInternalError, match="The set difference"):
-        validate_added_keys(current_keys, original_keys, keys_to_add)
 
 
 def test_validate_call_success():

--- a/test/unit/transforms/test_util.py
+++ b/test/unit/transforms/test_util.py
@@ -2,7 +2,7 @@ import re
 from unittest.mock import Mock
 
 import pytest
-from typing import NamedTuple, Set, Dict, Any, Optional, List, Tuple
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 from fmeval.transforms.util import (
     validate_existing_keys,
     validate_key_uniqueness,


### PR DESCRIPTION
*Description of changes:*
This PR relaxes the validation done in `validate_call` to only check if the keys in the `self.output_keys` attribute of the `Transform` are present in the output of `__call__`. Previously, we checked that the set difference between the current keys and the original keys is exactly equal to `self.output_keys`, but this validation is too strict for the BYO model outputs use case, where `GetModelOutputs` should overwrite existing model outputs in the record without validations failing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
