### PR TITLE
Fix comparisons for string enumerations

### DIFF
--- a/src/fmeval/eval_algorithms/__init__.py
+++ b/src/fmeval/eval_algorithms/__init__.py
@@ -29,7 +29,7 @@ class EvalScore:
             return False
 
 
-class EvalAlgorithm(Enum):
+class EvalAlgorithm(str, Enum):
     """The evaluation types supported by Amazon Foundation Model Evaluations.
 
     The evaluation types are used to determine the evaluation metrics for the
@@ -141,7 +141,7 @@ class EvalOutput:
             return False
 
 
-class ModelTask(Enum):
+class ModelTask(str, Enum):
     """The different types of tasks that are supported by the evaluations.
 
     The model tasks are used to determine the evaluation metrics for the

--- a/src/fmeval/eval_algorithms/helper_models/helper_model.py
+++ b/src/fmeval/eval_algorithms/helper_models/helper_model.py
@@ -4,7 +4,7 @@ import transformers
 
 from enum import Enum
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List
+from typing import Any, cast, Dict, List
 from transformers import pipeline, AutoConfig
 
 TOXIGEN_SCORE_NAME = "toxicity"
@@ -183,7 +183,7 @@ class BertscoreHelperModel(BaseHelperModel):
         )["f1"][0]
 
 
-class BertscoreHelperModelTypes(Enum):
+class BertscoreHelperModelTypes(str, Enum):
     """This class holds the names of all the allowed models for computing the BERTScore."""
 
     MICROSOFT_DEBERTA_MODEL = "microsoft/deberta-xlarge-mnli"
@@ -195,7 +195,8 @@ class BertscoreHelperModelTypes(Enum):
         Given a model name like 'roberta-large-mnli', check if this is an allowed model for computing BERTScore.
         """
         for elem in iter(cls):
-            if elem.value == model_name:
+            # Because this is a (str, Enum), need cast to keep mypy happy:
+            if cast(BertscoreHelperModelTypes, elem).value == model_name:
                 return True
         return False
 
@@ -204,4 +205,5 @@ class BertscoreHelperModelTypes(Enum):
         """
         Return a list of all the allowed models for computing BERTScore.
         """
-        return [elem.value for elem in iter(cls)]
+        # Because this is a (str, Enum), need cast to keep mypy happy:
+        return [cast(BertscoreHelperModelTypes, elem).value for elem in iter(cls)]

--- a/src/fmeval/reporting/constants.py
+++ b/src/fmeval/reporting/constants.py
@@ -65,7 +65,7 @@ LEFT = "left"
 RIGHT = "right"
 
 
-class ListType(Enum):
+class ListType(str, Enum):
     BULLETED = "bulleted"
     NUMBERED = "numbered"
 

--- a/test/unit/eval_algorithms/test_eval_algorithm.py
+++ b/test/unit/eval_algorithms/test_eval_algorithm.py
@@ -1,7 +1,34 @@
 import pytest
 from typing import List, NamedTuple, Optional
 from contextlib import nullcontext as does_not_raise
-from fmeval.eval_algorithms import EvalOutput, CategoryScore, EvalScore, get_default_prompt_template
+from fmeval.eval_algorithms import (
+    EvalAlgorithm,
+    EvalOutput,
+    CategoryScore,
+    EvalScore,
+    get_default_prompt_template,
+    ModelTask,
+)
+
+
+class TestEvalAlgorithm:
+    def test_equality(self):
+        """
+        GIVEN an instance of the EvalAlgorithm enumeration
+        WHEN compared to the same value as a plain string
+        THEN equality returns true
+        """
+        assert EvalAlgorithm.FACTUAL_KNOWLEDGE == "factual_knowledge"
+        assert EvalAlgorithm.QA_ACCURACY == "qa_accuracy"
+
+    def test_inequality(self):
+        """
+        GIVEN an instance of the EvalAlgorithm enumeration
+        WHEN compared to a different value as a plain string
+        THEN equality returns false
+        """
+        assert EvalAlgorithm.QA_ACCURACY != "factual_knowledge"
+        assert EvalAlgorithm.SUMMARIZATION_ACCURACY != "qa_accuracy"
 
 
 class TestEvalOutput:
@@ -187,6 +214,26 @@ class TestEvalScore:
     def test_inequality(self):
         assert EvalScore(name="name1", value=0.7) != EvalScore(name="name2", value=0.7)
         assert EvalScore(name="name1", value=0.7) != EvalScore(name="name1", value=0.69)
+
+
+class TestModelTask:
+    def test_equality(self):
+        """
+        GIVEN an instance of the ModelTask enumeration
+        WHEN compared to the same value as a plain string
+        THEN equality returns true
+        """
+        assert ModelTask.CLASSIFICATION == "classification"
+        assert ModelTask.QUESTION_ANSWERING == "question_answering"
+
+    def test_inequality(self):
+        """
+        GIVEN an instance of the ModelTask enumeration
+        WHEN compared to a different value as a plain string
+        THEN equality returns false
+        """
+        assert ModelTask.CLASSIFICATION != "question_answering"
+        assert ModelTask.NO_TASK != "classification"
 
 
 def test_get_default_prompt_template():

--- a/test/unit/eval_algorithms/test_helper_model.py
+++ b/test/unit/eval_algorithms/test_helper_model.py
@@ -14,6 +14,7 @@ from fmeval.eval_algorithms.helper_models.helper_model import (
     DETOXIFY_SCORE_THREAT,
     DETOXIFY_SCORE_SEXUAL_EXPLICIT,
     BertscoreHelperModel,
+    BertscoreHelperModelTypes,
 )
 
 
@@ -128,3 +129,55 @@ class TestHelperModel:
         """
         bertscore_model = BertscoreHelperModel("distilbert-base-uncased")
         assert bertscore_model.__reduce__() == (BertscoreHelperModel, ("distilbert-base-uncased",))
+
+
+class TestBertscoreHelperModelTypes:
+    def test_equality(self):
+        """
+        GIVEN an instance of the BertscoreHelperModelTypes enumeration
+        WHEN compared to the same value as a plain string
+        THEN equality returns true
+        """
+        assert BertscoreHelperModelTypes.MICROSOFT_DEBERTA_MODEL == "microsoft/deberta-xlarge-mnli"
+        assert BertscoreHelperModelTypes.ROBERTA_MODEL == "roberta-large-mnli"
+
+    def test_inequality(self):
+        """
+        GIVEN an instance of the BertscoreHelperModelTypes enumeration
+        WHEN compared to a different value as a plain string
+        THEN equality returns false
+        """
+        assert BertscoreHelperModelTypes.MICROSOFT_DEBERTA_MODEL != "roberta-large-mnli"
+        assert BertscoreHelperModelTypes.ROBERTA_MODEL != "microsoft/deberta-xlarge-mnli"
+
+    def test_model_is_allowed(self):
+        """
+        GIVEN a valid BertscoreHelperModelType
+        WHEN BertscoreHelperModelType.model_is_allowed() helper function is called
+        THEN the function returns true (model allowed)
+        """
+        assert BertscoreHelperModelTypes.model_is_allowed(BertscoreHelperModelTypes.ROBERTA_MODEL)
+        assert BertscoreHelperModelTypes.model_is_allowed(BertscoreHelperModelTypes.MICROSOFT_DEBERTA_MODEL)
+        assert BertscoreHelperModelTypes.model_is_allowed("roberta-large-mnli")
+        assert BertscoreHelperModelTypes.model_is_allowed("microsoft/deberta-xlarge-mnli")
+
+    def test_model_is_not_allowed(self):
+        """
+        GIVEN an invalid BertscoreHelperModelType
+        WHEN BertscoreHelperModelType.model_is_allowed() helper function is called
+        THEN the function returns false (not allowed)
+        """
+        assert not BertscoreHelperModelTypes.model_is_allowed("doesnotexist")
+        assert not BertscoreHelperModelTypes.model_is_allowed("")
+
+    def test_model_list(self):
+        """
+        GIVEN the static BertscoreHelperModelTypes enumeration
+        WHEN BertscoreHelperModelType.model_list() helper function is called
+        THEN the function returns a list of strings including expected model names
+        """
+        model_list = BertscoreHelperModelTypes.model_list()
+        assert isinstance(model_list, list)
+        assert "microsoft/deberta-xlarge-mnli" in model_list
+        assert "" not in model_list
+        assert "doesnotexist" not in model_list


### PR DESCRIPTION
**Issue #, if available:** #186

**Description of changes:**

- Update all string enums to inherit from `(str, Enum)` so that comparisons work as expected
- Add unit tests to cover equality comparisons

**Testing done:**

Ran `./devtool all` and all tests completed successfully

<br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
