### PR TITLE
Support multiple data configs in evaluate

### DIFF
--- a/src/fmeval/eval_algorithms/classification_accuracy.py
+++ b/src/fmeval/eval_algorithms/classification_accuracy.py
@@ -1,7 +1,7 @@
 import logging
 import warnings
 from dataclasses import dataclass
-from typing import Callable, Dict, List, Optional, Any, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from ray.data import Dataset
 from sklearn.metrics import balanced_accuracy_score, precision_score, recall_score
@@ -220,7 +220,7 @@ class ClassificationAccuracy(EvalAlgorithmInterface):
     def evaluate(
         self,
         model: Optional[ModelRunner] = None,
-        dataset_config: Optional[DataConfig] = None,
+        dataset_config: Optional[Union[DataConfig, List[DataConfig]]] = None,
         prompt_template: Optional[str] = None,
         num_records: int = 100,
         save: bool = False,
@@ -231,8 +231,9 @@ class ClassificationAccuracy(EvalAlgorithmInterface):
         :param model: An instance of ModelRunner representing the model under evaluation.
             If this argument is None, the `dataset_config` argument must not be None,
             and must correspond to a dataset that already contains a column with model outputs.
-        :param dataset_config: Configures the single dataset used for evaluation.
-            If not provided, evaluations will be run on all of this algorithm's built-in datasets.
+        :param dataset_config: Configures a single dataset or list of datasets used for the
+            evaluation. If not provided, this method will run evaluations using all of its
+            supported built-in datasets.
         :param prompt_template: A template used to generate prompts that are fed to the model.
             If not provided, defaults will be used. If provided, `model` must not be None.
         :param num_records: The number of records to be sampled randomly from the input dataset(s)

--- a/src/fmeval/eval_algorithms/classification_accuracy_semantic_robustness.py
+++ b/src/fmeval/eval_algorithms/classification_accuracy_semantic_robustness.py
@@ -1,7 +1,7 @@
 import logging
 import warnings
 
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Union
 from dataclasses import dataclass
 
 from fmeval.constants import (
@@ -194,7 +194,7 @@ class ClassificationAccuracySemanticRobustness(EvalAlgorithmInterface):
     def evaluate(
         self,
         model: ModelRunner,
-        dataset_config: Optional[DataConfig] = None,
+        dataset_config: Optional[Union[DataConfig, List[DataConfig]]] = None,
         prompt_template: Optional[str] = None,
         num_records: int = 100,
         save: bool = False,
@@ -207,8 +207,9 @@ class ClassificationAccuracySemanticRobustness(EvalAlgorithmInterface):
             semantic robustness algorithms rely on invoking a model on perturbed inputs
             to see how the model outputs from the perturbed inputs differ from the original
             model outputs.
-        :param dataset_config: Configures the single dataset used for evaluation. If not provided,
-            evaluation will use all of it's supported built-in datasets
+        :param dataset_config: Configures a single dataset or list of datasets used for the
+            evaluation. If not provided, this method will run evaluations using all of its
+            supported built-in datasets.
         :param prompt_template: A template which can be used to generate prompts, optional, if not provided defaults
             will be used.
         :param num_records: The number of records to be sampled randomly from the input dataset to perform the

--- a/src/fmeval/eval_algorithms/eval_algorithm.py
+++ b/src/fmeval/eval_algorithms/eval_algorithm.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Optional, List
+from typing import Optional, List, Union
 
 from fmeval.data_loaders.data_config import DataConfig
 from fmeval.eval_algorithms import EvalScore, EvalOutput
@@ -47,7 +47,7 @@ class EvalAlgorithmInterface(ABC):
     def evaluate(
         self,
         model: Optional[ModelRunner] = None,
-        dataset_config: Optional[DataConfig] = None,
+        dataset_config: Optional[Union[DataConfig, List[DataConfig]]] = None,
         prompt_template: Optional[str] = None,
         num_records: int = 100,
         save: bool = False,
@@ -56,9 +56,9 @@ class EvalAlgorithmInterface(ABC):
         """Compute metrics on all samples in one or more datasets.
 
         :param model: An instance of ModelRunner representing the model being evaluated.
-        :param dataset_config: Configures the single dataset used for the evaluation.
-            If not provided, this method will run evaluations using all of its supported
-            built-in datasets.
+        :param dataset_config: Configures a single dataset or list of datasets used for the
+            evaluation. If not provided, this method will run evaluations using all of its
+            supported built-in datasets.
         :param prompt_template: A template used to generate prompts from raw text inputs.
             This parameter is not required if you with to run evaluations using the built-in
             datasets, as they have their own default prompt templates pre-configured.

--- a/src/fmeval/eval_algorithms/factual_knowledge.py
+++ b/src/fmeval/eval_algorithms/factual_knowledge.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from typing import Optional, List, Dict, Any
+from typing import Any, Dict, List, Optional, Union
 
 from fmeval.constants import (
     DatasetColumns,
@@ -151,7 +151,7 @@ class FactualKnowledge(EvalAlgorithmInterface):
     def evaluate(
         self,
         model: Optional[ModelRunner] = None,
-        dataset_config: Optional[DataConfig] = None,
+        dataset_config: Optional[Union[DataConfig, List[DataConfig]]] = None,
         prompt_template: Optional[str] = None,
         num_records: int = 300,
         save: bool = False,
@@ -162,8 +162,9 @@ class FactualKnowledge(EvalAlgorithmInterface):
         :param model: An instance of ModelRunner representing the model under evaluation.
             If this argument is None, the `dataset_config` argument must not be None,
             and must correspond to a dataset that already contains a column with model outputs.
-        :param dataset_config: Configures the single dataset used for evaluation.
-            If not provided, evaluations will be run on all of this algorithm's built-in datasets.
+        :param dataset_config: Configures a single dataset or list of datasets used for the
+            evaluation. If not provided, this method will run evaluations using all of its
+            supported built-in datasets.
         :param prompt_template: A template used to generate prompts that are fed to the model.
             If not provided, defaults will be used. If provided, `model` must not be None.
         :param num_records: The number of records to be sampled randomly from the input dataset(s)

--- a/src/fmeval/eval_algorithms/general_semantic_robustness.py
+++ b/src/fmeval/eval_algorithms/general_semantic_robustness.py
@@ -1,7 +1,7 @@
 import itertools
 import logging
 from dataclasses import dataclass
-from typing import Optional, List, Dict, Any
+from typing import Any, Dict, List, Optional, Union
 
 from fmeval.constants import (
     DatasetColumns,
@@ -290,7 +290,7 @@ class GeneralSemanticRobustness(EvalAlgorithmInterface):
     def evaluate(
         self,
         model: ModelRunner,
-        dataset_config: Optional[DataConfig] = None,
+        dataset_config: Optional[Union[DataConfig, List[DataConfig]]] = None,
         prompt_template: Optional[str] = None,
         num_records: int = 100,
         save: bool = False,
@@ -303,8 +303,9 @@ class GeneralSemanticRobustness(EvalAlgorithmInterface):
             semantic robustness algorithms rely on invoking a model on perturbed inputs
             to see how the model outputs from the perturbed inputs differ from the original
             model outputs.
-        :param dataset_config: Configures the single dataset used for evaluation.
-            If not provided, evaluation will use all of its supported built-in datasets.
+        :param dataset_config: Configures a single dataset or list of datasets used for the
+            evaluation. If not provided, this method will run evaluations using all of its
+            supported built-in datasets.
         :param prompt_template: A template used to generate prompts that are fed to the model.
             If not provided, defaults will be used.
         :param num_records: The number of records to be sampled randomly from the input dataset

--- a/src/fmeval/eval_algorithms/prompt_stereotyping.py
+++ b/src/fmeval/eval_algorithms/prompt_stereotyping.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, List, Dict, Any
+from typing import Any, Dict, List, Optional, Union
 
 import fmeval.util as util
 from fmeval.constants import (
@@ -141,7 +141,7 @@ class PromptStereotyping(EvalAlgorithmInterface):
     def evaluate(
         self,
         model: Optional[ModelRunner] = None,
-        dataset_config: Optional[DataConfig] = None,
+        dataset_config: Optional[Union[DataConfig, List[DataConfig]]] = None,
         prompt_template: Optional[str] = None,
         num_records: int = 100,
         save: bool = False,
@@ -150,8 +150,9 @@ class PromptStereotyping(EvalAlgorithmInterface):
         """Compute prompt stereotyping metrics on one or more datasets.
 
         :param model: An instance of ModelRunner representing the model under evaluation.
-        :param dataset_config: Configures the single dataset used for evaluation.
-            If not provided, evaluation will use all of its supported built-in datasets.
+        :param dataset_config: Configures a single dataset or list of datasets used for the
+            evaluation. If not provided, this method will run evaluations using all of its
+            supported built-in datasets.
         :param prompt_template: A template used to generate prompts that are fed to the model.
             If not provided, defaults will be used.
         :param num_records: The number of records to be sampled randomly from the input dataset

--- a/src/fmeval/eval_algorithms/qa_accuracy.py
+++ b/src/fmeval/eval_algorithms/qa_accuracy.py
@@ -2,7 +2,7 @@ import logging
 import string
 
 from functools import partial
-from typing import Any, Callable, Dict, List, Optional, Set
+from typing import Any, Callable, Dict, List, Optional, Set, Union
 from dataclasses import dataclass
 from nltk.metrics.scores import f_measure, precision, recall
 
@@ -312,7 +312,7 @@ class QAAccuracy(EvalAlgorithmInterface):
     def evaluate(
         self,
         model: Optional[ModelRunner] = None,
-        dataset_config: Optional[DataConfig] = None,
+        dataset_config: Optional[Union[DataConfig, List[DataConfig]]] = None,
         prompt_template: Optional[str] = None,
         num_records: int = 100,
         save: bool = False,
@@ -323,8 +323,9 @@ class QAAccuracy(EvalAlgorithmInterface):
         :param model: An instance of ModelRunner representing the model under evaluation.
             If this argument is None, the `dataset_config` argument must not be None,
             and must correspond to a dataset that already contains a column with model outputs.
-        :param dataset_config: Configures the single dataset used for evaluation.
-            If not provided, evaluations will be run on all of this algorithm's built-in datasets.
+        :param dataset_config: Configures a single dataset or list of datasets used for the
+            evaluation. If not provided, this method will run evaluations using all of its
+            supported built-in datasets.
         :param prompt_template: A template used to generate prompts that are fed to the model.
             If not provided, defaults will be used. If provided, `model` must not be None.
         :param num_records: The number of records to be sampled randomly from the input dataset(s)

--- a/src/fmeval/eval_algorithms/qa_accuracy_semantic_robustness.py
+++ b/src/fmeval/eval_algorithms/qa_accuracy_semantic_robustness.py
@@ -1,6 +1,6 @@
 import logging
 
-from typing import List, Optional
+from typing import List, Optional, Union
 from dataclasses import dataclass
 
 from fmeval.constants import (
@@ -202,7 +202,7 @@ class QAAccuracySemanticRobustness(EvalAlgorithmInterface):
     def evaluate(
         self,
         model: ModelRunner,
-        dataset_config: Optional[DataConfig] = None,
+        dataset_config: Optional[Union[DataConfig, List[DataConfig]]] = None,
         prompt_template: Optional[str] = None,
         num_records: int = 100,
         save: bool = False,
@@ -215,8 +215,9 @@ class QAAccuracySemanticRobustness(EvalAlgorithmInterface):
             semantic robustness algorithms rely on invoking a model on perturbed inputs
             to see how the model outputs from the perturbed inputs differ from the original
             model outputs.
-        :param dataset_config: Configures the single dataset used for evaluation. If not provided,
-            evaluation will use all of it's supported built-in datasets
+        :param dataset_config: Configures a single dataset or list of datasets used for the
+            evaluation. If not provided, this method will run evaluations using all of its
+            supported built-in datasets.
         :param prompt_template: A template which can be used to generate prompts, optional, if not provided defaults
             will be used.
         :param num_records: The number of records to be sampled randomly from the input dataset to perform the

--- a/src/fmeval/eval_algorithms/summarization_accuracy.py
+++ b/src/fmeval/eval_algorithms/summarization_accuracy.py
@@ -181,7 +181,7 @@ class SummarizationAccuracy(EvalAlgorithmInterface):
     def evaluate(
         self,
         model: Optional[ModelRunner] = None,
-        dataset_config: Optional[DataConfig] = None,
+        dataset_config: Optional[Union[DataConfig, List[DataConfig]]] = None,
         prompt_template: Optional[str] = None,
         num_records: int = 100,
         save: bool = False,
@@ -192,8 +192,9 @@ class SummarizationAccuracy(EvalAlgorithmInterface):
         :param model: An instance of ModelRunner representing the model under evaluation.
             If this argument is None, the `dataset_config` argument must not be None,
             and must correspond to a dataset that already contains a column with model outputs.
-        :param dataset_config: Configures the single dataset used for evaluation.
-            If not provided, evaluations will be run on all of this algorithm's built-in datasets.
+        :param dataset_config: Configures a single dataset or list of datasets used for the
+            evaluation. If not provided, this method will run evaluations using all of its
+            supported built-in datasets.
         :param prompt_template: A template used to generate prompts that are fed to the model.
             If not provided, defaults will be used. If provided, `model` must not be None.
         :param num_records: The number of records to be sampled randomly from the input dataset(s)

--- a/src/fmeval/eval_algorithms/summarization_accuracy_semantic_robustness.py
+++ b/src/fmeval/eval_algorithms/summarization_accuracy_semantic_robustness.py
@@ -236,7 +236,7 @@ class SummarizationAccuracySemanticRobustness(EvalAlgorithmInterface):
     def evaluate(
         self,
         model: ModelRunner,
-        dataset_config: Optional[DataConfig] = None,
+        dataset_config: Optional[Union[DataConfig, List[DataConfig]]] = None,
         prompt_template: Optional[str] = None,
         num_records: int = 100,
         save: bool = False,
@@ -250,8 +250,9 @@ class SummarizationAccuracySemanticRobustness(EvalAlgorithmInterface):
             semantic robustness algorithms rely on invoking a model on perturbed inputs
             to see how the model outputs from the perturbed inputs differ from the original
             model outputs.
-        :param dataset_config: Configures the single dataset used for evaluation. If not provided,
-            evaluation will use all of it's supported built-in datasets
+        :param dataset_config: Configures a single dataset or list of datasets used for the
+            evaluation. If not provided, this method will run evaluations using all of its
+            supported built-in datasets.
         :param prompt_template: A template which can be used to generate prompts, optional, if not provided defaults
             will be used.
         :param num_records: The number of records to be sampled randomly from the input dataset to perform the

--- a/src/fmeval/eval_algorithms/toxicity.py
+++ b/src/fmeval/eval_algorithms/toxicity.py
@@ -143,7 +143,7 @@ class Toxicity(EvalAlgorithmInterface):
     def evaluate(
         self,
         model: Optional[ModelRunner] = None,
-        dataset_config: Optional[DataConfig] = None,
+        dataset_config: Optional[Union[DataConfig, List[DataConfig]]] = None,
         prompt_template: Optional[str] = None,
         num_records: int = 100,
         save: bool = False,
@@ -154,8 +154,9 @@ class Toxicity(EvalAlgorithmInterface):
         :param model: An instance of ModelRunner representing the model under evaluation.
             If this argument is None, the `dataset_config` argument must not be None,
             and must correspond to a dataset that already contains a column with model outputs.
-        :param dataset_config: Configures the single dataset used for evaluation.
-            If not provided, evaluations will be run on all of this algorithm's built-in datasets.
+        :param dataset_config: Configures a single dataset or list of datasets used for the
+            evaluation. If not provided, this method will run evaluations using all of its
+            supported built-in datasets.
         :param prompt_template: A template used to generate prompts that are fed to the model.
             If not provided, defaults will be used. If provided, `model` must not be None.
         :param num_records: The number of records to be sampled randomly from the input dataset(s)

--- a/src/fmeval/eval_algorithms/util.py
+++ b/src/fmeval/eval_algorithms/util.py
@@ -36,10 +36,15 @@ from fmeval.util import get_num_actors
 logger = logging.getLogger(__name__)
 
 
-def get_dataset_configs(data_config: Optional[DataConfig], eval_name: str) -> List[DataConfig]:
-    return (
-        [data_config] if data_config else [DATASET_CONFIGS[dataset_name] for dataset_name in EVAL_DATASETS[eval_name]]
-    )
+def get_dataset_configs(data_config: Optional[Union[DataConfig, List[DataConfig]]], eval_name: str) -> List[DataConfig]:
+    if not data_config:
+        return [DATASET_CONFIGS[dataset_name] for dataset_name in EVAL_DATASETS[eval_name]]
+    elif isinstance(data_config, list):
+        return data_config
+    elif isinstance(data_config, tuple):
+        return [cfg for cfg in data_config]
+    else:
+        return [data_config]
 
 
 def generate_model_predict_response_for_dataset(

--- a/test/integration/test_factual_knowledge.py
+++ b/test/integration/test_factual_knowledge.py
@@ -65,3 +65,31 @@ class TestFactualKnowledge:
         assert eval_output.dataset_scores[0].value == approx(test_case.dataset_score, abs=ABS_TOL)
         for category_score in eval_output.category_scores:  # pragma: no branch
             assert category_score.scores[0].value == approx(test_case.category_scores[category_score.name], abs=ABS_TOL)
+
+    def test_evaluate_multi_datasets(self, integration_tests_dir):
+        dataset_config = [
+            DataConfig(
+                dataset_name="TREXbig",
+                dataset_uri=os.path.join(integration_tests_dir, "datasets", "trex_sample.jsonl"),
+                dataset_mime_type=MIME_TYPE_JSONLINES,
+                model_input_location="question",
+                target_output_location="answers",
+                category_location="knowledge_category",
+            ),
+            DataConfig(
+                dataset_name="TREXsmall",
+                dataset_uri=os.path.join(integration_tests_dir, "datasets", "trex_sample_small.jsonl"),
+                dataset_mime_type=MIME_TYPE_JSONLINES,
+                model_input_location="question",
+                target_output_location="answers",
+                category_location="knowledge_category",
+            ),
+        ]
+        eval_outputs = eval_algo.evaluate(
+            model=hf_model_runner,
+            dataset_config=dataset_config,
+            prompt_template="$model_input",
+            save=True,
+        )
+        assert len(eval_outputs) == len(dataset_config)
+        assert [eo.dataset_name for eo in eval_outputs] == [dc.dataset_name for dc in dataset_config]


### PR DESCRIPTION
**Issue #, if available:** #269

**Description of changes:**

Extend `EvalAlgorithmInterface.evaluate()` interface to support specifying a list of multiple `data_config` objects. evaluate() already returns a list of results by dataset, because when run with no `data_config` argument all applicable built-in datasets are analyzed. As mentioned in the attached issue, it was weird and confusing that users couldn't explicitly specify a set of more than one datasets to use.

**Testing done:**

- Added unit tests to cover all scenarios of `get_dataset_configs()`
- Added one integration test to validate multi-dataset functionality for the only evaluator (`FactualKnowledge`) where multiple integration test datasets had already been defined.

<br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
