### PR TITLE
feat: fetch log probability jmespath from JS metadata

### DIFF
--- a/src/fmeval/constants.py
+++ b/src/fmeval/constants.py
@@ -128,6 +128,7 @@ SDK_MANIFEST_FILE = "models_manifest.json"
 JUMPSTART_BUCKET_BASE_URL_FORMAT = "https://jumpstart-cache-prod-{}.s3.{}.amazonaws.com"
 JUMPSTART_BUCKET_BASE_URL_FORMAT_ENV_VAR = "JUMPSTART_BUCKET_BASE_URL_FORMAT"
 GENERATED_TEXT_JMESPATH_EXPRESSION = "*.output_keys.generated_text"
+INPUT_LOG_PROBS_JMESPATH_EXPRESSION = "*.output_keys.input_logprobs"
 
 # BERTScore
 BERTSCORE_DEFAULT_MODEL = "microsoft/deberta-xlarge-mnli"

--- a/src/fmeval/model_runners/extractors/jumpstart_extractor.py
+++ b/src/fmeval/model_runners/extractors/jumpstart_extractor.py
@@ -17,15 +17,13 @@ from fmeval.constants import (
     DEFAULT_PAYLOADS,
     JUMPSTART_BUCKET_BASE_URL_FORMAT,
     JUMPSTART_BUCKET_BASE_URL_FORMAT_ENV_VAR,
+    INPUT_LOG_PROBS_JMESPATH_EXPRESSION,
 )
 from fmeval.exceptions import EvalAlgorithmClientError, EvalAlgorithmInternalError
-from fmeval.data_loaders.jmespath_util import compile_jmespath
 from fmeval.model_runners.extractors.extractor import Extractor
 
 # The expected model response location for Jumpstart that do produce the log probabilities
 from fmeval.model_runners.util import get_sagemaker_session
-
-JS_LOG_PROB_JMESPATH = "[0].details.prefill[*].logprob"
 
 
 class JumpStartExtractor(Extractor):
@@ -47,7 +45,6 @@ class JumpStartExtractor(Extractor):
         self._model_id = jumpstart_model_id
         self._model_version = jumpstart_model_version
         self._sagemaker_session = sagemaker_session if sagemaker_session else get_sagemaker_session()
-        self._log_prob_compiler = compile_jmespath(JS_LOG_PROB_JMESPATH)
 
         model_manifest = seq(self.get_jumpstart_sdk_manifest(self._sagemaker_session.boto_region_name)).find(
             lambda x: x.get(MODEL_ID, None) == jumpstart_model_id
@@ -61,8 +58,13 @@ class JumpStartExtractor(Extractor):
             DEFAULT_PAYLOADS in model_spec_key, f"JumpStart Model: {jumpstart_model_id} is not supported at this time"
         )
 
+        output_jmespath_expressions = None
+        input_log_probs_jmespath_expressions = None
         try:
             output_jmespath_expressions = jmespath.compile(GENERATED_TEXT_JMESPATH_EXPRESSION).search(
+                model_spec_key[DEFAULT_PAYLOADS]
+            )
+            input_log_probs_jmespath_expressions = jmespath.compile(INPUT_LOG_PROBS_JMESPATH_EXPRESSION).search(
                 model_spec_key[DEFAULT_PAYLOADS]
             )
         except (TypeError, JMESPathError) as e:
@@ -75,13 +77,23 @@ class JumpStartExtractor(Extractor):
             f"Output jmespath expression for Jumpstart model {jumpstart_model_id} is empty. "
             f"Please provide output jmespath to the JumpStartModelRunner",
         )
+        self._output_jmespath_compiler = None
+        self._log_prob_compiler = None
         try:
             self._output_jmespath_compiler = jmespath.compile(output_jmespath_expressions[0])
+            if input_log_probs_jmespath_expressions:  # pragma: no branch
+                self._log_prob_compiler = jmespath.compile(input_log_probs_jmespath_expressions[0])
         except (TypeError, JMESPathError) as e:
-            raise EvalAlgorithmInternalError(
-                f"Output jmespath expression found for Jumpstart model {jumpstart_model_id} is not valid jmespath. "
-                f"Please provide output jmespath to the JumpStartModelRunner"
-            ) from e
+            if not self._output_jmespath_compiler:
+                raise EvalAlgorithmInternalError(
+                    f"Output jmespath expression found for Jumpstart model {jumpstart_model_id} is not valid jmespath. "
+                    f"Please provide output jmespath to the JumpStartModelRunner"
+                ) from e
+            else:
+                raise EvalAlgorithmInternalError(
+                    f"Input log probability jmespath expression found for Jumpstart model {jumpstart_model_id} is not valid jmespath. "
+                    f"Please provide correct input log probability jmespath to the JumpStartModelRunner"
+                ) from e
 
     def extract_log_probability(self, data: Union[List, Dict], num_records: int = 1) -> float:
         """
@@ -91,7 +103,13 @@ class JumpStartExtractor(Extractor):
         :param num_records: The number of records in the model response. Must be 1.
         """
         assert num_records == 1, "Jumpstart extractor does not support batch requests"
+        util.require(
+            self._log_prob_compiler, f"Model {self._model_id} does not include input log probabilities in it's response"
+        )
         try:
+            assert (
+                self._log_prob_compiler
+            ), f"Model {self._model_id} does not include input log probabilities in it's response"
             log_probs = self._log_prob_compiler.search(data)
             if log_probs is None and not isinstance(log_probs, list):
                 raise EvalAlgorithmClientError(
@@ -113,6 +131,9 @@ class JumpStartExtractor(Extractor):
         """
         assert num_records == 1, "Jumpstart extractor does not support batch requests"
         try:
+            assert (
+                self._output_jmespath_compiler
+            ), f"Unable to extract generated text from Jumpstart model: {self._model_id}"
             output = self._output_jmespath_compiler.search(data)
             if output is None and not isinstance(output, str):
                 raise EvalAlgorithmClientError(f"Unable to extract output from Jumpstart model: {self._model_id}")


### PR DESCRIPTION
*Description of changes:*
Fetch log probability jmespath from JS metadata. This is a non-breaking change. 

We were using a constant path, and so far that was also correct. But, going forward, for new models, it might not be. It is better to fetch the jmespath directly from metadata. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
