### PR TITLE
fix: fix patching in unit tests

### DIFF
--- a/test/unit/data_loaders/test_data_sources.py
+++ b/test/unit/data_loaders/test_data_sources.py
@@ -35,7 +35,7 @@ class TestLocalDatafile:
 class TestS3DataFile:
     @pytest.mark.parametrize("file_path", FILE_PATHS)
     def test_open_s3_data_file(self, file_path):
-        with patch("src.fmeval.data_loaders.data_sources.boto3.client") as mock_boto3_client:
+        with patch("fmeval.data_loaders.data_sources.boto3.client") as mock_boto3_client:
             mock_s3_client = Mock()
             mock_boto3_client.return_value = mock_s3_client
             with io.StringIO() as buf:
@@ -49,7 +49,7 @@ class TestS3DataFile:
 
     @pytest.mark.parametrize("invalid_file_path", INVALID_FILE_PATHS)
     def test_open_invalid_s3_data_file(self, invalid_file_path):
-        with patch("src.fmeval.data_loaders.data_sources.boto3.client") as mock_boto3_client:
+        with patch("fmeval.data_loaders.data_sources.boto3.client") as mock_boto3_client:
             mock_s3_client = Mock()
             mock_s3_client.get_object.side_effect = botocore.errorfactory.ClientError({"error": "blah"}, "blah")
             mock_boto3_client.return_value = mock_s3_client

--- a/test/unit/data_loaders/test_util.py
+++ b/test/unit/data_loaders/test_util.py
@@ -191,7 +191,7 @@ class TestDataLoaderUtil:
         WHEN get_data_source is called
         THEN an S3DataFile with the correct URI is returned
         """
-        with patch("src.fmeval.data_loaders.data_sources.boto3.client") as mock_s3_client:
+        with patch("fmeval.data_loaders.data_sources.boto3.client") as mock_s3_client:
             mock_s3_client.get_object = Mock(return_value={"ContentType": "binary/octet-stream"})
             dataset_uri = S3_PREFIX + DATASET_URI
             data_source = get_data_source(dataset_uri)
@@ -221,7 +221,7 @@ class TestDataLoaderUtil:
         WHEN get_data_source is called
         THEN the correct exception is raised
         """
-        with patch("src.fmeval.data_loaders.data_sources.boto3.client") as mock_s3_client:
+        with patch("fmeval.data_loaders.data_sources.boto3.client") as mock_s3_client:
             mock_s3_client.return_value.get_object = Mock(
                 return_value={"ContentType": "application/x-directory; charset=UTF-8"}
             )
@@ -246,8 +246,8 @@ class TestDataLoaderUtil:
 
     def test_get_data_source_invalid_dataset_path(self):
         with (
-            patch("src.fmeval.data_loaders.util._is_valid_local_path", return_value=False),
-            patch("src.fmeval.data_loaders.util._is_valid_s3_uri", return_value=False),
+            patch("fmeval.data_loaders.util._is_valid_local_path", return_value=False),
+            patch("fmeval.data_loaders.util._is_valid_s3_uri", return_value=False),
         ):
             with pytest.raises(EvalAlgorithmClientError, match="Invalid dataset path"):
                 get_data_source("unused")
@@ -259,7 +259,7 @@ class TestDataLoaderUtil:
         THEN True is returned
         """
         dataset_uri = S3_PREFIX + DATASET_URI
-        with patch("src.fmeval.data_loaders.data_sources.boto3.client") as mock_s3_client:
+        with patch("fmeval.data_loaders.data_sources.boto3.client") as mock_s3_client:
             mock_s3_client.return_value.get_object.return_value = Mock()
             assert _is_valid_s3_uri(dataset_uri)
 
@@ -279,7 +279,7 @@ class TestDataLoaderUtil:
         WHEN _is_valid_s3_uri is called
         THEN False is returned
         """
-        with patch("src.fmeval.data_loaders.data_sources.boto3.client") as mock_s3_client:
+        with patch("fmeval.data_loaders.data_sources.boto3.client") as mock_s3_client:
             mock_s3_client.return_value.get_object = Mock(
                 side_effect=botocore.errorfactory.ClientError({"error": "blah"}, "blah")
             )

--- a/test/unit/model_runners/test_util.py
+++ b/test/unit/model_runners/test_util.py
@@ -13,8 +13,8 @@ ENDPOINT_NAME = "valid_endpoint_name"
 
 
 def test_get_user_agent_extra():
-    with patch("src.fmeval.model_runners.util.get_fmeval_package_version", return_value="1.0.1") as get_package_ver:
-        assert get_user_agent_extra().endswith("fmeval/1.0.1")
+    with patch("fmeval.model_runners.util.get_fmeval_package_version", return_value="1.0.0") as get_package_ver:
+        assert get_user_agent_extra().endswith("fmeval/1.0.0")
         os.environ[DISABLE_FMEVAL_TELEMETRY] = "True"
         assert "fmeval" not in get_user_agent_extra()
         del os.environ[DISABLE_FMEVAL_TELEMETRY]


### PR DESCRIPTION
*Description of changes:*
A couple unit tests are incorrectly using `"src.fmeval"` instead of just `"fmeval"` when patching functions. As a result, tests like `test_get_user_agent_extra` are calling the _actual function_  instead. In hindsight, I should've used a different `return_value` when patching `fmeval.model_runners.util.get_fmeval_package_version` so that this would've been easily caught.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
