### PR TITLE
feat: modify GeneratePrompt transform to take placeholder_dict

### DIFF
--- a/src/fmeval/transforms/common.py
+++ b/src/fmeval/transforms/common.py
@@ -19,22 +19,35 @@ class GeneratePrompt(Transform):
         input_keys: List[str],
         output_keys: List[str],
         prompt_template: str,
-        placeholder_keys_dict: Optional[Dict[str, str]] = None,
+        placeholder_to_record_key: Optional[Dict[str, str]] = None,
     ):
         """GeneratePrompt initializer.
 
-        :param input_keys: The keys corresponding to the text that will be used to create prompts.
-            If multiple input keys are provided, a prompt will be constructed from each input, but
-            the created prompts will all utilize the same prompt template.
-        :param output_keys: The keys corresponding to the prompts that get added by this Transform.
-        :param prompt_template: The template used to construct the prompt.
-            Example: "Summarize the following text: $model_input".
-        :param placeholder_keys_dict: The placeholders and the corresponding input keys dict.
-            Example: {"question": "model_input"} with prompt_template "Question: $question"
+                :param input_keys: The keys corresponding to the text that will be used to create prompts.
+                    If multiple input keys are provided, a prompt will be constructed from each input, but
+                    the created prompts will all utilize the same prompt template.
+                :param output_keys: The keys corresponding to the prompts that get added by this Transform.
+                :param prompt_template: The template used to construct the prompt.
+                    Example: "Summarize the following text: $model_input".
+                :param placeholder_to_record_key: The placeholders and the corresponding record keys dict.
+                    Note that when using `placeholder_to_record_key`, having input keys or more than one output key
+                    doesn't make much sense, as all composed prompts will be identical.
+                    Example:
+                        Inputs:
+                            prompt_template = "Summarize $x and $y"
+                            input_keys = []
+                            output_keys = ["my_prompt"]
+                            placeholder_to_record_key = {"x": "statement_1", "y": "statement_2"}
+                            record = {"statement_1": "some long text", "statement_2": "some other long text"}
+                        Output record (only new keys and values are shown):
+                            {"my_prompt": "Summarize some long text and some other long text"}
+
+        Output record (only new keys and values are shown):
+        {"my_prompt": "Summarize some long text and some other long text"}
         """
-        super().__init__(input_keys, output_keys, prompt_template, placeholder_keys_dict)
+        super().__init__(input_keys, output_keys, prompt_template, placeholder_to_record_key)
         self.register_input_output_keys(input_keys, output_keys)
-        self.placeholder_keys_dict = placeholder_keys_dict
+        self.placeholder_to_record_key = placeholder_to_record_key
         self.prompt_template = prompt_template
         self.prompt_composer = PromptComposer(prompt_template)
 
@@ -45,10 +58,11 @@ class GeneratePrompt(Transform):
         :param record: The input record.
         :returns: The input record with prompts added in.
         """
-        if self.placeholder_keys_dict is not None:
-            placeholder_data_dict = {}
-            for placeholder_key in self.placeholder_keys_dict.keys():
-                placeholder_data_dict[placeholder_key] = record[self.placeholder_keys_dict[placeholder_key]]
+        if self.placeholder_to_record_key is not None:
+            placeholder_data_dict = {
+                placeholder_key: record[self.placeholder_to_record_key[placeholder_key]]
+                for placeholder_key in self.placeholder_to_record_key
+            }
             for prompt_key in self.output_keys:
                 record[prompt_key] = self.prompt_composer.compose(placeholder_data_dict=placeholder_data_dict)
         else:

--- a/test/unit/transforms/test_common.py
+++ b/test/unit/transforms/test_common.py
@@ -1,3 +1,5 @@
+from typing import List, Dict, NamedTuple
+
 import pytest
 from unittest.mock import patch
 
@@ -17,23 +19,59 @@ def test_generate_prompt_init():
         mock_prompt_composer.assert_called_once_with("Summarize the following: $model_input")
 
 
-def test_generate_prompt_call():
+class TestGeneratePrompt(NamedTuple):
+    record: Dict[str, str]
+    input_keys: List[str]
+    output_keys: List[str]
+    prompt_template: str
+    placeholder_keys_dict: Dict[str, str]
+    expected_record: Dict[str, str]
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestGeneratePrompt(
+            record={"input_1": "Hello", "input_2": "world"},
+            input_keys=["input_1", "input_2"],
+            output_keys=["prompt_1", "prompt_2"],
+            prompt_template="Summarize the following: $model_input",
+            placeholder_keys_dict=None,
+            expected_record={
+                "input_1": "Hello",
+                "input_2": "world",
+                "prompt_1": "Summarize the following: Hello",
+                "prompt_2": "Summarize the following: world",
+            },
+        ),
+        TestGeneratePrompt(
+            record={"input_1": "sample question", "input_2": "sample answer"},
+            input_keys=[],
+            output_keys=["prompt"],
+            prompt_template="Question: $question\n Answer: $answer",
+            placeholder_keys_dict={"question": "input_1", "answer": "input_2"},
+            expected_record={
+                "input_1": "sample question",
+                "input_2": "sample answer",
+                "prompt": "Question: sample question\n Answer: sample answer",
+            },
+        ),
+    ],
+)
+def test_generate_prompt_call(test_case):
     """
     GIVEN a GeneratePrompt instance.
     WHEN its __call__ method is called on a record.
     THEN the correct output is returned.
     """
     gen_prompt = GeneratePrompt(
-        ["input_1", "input_2"], ["prompt_1", "prompt_2"], "Summarize the following: $model_input"
+        input_keys=test_case.input_keys,
+        output_keys=test_case.output_keys,
+        prompt_template=test_case.prompt_template,
+        placeholder_keys_dict=test_case.placeholder_keys_dict,
     )
-    sample = {"input_1": "Hello", "input_2": "world"}
-    result = gen_prompt(sample)
-    assert result == {
-        "input_1": "Hello",
-        "input_2": "world",
-        "prompt_1": "Summarize the following: Hello",
-        "prompt_2": "Summarize the following: world",
-    }
+    result = gen_prompt(test_case.record)
+    assert result == test_case.expected_record
 
 
 def test_get_model_outputs_init_success():

--- a/test/unit/transforms/test_common.py
+++ b/test/unit/transforms/test_common.py
@@ -24,7 +24,7 @@ class TestGeneratePrompt(NamedTuple):
     input_keys: List[str]
     output_keys: List[str]
     prompt_template: str
-    placeholder_keys_dict: Dict[str, str]
+    placeholder_to_record_key: Dict[str, str]
     expected_record: Dict[str, str]
 
 
@@ -36,7 +36,7 @@ class TestGeneratePrompt(NamedTuple):
             input_keys=["input_1", "input_2"],
             output_keys=["prompt_1", "prompt_2"],
             prompt_template="Summarize the following: $model_input",
-            placeholder_keys_dict=None,
+            placeholder_to_record_key=None,
             expected_record={
                 "input_1": "Hello",
                 "input_2": "world",
@@ -49,7 +49,7 @@ class TestGeneratePrompt(NamedTuple):
             input_keys=[],
             output_keys=["prompt"],
             prompt_template="Question: $question\n Answer: $answer",
-            placeholder_keys_dict={"question": "input_1", "answer": "input_2"},
+            placeholder_to_record_key={"question": "input_1", "answer": "input_2"},
             expected_record={
                 "input_1": "sample question",
                 "input_2": "sample answer",
@@ -68,7 +68,7 @@ def test_generate_prompt_call(test_case):
         input_keys=test_case.input_keys,
         output_keys=test_case.output_keys,
         prompt_template=test_case.prompt_template,
-        placeholder_keys_dict=test_case.placeholder_keys_dict,
+        placeholder_to_record_key=test_case.placeholder_to_record_key,
     )
     result = gen_prompt(test_case.record)
     assert result == test_case.expected_record

--- a/test/unit/transforms/test_transform_pipeline.py
+++ b/test/unit/transforms/test_transform_pipeline.py
@@ -68,7 +68,7 @@ class TestCaseInitFailure(NamedTuple):
                 "TransformPipeline contains Transforms with the same output keys as other Transforms. "
                 "Here are the problematic Transforms, paired with their offending keys: "
                 "{GeneratePrompt(input_keys=['input_1'], output_keys=['output_1'], "
-                "args=[['input_1'], ['output_1'], '1'], kwargs={}): ['output_1']}"
+                "args=[['input_1'], ['output_1'], '1', None], kwargs={}): ['output_1']}"
             ),
         ),
     ],


### PR DESCRIPTION
*Issue #, if available:*
Currently GeneratePrompt transform can only substitute default placeholder `$model_input` with `data` field. 
This PR will support `placeholder_data_dict` (https://github.com/aws/fmeval/pull/273)

*Description of changes:*
`placeholder_keys_dict` will be placeholder keys to input keys mapping, but in this way it only supports transform 1 prompt with one placeholder dict. See unit test for use case


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
