### PR TITLE
docs: update telemetry-related info in README and docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,10 @@ eval_output = eval_algo.evaluate(model=model_runner, dataset_config=config)
 eval algorithms.*
 
 ## Telemetry
-By default, `fmeval` has very basic telemetry enabled, purely for tracking usage of the package.
-The only data that is tracked is the number of SageMaker, JumpStart, or Bedrock `ModelRunner` objects that get created.
-*We do not collect any user-level data*.
+`fmeval` has telemetry enabled for tracking the usage of AWS-provided/hosted LLMs.
+This data is tracked using the number of SageMaker or JumpStart `ModelRunner` objects that get created.
+Telemetry can be disabled by setting the `DISABLE_FMEVAL_TELEMETRY` environment variable to `true`.
 
-The `ModelRunner` data in question gets collected via the use of an fmeval-specific user agent header that is used by the botocore session that manages these model runners.
-See `fmeval.model_runners.util.get_user_agent_extra` and `fmeval.model_runners.util.get_boto_session` for implementation details.
-
-To opt out of telemetry, simply set the `DISABLE_FMEVAL_TELEMETRY` environment variable to any non-null value.
 
 ## Troubleshooting
 

--- a/devtool
+++ b/devtool
@@ -34,7 +34,7 @@ lint() {
     echo "Note: This only syncs poetry.lock with pyproject.toml.  If you wish to update all downstream dependencies, run 'poetry update'"
 
     install_poetry
-    poetry lock --check || (poetry lock --no-update && poetry lock --check)
+    poetry check --lock || (poetry lock --no-update && poetry check --lock)
     echo ""
 
     echo "Lint: SUCCESS"

--- a/src/fmeval/model_runners/util.py
+++ b/src/fmeval/model_runners/util.py
@@ -19,7 +19,12 @@ logger = logging.getLogger(__name__)
 
 
 def get_user_agent_extra() -> str:
-    """
+    """Return a string containing various user-agent headers to be passed to a botocore config.
+
+    This string will always contain SageMaker Python SDK headers obtained using the determine_prefix
+    utility function from sagemaker.user_agent. If fmeval telemetry is enabled, this string will
+    additionally contain an fmeval-specific header.
+
     :return: A string to be used as the user_agent_extra parameter in a botocore config.
     """
     # Obtain user-agent headers for information such as SageMaker notebook instance type and SageMaker Studio app type.


### PR DESCRIPTION
*Description of changes:*
This PR contains edits to documentation regarding telemetry details. It also updates `devtool` to use `poetry check --lock` instead of the now-deprecated `poetry lock --check` command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
