### PR TITLE
feat: add target_context to dataset columns

### DIFF
--- a/src/fmeval/constants.py
+++ b/src/fmeval/constants.py
@@ -68,6 +68,7 @@ class DatasetColumns(Enum):
     MODEL_LOG_PROBABILITY = Column(name="model_log_probability")
     TARGET_OUTPUT = Column(name="target_output", should_cast=True)
     CATEGORY = Column(name="category", should_cast=True)
+    TARGET_CONTEXT = Column(name="target_context", should_cast=True)
     SENT_MORE_INPUT = Column(name="sent_more_input", should_cast=True)
     SENT_LESS_INPUT = Column(name="sent_less_input", should_cast=True)
     SENT_MORE_PROMPT = Column(name="sent_more_prompt")

--- a/src/fmeval/data_loaders/data_config.py
+++ b/src/fmeval/data_loaders/data_config.py
@@ -37,6 +37,7 @@ class DataConfig:
             input log probability (used by the Prompt Stereotyping evaluation algorithm)
     :param sent_less_log_prob_location: the location for the "sent less"
             input log probability (used by the Prompt Stereotyping evaluation algorithm).
+    :param target_context_location: the location of the target context.
     """
 
     dataset_name: str
@@ -50,6 +51,7 @@ class DataConfig:
     sent_less_input_location: Optional[str] = None
     sent_more_log_prob_location: Optional[str] = None
     sent_less_log_prob_location: Optional[str] = None
+    target_context_location: Optional[str] = None
 
     def __post_init__(self):
         require(

--- a/src/fmeval/data_loaders/json_parser.py
+++ b/src/fmeval/data_loaders/json_parser.py
@@ -153,14 +153,12 @@ class JsonParser:
         return result
 
     @staticmethod
-    def _validate_jmespath_result(result: Union[Any, List[Any], List[List[Any]]], args: ColumnParseArguments) -> None:
+    def _validate_jmespath_result(result: Union[Any, List[Any]], args: ColumnParseArguments) -> None:
         """Validates that the JMESPath result is as expected.
 
-        For dataset column TARGET_CONTEXT, if `args.dataset_mime_type` is MIME_TYPE_JSON, then `result` is
-        expected to be a 2D array. If MIME_TYPE_JSON_LINES, then `result` is expected to be a 1D array (list).
-
-        For all other dataset columns, if `args.dataset_mime_type` is MIME_TYPE_JSON, then `result` is expected to be
-        a 1D array (list). If MIME_TYPE_JSON_LINES, then `result` is expected to be a single scalar value.
+        If `args.dataset_mime_type` is MIME_TYPE_JSON, then `result` is expected
+        to be a 1D array (list). If MIME_TYPE_JSON_LINES, then `result` is expected
+        to be a single scalar value.
 
         :param result: JMESPath query result to be validated.
         :param args: See ColumnParseArguments docstring.
@@ -177,38 +175,24 @@ class JsonParser:
                 f"the {args.column.value.name} column of dataset `{args.dataset_name}`, but found at least "
                 "one value that is None.",
             )
-            if args.column.value.name == DatasetColumns.TARGET_CONTEXT.value.name:
-                require(
-                    all(isinstance(x, list) for x in result),
-                    f"Expected a 2D array using JMESPath '{args.jmespath_parser.expression}' on dataset "
-                    f"`{args.dataset_name}` but found at least one non-list object.",
-                )
-            else:
-                require(
-                    all(not isinstance(x, list) for x in result),
-                    f"Expected a 1D array using JMESPath '{args.jmespath_parser.expression}' on dataset "
-                    f"`{args.dataset_name}`, where each element of the array is a sample's {args.column.value.name}, "
-                    f"but found at least one nested array.",
-                )
+            require(
+                all(not isinstance(x, list) for x in result),
+                f"Expected a 1D array using JMESPath '{args.jmespath_parser.expression}' on dataset "
+                f"`{args.dataset_name}`, where each element of the array is a sample's {args.column.value.name}, "
+                f"but found at least one nested array.",
+            )
         elif args.dataset_mime_type == MIME_TYPE_JSONLINES:
             require(
                 result is not None,
                 f"Found no values using {args.column.value.name} JMESPath '{args.jmespath_parser.expression}' "
                 f"on dataset `{args.dataset_name}`.",
             )
-            if args.column.value.name == DatasetColumns.TARGET_CONTEXT.value.name:
-                require(
-                    isinstance(result, list),
-                    f"Expected to find a List using JMESPath '{args.jmespath_parser.expression}' on a dataset line in "
-                    f"`{args.dataset_name}`, but found a non-list object instead.",
-                )
-            else:
-                require(
-                    not isinstance(result, list),
-                    f"Expected to find a single value using {args.column.value.name} JMESPath "
-                    f"'{args.jmespath_parser.expression}' on a dataset line in "
-                    f"dataset `{args.dataset_name}`, but found a list instead.",
-                )
+            require(
+                not isinstance(result, list),
+                f"Expected to find a single value using {args.column.value.name} JMESPath "
+                f"'{args.jmespath_parser.expression}' on a dataset line in "
+                f"dataset `{args.dataset_name}`, but found a list instead.",
+            )
         else:  # pragma: no cover
             raise EvalAlgorithmInternalError(
                 f"args.dataset_mime_type is {args.dataset_mime_type}, but only JSON " "and JSON Lines are supported."
@@ -233,20 +217,16 @@ class JsonParser:
         )
 
     @staticmethod
-    def _cast_to_string(
-        result: Union[Any, List[Any], List[List[Any]]], args: ColumnParseArguments
-    ) -> Union[str, List[str], List[List[str]]]:
+    def _cast_to_string(result: Union[Any, List[Any]], args: ColumnParseArguments) -> Union[str, List[str]]:
         """
         Casts the contents of `result` to string(s), raising an error if casting fails.
         It is extremely unlikely that the str() operation should fail; this basically
         only happens if the object has explicitly overwritten the __str__ method to raise
         an exception.
 
-        For dataset column TARGET_CONTEXT, if `args.dataset_mime_type` is MIME_TYPE_JSON, then `result` is
-        expected to be a 2D array. If MIME_TYPE_JSON_LINES, then `result` is expected to be a 1D array (list).
-
-        For all other dataset columns, if `args.dataset_mime_type` is MIME_TYPE_JSON, then `result` is expected to be
-        a 1D array (list). If MIME_TYPE_JSON_LINES, then `result` is expected to be a single scalar value.
+        If `args.dataset_mime_type` is MIME_TYPE_JSON, then `result` is expected
+        to be a 1D array (list) of objects. If MIME_TYPE_JSON_LINES, then `result`
+        is expected to be a single object.
 
         :param result: JMESPath query result to be casted.
         :param args: See ColumnParseArguments docstring.
@@ -254,16 +234,9 @@ class JsonParser:
         """
         try:
             if args.dataset_mime_type == MIME_TYPE_JSON:
-                if args.column.value.name == DatasetColumns.TARGET_CONTEXT.value.name:
-                    return [[str(x) for x in sample] for sample in result]
-                else:
-                    return [str(x) for x in result]
+                return [str(x) for x in result]
             elif args.dataset_mime_type == MIME_TYPE_JSONLINES:
-                return (
-                    [str(x) for x in result]
-                    if args.column.value.name == DatasetColumns.TARGET_CONTEXT.value.name
-                    else str(result)
-                )
+                return str(result)
             else:
                 raise EvalAlgorithmInternalError(  # pragma: no cover
                     f"args.dataset_mime_type is {args.dataset_mime_type}, but only JSON and JSON Lines are supported."

--- a/test/unit/data_loaders/test_json_data_loader.py
+++ b/test/unit/data_loaders/test_json_data_loader.py
@@ -11,7 +11,7 @@ from fmeval.data_loaders.json_data_loader import (
     CustomJSONDatasource,
 )
 from fmeval.data_loaders.util import DataConfig
-from typing import Any, Dict, List, NamedTuple, Optional, Union
+from typing import Any, Dict, List, NamedTuple, Optional
 from fmeval.constants import (
     DatasetColumns,
     MIME_TYPE_JSON,
@@ -45,7 +45,7 @@ def create_temp_jsonlines_data_file_from_input_dataset(path: pathlib.Path, input
 
 class TestJsonDataLoader:
     class TestCaseReadDataset(NamedTuple):
-        input_dataset: Union[Dict[str, Any], List[Dict[str, Any]]]
+        input_dataset: Dict[str, Any]
         expected_dataset: List[Dict[str, Any]]
         dataset_mime_type: str
         model_input_jmespath: Optional[str] = None
@@ -72,9 +72,9 @@ class TestJsonDataLoader:
             # containing heterogeneous lists.
             TestCaseReadDataset(
                 input_dataset={
-                    "row_1": ["a", True, False, 0],
-                    "row_2": ["b", False, False, 1],
-                    "row_3": ["c", False, True, 2],
+                    "row_1": ["a", True, False, 0, "context_a"],
+                    "row_2": ["b", False, False, 1, "context_b"],
+                    "row_3": ["c", False, True, 2, "context_c"],
                 },
                 expected_dataset=[
                     {
@@ -82,18 +82,21 @@ class TestJsonDataLoader:
                         DatasetColumns.MODEL_OUTPUT.value.name: "True",
                         DatasetColumns.TARGET_OUTPUT.value.name: "False",
                         DatasetColumns.CATEGORY.value.name: "0",
+                        DatasetColumns.TARGET_CONTEXT.value.name: "context_a",
                     },
                     {
                         DatasetColumns.MODEL_INPUT.value.name: "b",
                         DatasetColumns.MODEL_OUTPUT.value.name: "False",
                         DatasetColumns.TARGET_OUTPUT.value.name: "False",
                         DatasetColumns.CATEGORY.value.name: "1",
+                        DatasetColumns.TARGET_CONTEXT.value.name: "context_b",
                     },
                     {
                         DatasetColumns.MODEL_INPUT.value.name: "c",
                         DatasetColumns.MODEL_OUTPUT.value.name: "False",
                         DatasetColumns.TARGET_OUTPUT.value.name: "True",
                         DatasetColumns.CATEGORY.value.name: "2",
+                        DatasetColumns.TARGET_CONTEXT.value.name: "context_c",
                     },
                 ],
                 dataset_mime_type=MIME_TYPE_JSON,
@@ -101,59 +104,35 @@ class TestJsonDataLoader:
                 model_output_jmespath="[row_1[1], row_2[1], row_3[1]]",
                 target_output_jmespath="[row_1[2], row_2[2], row_3[2]]",
                 category_jmespath="[row_1[3], row_2[3], row_3[3]]",
-            ),
-            TestCaseReadDataset(
-                input_dataset={
-                    "model_input_col": ["a", "b", "c"],
-                    "target_context": [["a", "b"], ["c", "d"], ["e", "f"]],
-                },
-                expected_dataset=[
-                    {DatasetColumns.MODEL_INPUT.value.name: "a", DatasetColumns.TARGET_CONTEXT.value.name: ["a", "b"]},
-                    {DatasetColumns.MODEL_INPUT.value.name: "b", DatasetColumns.TARGET_CONTEXT.value.name: ["c", "d"]},
-                    {DatasetColumns.MODEL_INPUT.value.name: "c", DatasetColumns.TARGET_CONTEXT.value.name: ["e", "f"]},
-                ],
-                dataset_mime_type=MIME_TYPE_JSON,
-                model_input_jmespath="model_input_col",
-                target_context_jmespath="target_context",
+                target_context_jmespath="[row_1[4], row_2[4], row_3[4]]",
             ),
             TestCaseReadDataset(
                 input_dataset=[
-                    {"input": "a", "output": 3.14},
-                    {"input": "c", "output": 2.718},
-                    {"input": "e", "output": 1.00},
-                ],
-                expected_dataset=[
-                    {DatasetColumns.MODEL_INPUT.value.name: "a", DatasetColumns.MODEL_OUTPUT.value.name: "3.14"},
-                    {DatasetColumns.MODEL_INPUT.value.name: "c", DatasetColumns.MODEL_OUTPUT.value.name: "2.718"},
-                    {DatasetColumns.MODEL_INPUT.value.name: "e", DatasetColumns.MODEL_OUTPUT.value.name: "1.0"},
-                ],
-                dataset_mime_type=MIME_TYPE_JSONLINES,
-                model_input_jmespath="input",
-                model_output_jmespath="output",
-            ),
-            TestCaseReadDataset(
-                input_dataset=[
-                    {"input": "a", "target_context": ["context 1", "context 2"]},
-                    {"input": "c", "target_context": ["context 3"]},
-                    {"input": "e", "target_context": ["context 4"]},
+                    {"input": "a", "output": 3.14, "context": "1"},
+                    {"input": "c", "output": 2.718, "context": "2"},
+                    {"input": "e", "output": 1.00, "context": "3"},
                 ],
                 expected_dataset=[
                     {
                         DatasetColumns.MODEL_INPUT.value.name: "a",
-                        DatasetColumns.TARGET_CONTEXT.value.name: ["context 1", "context 2"],
+                        DatasetColumns.MODEL_OUTPUT.value.name: "3.14",
+                        DatasetColumns.TARGET_CONTEXT.value.name: "1",
                     },
                     {
                         DatasetColumns.MODEL_INPUT.value.name: "c",
-                        DatasetColumns.TARGET_CONTEXT.value.name: ["context 3"],
+                        DatasetColumns.MODEL_OUTPUT.value.name: "2.718",
+                        DatasetColumns.TARGET_CONTEXT.value.name: "2",
                     },
                     {
                         DatasetColumns.MODEL_INPUT.value.name: "e",
-                        DatasetColumns.TARGET_CONTEXT.value.name: ["context 4"],
+                        DatasetColumns.MODEL_OUTPUT.value.name: "1.0",
+                        DatasetColumns.TARGET_CONTEXT.value.name: "3",
                     },
                 ],
                 dataset_mime_type=MIME_TYPE_JSONLINES,
                 model_input_jmespath="input",
-                target_context_jmespath="target_context",
+                model_output_jmespath="output",
+                target_context_jmespath="context",
             ),
         ],
     )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

**Update**: Initially we planned on the `target_context` dataset column taking list of strings. This does not work with ray operations such as `map_batches` due to issues including https://github.com/ray-project/ray/issues/39559 and other unsupported data type errors. Thus the `target_context` dataset column has been modified to take a string, and we will use string concatenation when there are multiple target contexts, similar to the existing `target_output` field.

**Description (updated)**:
* Adds support for loading `target_context` for evaluation of RAG "ground truth" context provided in a dataset. The `target_context` for each dataset sample is a ~~list of~~ string. 
* ~~Modifies `json_parser` to accept lists of strings by updating JMESPath output validation and string casting~~.
* Adds unit tests for JSON and JSONLINES cases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
