### PR TITLE
feat: add fmeval-specific user agent header to botocore config for telemetry purposes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,29 @@ Once you have created a virtual environment with python3.10, run the following c
 ./devtool all
 ```
 
+**Note**: If you are on a Mac, the `install_poetry_version` devtool command may fail when running the poetry installation script. If there is a failure, you should get error logs sent to a file with a name like `poetry-installer-error-cvulo5s0.log`. Open the logs, and if the error message looks like the following:
+```
+dyld[10908]: Library not loaded: @loader_path/../../../../Python.framework/Versions/3.10/Python
+  Referenced from: <8A5DEEDB-CE8E-325F-88B0-B0397BD5A5DE> /Users/daniezh/Library/Application Support/pypoetry/venv/bin/python3
+  Reason: tried: '/Users/daniezh/Library/Application Support/pypoetry/venv/bin/../../../../Python.framework/Versions/3.10/Python' (no such file), '/Library/Frameworks/Python.framework/Versions/3.10/Python' (no such file), '/System/Library/Frameworks/Python.framework/Versions/3.10/Python' (no such file, not in dyld cache)
+
+Traceback:
+
+  File "<string>", line 923, in main
+  File "<string>", line 562, in run
+```
+then you will need to tweak the poetry installation script and re-run it.
+
+Steps:
+1. `curl -sSL https://install.python-poetry.org > poetry_script.py`
+2. Change the `symlinks` argument in `builder = venv.EnvBuilder(clear=True, with_pip=True, symlinks=False)` to `True`. See mionker's comment [here](https://github.com/python-poetry/install.python-poetry.org/issues/56) for an explanation.
+3. `python poetry_script.py --version 1.2.0` (where `1.2.0` is the version listed in `devtool`; this may change after the time of this writing).
+4. Confirm installation via `poetry --version`
+
+Additionally, if you already have an existing version of Poetry installed and want to install a new version, before you re-run the above command, you will need to uninstall Poetry:
+
+`curl -sSL https://install.python-poetry.org | python3 - --uninstall`
+
 Before submitting a PR, rerun `./devtool all` for testing and linting. It should run without errors.
 
 ### Adding python dependencies

--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ eval_output = eval_algo.evaluate(model=model_runner, dataset_config=config)
 [examples](https://github.com/aws/fmeval/tree/main/examples) for more details around the usage of
 eval algorithms.*
 
+## Telemetry
+By default, `fmeval` has very basic telemetry enabled, purely for tracking usage of the package.
+The only data that is tracked is the number of SageMaker, JumpStart, or Bedrock `ModelRunner` objects that get created.
+*We do not collect any user-level data*.
+
+The `ModelRunner` data in question gets collected via the use of an fmeval-specific user agent header that is used by the botocore session that manages these model runners.
+See `fmeval.model_runners.util.get_user_agent_extra` and `fmeval.model_runners.util.get_boto_session` for implementation details.
+
+To opt out of telemetry, simply set the `DISABLE_FMEVAL_TELEMETRY` environment variable to any non-null value.
+
 ## Troubleshooting
 
 1. Users running `fmeval` on a Windows machine may encounter the error `OSError: [Errno 0] AssignProcessToJobObject() failed` when `fmeval` internally calls `ray.init()`. This OS error is a known Ray issue, and is detailed [here](https://github.com/ray-project/ray/issues/21994). Multiple users have reported that installing Python from the [official Python website](https://www.python.org/downloads/windows/) rather than the Microsoft store fixes this issue. You can view more details on limitations of running Ray on Windows on [Ray's webpage](https://docs.ray.io/en/latest/ray-overview/installation.html#windows-support).

--- a/devtool
+++ b/devtool
@@ -33,7 +33,7 @@ lint() {
     echo "===================="
     echo "Note: This only syncs poetry.lock with pyproject.toml.  If you wish to update all downstream dependencies, run 'poetry update'"
 
-    install_poetry_version 1.8.2
+    install_poetry
     poetry lock --check || (poetry lock --no-update && poetry lock --check)
     echo ""
 

--- a/src/fmeval/constants.py
+++ b/src/fmeval/constants.py
@@ -20,6 +20,9 @@ SAGEMAKER_RUNTIME_ENDPOINT_URL = "SAGEMAKER_RUNTIME_ENDPOINT_URL"
 BUILT_IN_DATASET_PREFIX = "s3://fmeval/datasets"
 BUILT_IN_DATASET_DEFAULT_REGION = "us-west-2"
 
+# Environment variable for disabling telemetry
+DISABLE_FMEVAL_TELEMETRY = "DISABLE_FMEVAL_TELEMETRY"
+
 
 @dataclass(frozen=True)
 class Column:

--- a/src/fmeval/model_runners/util.py
+++ b/src/fmeval/model_runners/util.py
@@ -21,10 +21,7 @@ def get_user_agent_extra() -> str:
     """
     :return: A string to be used as the user_agent_extra parameter in a botocore config.
     """
-    return (
-        "" if os.getenv(DISABLE_FMEVAL_TELEMETRY)
-        else f"fmeval/{get_fmeval_package_version()}"
-    )
+    return "" if os.getenv(DISABLE_FMEVAL_TELEMETRY) else f"fmeval/{get_fmeval_package_version()}"
 
 
 def get_boto_session(
@@ -41,7 +38,7 @@ def get_boto_session(
             # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html
             retries={"mode": boto_retry_mode, "max_attempts": retry_attempts},
             # https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html
-            user_agent_extra=get_user_agent_extra()
+            user_agent_extra=get_user_agent_extra(),
         )
     )
     return boto3.session.Session(botocore_session=botocore_session)

--- a/src/fmeval/model_runners/util.py
+++ b/src/fmeval/model_runners/util.py
@@ -10,9 +10,10 @@ import botocore.config
 import sagemaker
 
 from fmeval.constants import SAGEMAKER_SERVICE_ENDPOINT_URL, SAGEMAKER_RUNTIME_ENDPOINT_URL, DISABLE_FMEVAL_TELEMETRY
+from fmeval.util import get_fmeval_package_version
+from sagemaker.user_agent import determine_prefix
 from mypy_boto3_bedrock.client import BedrockClient
 
-from fmeval.util import get_fmeval_package_version
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +22,17 @@ def get_user_agent_extra() -> str:
     """
     :return: A string to be used as the user_agent_extra parameter in a botocore config.
     """
-    return "" if os.getenv(DISABLE_FMEVAL_TELEMETRY) else f"fmeval/{get_fmeval_package_version()}"
+    # Obtain user-agent headers for information such as SageMaker notebook instance type and SageMaker Studio app type.
+    # We manually obtain these headers, so we can pass them in the user_agent_extra parameter of botocore.config.Config.
+    # This is because although these headers are already obtained in the sagemaker.session.Session initializer,
+    # there is currently a bug in the sagemaker.session.Session code where these headers get assigned to an instance
+    # attribute, but don't actually show up in the user-agent header when making API calls.
+    sagemaker_python_sdk_headers = determine_prefix()
+    return (
+        sagemaker_python_sdk_headers
+        if os.getenv(DISABLE_FMEVAL_TELEMETRY)
+        else f"{sagemaker_python_sdk_headers} fmeval/{get_fmeval_package_version()}"
+    )
 
 
 def get_boto_session(

--- a/src/fmeval/model_runners/util.py
+++ b/src/fmeval/model_runners/util.py
@@ -9,10 +9,22 @@ import botocore.session
 import botocore.config
 import sagemaker
 
-from fmeval.constants import SAGEMAKER_SERVICE_ENDPOINT_URL, SAGEMAKER_RUNTIME_ENDPOINT_URL
+from fmeval.constants import SAGEMAKER_SERVICE_ENDPOINT_URL, SAGEMAKER_RUNTIME_ENDPOINT_URL, DISABLE_FMEVAL_TELEMETRY
 from mypy_boto3_bedrock.client import BedrockClient
 
+from fmeval.util import get_fmeval_package_version
+
 logger = logging.getLogger(__name__)
+
+
+def get_user_agent_extra() -> str:
+    """
+    :return: A string to be used as the user_agent_extra parameter in a botocore config.
+    """
+    return (
+        "" if os.getenv(DISABLE_FMEVAL_TELEMETRY)
+        else f"fmeval/{get_fmeval_package_version()}"
+    )
 
 
 def get_boto_session(
@@ -27,7 +39,9 @@ def get_boto_session(
     botocore_session.set_default_client_config(
         botocore.config.Config(
             # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html
-            retries={"mode": boto_retry_mode, "max_attempts": retry_attempts}
+            retries={"mode": boto_retry_mode, "max_attempts": retry_attempts},
+            # https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html
+            user_agent_extra=get_user_agent_extra()
         )
     )
     return boto3.session.Session(botocore_session=botocore_session)

--- a/src/fmeval/util.py
+++ b/src/fmeval/util.py
@@ -1,8 +1,8 @@
 import os
 import re
-
 import ray
 import multiprocessing as mp
+import importlib.metadata
 
 from ray.actor import ActorHandle
 from fmeval.constants import EVAL_RESULTS_PATH, DEFAULT_EVAL_RESULTS_PATH, PARALLELIZATION_FACTOR
@@ -115,7 +115,7 @@ def create_shared_resource(resource: object, num_cpus: int = 1) -> ActorHandle:
 
 
 def cleanup_shared_resource(resource: ActorHandle) -> None:
-    """Removes the resource from shared memory.
+    """Remove the resource from shared memory.
 
     Concretely, this function kills the Ray actor corresponding
     to `resource`, which in most cases will be an actor created
@@ -126,3 +126,10 @@ def cleanup_shared_resource(resource: ActorHandle) -> None:
     :returns: None
     """
     ray.kill(resource)
+
+
+def get_fmeval_package_version() -> str:
+    """
+    :returns: The current fmeval package version.
+    """
+    return importlib.metadata.version("fmeval")

--- a/test/unit/model_runners/test_util.py
+++ b/test/unit/model_runners/test_util.py
@@ -1,8 +1,19 @@
+import os
 from unittest.mock import MagicMock, patch
 
-from fmeval.model_runners.util import get_sagemaker_session, is_endpoint_in_service, get_bedrock_runtime_client
+from fmeval.model_runners.util import get_sagemaker_session, is_endpoint_in_service, get_bedrock_runtime_client, \
+    get_user_agent_extra
+from fmeval.constants import DISABLE_FMEVAL_TELEMETRY
 
 ENDPOINT_NAME = "valid_endpoint_name"
+
+
+def test_get_user_agent_extra():
+    with patch("src.fmeval.model_runners.util.get_fmeval_package_version", return_value="1.0.1") as get_package_ver:
+        assert get_user_agent_extra() == "fmeval/1.0.1"
+        os.environ[DISABLE_FMEVAL_TELEMETRY] = "True"
+        assert get_user_agent_extra() == ""
+        del os.environ[DISABLE_FMEVAL_TELEMETRY]
 
 
 def test_get_sagemaker_session():

--- a/test/unit/model_runners/test_util.py
+++ b/test/unit/model_runners/test_util.py
@@ -1,8 +1,12 @@
 import os
 from unittest.mock import MagicMock, patch
 
-from fmeval.model_runners.util import get_sagemaker_session, is_endpoint_in_service, get_bedrock_runtime_client, \
-    get_user_agent_extra
+from fmeval.model_runners.util import (
+    get_sagemaker_session,
+    is_endpoint_in_service,
+    get_bedrock_runtime_client,
+    get_user_agent_extra,
+)
 from fmeval.constants import DISABLE_FMEVAL_TELEMETRY
 
 ENDPOINT_NAME = "valid_endpoint_name"


### PR DESCRIPTION
*Description of changes:*
This PR implements very basic telemetry through the use of user agent headers that get included when making SageMaker `DescribeEndpoint` API calls.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
