### PR TITLE
feat: add context precision for context quality eval algo

### DIFF
--- a/src/fmeval/constants.py
+++ b/src/fmeval/constants.py
@@ -69,6 +69,7 @@ class DatasetColumns(Enum):
     TARGET_OUTPUT = Column(name="target_output", should_cast=True)
     CATEGORY = Column(name="category", should_cast=True)
     TARGET_CONTEXT = Column(name="target_context", should_cast=True)
+    RETRIEVED_CONTEXT = Column(name="retrieved_context", should_cast=True)
     SENT_MORE_INPUT = Column(name="sent_more_input", should_cast=True)
     SENT_LESS_INPUT = Column(name="sent_less_input", should_cast=True)
     SENT_MORE_PROMPT = Column(name="sent_more_prompt")

--- a/src/fmeval/data_loaders/data_config.py
+++ b/src/fmeval/data_loaders/data_config.py
@@ -52,6 +52,7 @@ class DataConfig:
     sent_more_log_prob_location: Optional[str] = None
     sent_less_log_prob_location: Optional[str] = None
     target_context_location: Optional[str] = None
+    retrieved_context_location: Optional[str] = None
 
     def __post_init__(self):
         require(

--- a/src/fmeval/eval_algorithms/__init__.py
+++ b/src/fmeval/eval_algorithms/__init__.py
@@ -49,6 +49,7 @@ class EvalAlgorithm(Enum):
     SUMMARIZATION_ACCURACY_SEMANTIC_ROBUSTNESS = "summarization_accuracy_semantic_robustness"
     CLASSIFICATION_ACCURACY = "classification_accuracy"
     CLASSIFICATION_ACCURACY_SEMANTIC_ROBUSTNESS = "classification_accuracy_semantic_robustness"
+    CONTEXT_QUALITY = "context_quality"
 
     def __str__(self):
         """

--- a/src/fmeval/eval_algorithms/context_quality.py
+++ b/src/fmeval/eval_algorithms/context_quality.py
@@ -1,0 +1,291 @@
+from typing import Optional, List, Dict, Any
+import logging
+from dataclasses import dataclass
+
+from fmeval.constants import (
+    DatasetColumns,
+    MEAN,
+)
+from fmeval.data_loaders.data_config import DataConfig
+from fmeval.data_loaders.util import get_dataset
+from fmeval.eval_algorithms import EvalAlgorithm, EvalScore, EvalOutput
+from fmeval.eval_algorithms.common import evaluate_dataset
+from fmeval.eval_algorithms.eval_algorithm import (
+    EvalAlgorithmInterface,
+    EvalAlgorithmConfig,
+)
+from fmeval.eval_algorithms.save_strategy import SaveStrategy
+from fmeval.eval_algorithms.util import get_dataset_configs, validate_dataset
+from fmeval.model_runners.bedrock_model_runner import BedrockModelRunner
+from fmeval.model_runners.model_runner import ModelRunner
+from fmeval.transforms.transform import Transform
+from fmeval.transforms.util import validate_call
+from fmeval.model_runners.composers.composers import PromptComposer
+from fmeval.transforms.transform_pipeline import TransformPipeline
+from fmeval.util import get_eval_results_path
+
+logger = logging.getLogger(__name__)
+
+CONTEXT_PRECISION_SCORE = "context_precision_score"
+
+DEFAULT_CONTEXT_PRECISION_PROMPT_TEMPLATE = (
+    "Given question, answer and context verify if the context was useful in "
+    "arriving at the given answer. Give verdict as 1 if useful and 0 if "
+    "not. question: $model_input, answer: $target_output, "
+    "context: $retrieved_context."
+    "The verdict should only contain an integer, either 1 or 0, do not give an explanation."
+)
+
+BINARY_SCORE_VALUES = ["0", "1"]
+
+# TODO: Pending judge model selection
+def get_default_judge_model() -> BedrockModelRunner:  # pragma: no cover
+    return BedrockModelRunner(
+        model_id="anthropic.claude-v2",
+        output="completion",
+        content_template='{"prompt": $prompt, "max_tokens_to_sample": 10000, "temperature": 0.1}',
+    )
+
+
+@dataclass(frozen=True)
+class ContextQualityConfig(EvalAlgorithmConfig):
+    """Configures the Context Quality evaluation algorithm.
+
+    :param target_output_delimiter: There can be multiple target outputs for a given input.
+        This delimiter is used to combine all retrieved contexts into a single string.
+    :param retrieved_context_delimiter: There can be multiple retrieved contexts for a given input.
+        This delimiter is used to combine all retrieved contexts into a single string.
+    """
+
+    target_output_delimiter: Optional[str] = "<OR>"
+    retrieved_context_delimiter: Optional[str] = "<AND>"
+
+
+class ContextQuality(EvalAlgorithmInterface):
+    eval_name = EvalAlgorithm.CONTEXT_QUALITY.value
+
+    def __init__(self, eval_algorithm_config: ContextQualityConfig = ContextQualityConfig()):
+        """ContextQuality initializer
+
+        :param eval_algorithm_config: Context Quality evaluation algorithm config.
+        """
+        super().__init__(eval_algorithm_config)
+        self.eval_algorithm_config = eval_algorithm_config
+
+    def evaluate(
+        self,
+        judge_model: Optional[ModelRunner] = None,
+        dataset_config: Optional[DataConfig] = None,
+        num_records: int = 100,
+        save: bool = False,
+        save_strategy: Optional[SaveStrategy] = None,
+        context_precision_prompt_template: Optional[str] = DEFAULT_CONTEXT_PRECISION_PROMPT_TEMPLATE,
+    ) -> List[EvalOutput]:
+        """Compute context quality metrics on one or more datasets.
+
+        :param judge_model: An instance of ModelRunner representing the judge model to be used.
+            If this argument is None, default judge model will be provided.
+        :param dataset_config: Configures the single dataset used for evaluation.
+            If not provided, evaluations will be run on all of this algorithm's built-in datasets.
+        :param num_records: The number of records to be sampled randomly from the input dataset(s)
+            used to perform the evaluation(s).
+        :param save: If set to true, prompt responses and scores will be saved to a file.
+        :param save_strategy: Specifies the strategy to use the save the localized outputs of the evaluations. If not
+            specified, it will save it to the path that can be configured by the EVAL_RESULTS_PATH environment variable.
+            If that environment variable is also not configured, it will be saved to the default path `/tmp/eval_results/`.
+        :param context_precision_prompt_template: The string prompt template for context precision prompts.
+        :return: A list of EvalOutput objects.
+        """
+        dataset_configs = get_dataset_configs(dataset_config, self.eval_name)
+        if not judge_model:  # pragma: no cover
+            judge_model = get_default_judge_model()
+        pipeline = ContextQuality._build_pipeline(judge_model, self.eval_algorithm_config)
+
+        eval_outputs = []
+        for dataset_config in dataset_configs:
+            dataset = get_dataset(dataset_config, num_records)
+            validate_dataset(
+                dataset,
+                [
+                    DatasetColumns.MODEL_INPUT.value.name,
+                    DatasetColumns.TARGET_OUTPUT.value.name,
+                    DatasetColumns.RETRIEVED_CONTEXT.value.name,
+                ],
+            )
+            eval_output = evaluate_dataset(
+                dataset=dataset,
+                pipeline=pipeline,
+                dataset_name=dataset_config.dataset_name,
+                eval_name=self.eval_name,
+                metric_names=[CONTEXT_PRECISION_SCORE],
+                eval_results_path=get_eval_results_path(),
+                agg_method=MEAN,
+                save=save,
+                save_strategy=save_strategy,
+            )
+            eval_outputs.append(eval_output)
+        return eval_outputs
+
+    def evaluate_sample(
+        self,
+        model_input: str,
+        target_output: str,
+        retrieved_context: str,
+        judge_model: Optional[ModelRunner] = None,
+        context_precision_prompt_template: str = DEFAULT_CONTEXT_PRECISION_PROMPT_TEMPLATE,
+    ) -> List[EvalScore]:
+        """
+        :param model_input: The input that is composed with a prompt template and passed to the model.
+        :param target_output: The referenced "ground truth" answer.
+        :param retrieved_context: The context retrieved from the RAG system.
+        :param judge_model: An instance of ModelRunner representing the judge model to be used.
+            If this argument is None, default judge model will be provided.
+        :param context_precision_prompt_template: The string prompt template for context precision prompts.
+        :return: A list of EvalScores corresponding to the context quality metrics.
+        """
+        if not judge_model:  # pragma: no cover
+            judge_model = get_default_judge_model()
+        sample = {
+            DatasetColumns.MODEL_INPUT.value.name: model_input,
+            DatasetColumns.TARGET_OUTPUT.value.name: target_output,
+            DatasetColumns.RETRIEVED_CONTEXT.value.name: retrieved_context,
+        }
+        pipeline = ContextQuality._build_pipeline(judge_model, self.eval_algorithm_config)
+        result = pipeline.execute_record(sample)
+        context_precision_score = EvalScore(name=CONTEXT_PRECISION_SCORE, value=result[CONTEXT_PRECISION_SCORE])
+        return [context_precision_score]
+
+    @staticmethod
+    def _build_pipeline(judge_model, context_quality_config) -> TransformPipeline:
+        """Builds a transform pipeline to compute context quality scores.
+
+        :param judge_model: An instance of ModelRunner representing the judge model to be used.
+        :param context_quality_config: An instance of ContextQualityConfig.
+        :return: A TransformPipeline containing Transforms to compute context quality scores.
+        """
+        precision_score = ContextPrecisionScore(
+            judge_model=judge_model,
+            target_output_delimiter=context_quality_config.target_output_delimiter,
+            retrieved_context_delimiter=context_quality_config.retrieved_context_delimiter,
+        )
+        pipeline = TransformPipeline([precision_score])
+        return pipeline
+
+
+class ContextPrecisionScore(Transform):
+    def __init__(
+        self,
+        judge_model: ModelRunner,
+        model_input_key: str = DatasetColumns.MODEL_INPUT.value.name,
+        target_output_key: str = DatasetColumns.TARGET_OUTPUT.value.name,
+        retrieved_context_key: str = DatasetColumns.RETRIEVED_CONTEXT.value.name,
+        context_precision_score_key: str = CONTEXT_PRECISION_SCORE,
+        target_output_delimiter: Optional[str] = "<OR>",
+        retrieved_context_delimiter: Optional[str] = "<AND>",
+        judge_model_context_precision_prompt_template: str = DEFAULT_CONTEXT_PRECISION_PROMPT_TEMPLATE,
+    ):
+        """Context Precision score initializer.
+
+        :param judge_model: A ModelRunner instance for the context judge model.
+        :param model_input_key: The key corresponding to the model input.
+        :param target_output_key: The key corresponding to the target output.
+        :param retrieved_context_key: The key corresponding to the retrieved context.
+        :param context_precision_score_key: The key corresponding to the context precision score.
+        :param target_output_delimiter: The delimiter used to concatenate multiple target outputs.
+        :param retrieved_context_delimiter: The delimiter used to concatenate multiple retrieved contexts.
+        :param judge_model_context_precision_prompt_template: The prompt template for context precision.
+        """
+        super().__init__(
+            judge_model,
+            model_input_key,
+            target_output_key,
+            retrieved_context_key,
+            context_precision_score_key,
+            target_output_delimiter,
+            retrieved_context_delimiter,
+            judge_model_context_precision_prompt_template,
+        )
+        self.register_input_output_keys(
+            input_keys=[model_input_key, target_output_key, retrieved_context_key],
+            output_keys=[context_precision_score_key],
+        )
+        self.model_input_key = model_input_key
+        self.target_output_key = target_output_key
+        self.retrieved_context_key = retrieved_context_key
+        self.judge_model = judge_model
+        self.judge_model_context_precision_prompt_template = judge_model_context_precision_prompt_template
+        self.context_precision_score_key = context_precision_score_key
+        self.target_output_delimiter = target_output_delimiter
+        self.retrieved_context_delimiter = retrieved_context_delimiter
+        self.context_precision_prompt_composer = PromptComposer(self.judge_model_context_precision_prompt_template)
+
+    @validate_call
+    def __call__(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        """Augment the input record with the computed context quality scores.
+
+        :param record: the input record.
+        :return: The input record with the context quality scores added.
+        """
+        model_input = record[self.model_input_key]
+        target_output = record[self.target_output_key]
+        retrieved_context = record[self.retrieved_context_key]
+        record[self.context_precision_score_key] = self._get_score(model_input, target_output, retrieved_context)
+        return record
+
+    def _get_score(self, model_input: str, target_output: str, retrieved_context: str) -> float:
+        """Computes the context precision score by composing a prompt on each (context chunk, model input,
+        target output) triple and doing inference on the judge model to get a verdict of 0 or 1, then
+        calculating the score using the judge model verdicts.
+
+        For multiple target contexts, we do a "logical or" operation on the model verdicts, so if the
+        model verdict for a given context chunk is 1 for any target output, the model verdict for that
+        context chunk will be 1.
+
+        :param model_input: The input that is composed with a prompt template and passed to the model.
+        :param target_output: The referenced "ground truth" answer.
+        :param retrieved_context: The context retrieved from the RAG system.
+        :return: the context precision score.
+        """
+        target_outputs = target_output.split(self.target_output_delimiter)
+        context_chunks = retrieved_context.split(self.retrieved_context_delimiter)
+        results = []
+        for context_chunk in context_chunks:
+            model_verdict = 0
+            for target_output in target_outputs:
+                prompt = self.context_precision_prompt_composer.compose(
+                    model_input, {"target_output": target_output, "retrieved_context": context_chunk}
+                )
+                model_output = self.judge_model.predict(prompt)[0]
+                model_verdict = ContextPrecisionScore._parse_model_output(model_output)
+                if model_verdict:
+                    break
+            results.append(model_verdict)
+        score = ContextPrecisionScore._compute_metric(results)
+        return score
+
+    @staticmethod
+    def _parse_model_output(model_output: str) -> int:
+        """Parses the model output to a binary score of 0 or 1
+
+        :param model_output: The output of the judge model.
+        :return: Score of 0 or 1.
+        """
+        response_words = model_output.split(" ")
+        predicted_labels = [
+            word.lower().strip() for word in response_words if word.lower().strip() in BINARY_SCORE_VALUES
+        ]
+        string_label = predicted_labels[0] if predicted_labels else "0"
+        return int(string_label)
+
+    @staticmethod
+    def _compute_metric(judge_model_verdicts: List[int]) -> float:
+        """Computes the context precision score for one record given judge model verdicts
+
+        :param judge_model_verdicts: A list of judge model verdicts of 0 or 1.
+        :return: the context precision score for the record.
+        """
+        response_list = [1 if ver else 0 for ver in judge_model_verdicts]
+        denominator = sum(response_list) + 1e-10
+        numerator = sum([(sum(response_list[: i + 1]) / (i + 1)) * response_list[i] for i in range(len(response_list))])
+        score = numerator / denominator
+        return score

--- a/test/unit/eval_algorithms/test_context_quality.py
+++ b/test/unit/eval_algorithms/test_context_quality.py
@@ -61,7 +61,28 @@ class TestContextQuality:
                 retrieved_context="The Andes is the longest continental mountain range in the world<AND> located in South America. <AND>It stretches across seven countries and features many of the highest peaks in the Western Hemisphere. <AND>The range is known for its diverse ecosystems, including the high-altitude Andean Plateau and the Amazon rainforest.",
                 mocked_judge_model_responses=[("The score is 0", None), ("0", None), ("1", None), ("unknown", None)],
                 expected_response=[EvalScore(name=CONTEXT_PRECISION_SCORE, value=0.3333333333)],
-            )
+            ),
+            TestCaseContextQualityEvaluateSample(
+                model_input="What is the tallest mountain in the world?",
+                target_output="Mount Everest.",
+                retrieved_context="The Andes is the longest continental mountain range in the world",
+                mocked_judge_model_responses=[("0", None)],
+                expected_response=[EvalScore(name=CONTEXT_PRECISION_SCORE, value=0)],
+            ),
+            TestCaseContextQualityEvaluateSample(
+                model_input="Who won the most super bowls?",
+                target_output="Pittsburgh Steelers<OR>New England Patriots",
+                retrieved_context="The AFC's Pittsburgh Steelers and New England Patriots have the most Super Bowl titles at six each.",
+                mocked_judge_model_responses=[("1", None)],
+                expected_response=[EvalScore(name=CONTEXT_PRECISION_SCORE, value=0.9999999999)],
+            ),
+            TestCaseContextQualityEvaluateSample(
+                model_input="Who won the most super bowls?",
+                target_output="Pittsburgh Steelers<OR>New England Patriots",
+                retrieved_context="The Patriots have the most Super Bowl appearances at 11. <AND>The AFC's Pittsburgh Steelers and New England Patriots have the most Super Bowl titles at six each.",
+                mocked_judge_model_responses=[("The score is 0", None), ("0", None), ("1", None)],
+                expected_response=[EvalScore(name=CONTEXT_PRECISION_SCORE, value=0.5)],
+            ),
         ],
     )
     def test_context_quality_evaluate_sample(self, test_case):
@@ -101,7 +122,6 @@ class TestContextQuality:
                     ("The score is 1", None),
                     ("1", None),
                     ("It's hard to say", None),
-                    ("1", None),
                 ],
                 expected_response=[
                     EvalOutput(

--- a/test/unit/eval_algorithms/test_context_quality.py
+++ b/test/unit/eval_algorithms/test_context_quality.py
@@ -1,0 +1,138 @@
+from typing import NamedTuple, List, Tuple
+from unittest.mock import Mock, patch
+
+import pytest
+import ray
+from ray.data import Dataset
+
+from fmeval.constants import (
+    DatasetColumns,
+    MIME_TYPE_JSONLINES,
+)
+from fmeval.data_loaders.data_config import DataConfig
+from fmeval.eval_algorithms import EvalScore, EvalOutput
+
+from fmeval.eval_algorithms.context_quality import ContextQuality, ContextQualityConfig, CONTEXT_PRECISION_SCORE
+
+
+class TestCaseContextQualityEvaluateSample(NamedTuple):
+    model_input: str
+    target_output: str
+    retrieved_context: str
+    mocked_judge_model_responses: List[Tuple]
+    expected_response: List[EvalScore]
+
+
+class TestCaseContextQualityEvaluate(NamedTuple):
+    dataset: Dataset
+    data_config: DataConfig
+    mocked_judge_model_responses: List[Tuple]
+    expected_response: List[EvalOutput]
+
+
+CONTEXT_QUALITY_DATASET = ray.data.from_items(
+    [
+        {
+            DatasetColumns.MODEL_INPUT.value.name: "What is the tallest mountain in the world?",
+            DatasetColumns.TARGET_OUTPUT.value.name: "Mount Everest.",
+            DatasetColumns.RETRIEVED_CONTEXT.value.name: "The Andes is the longest continental mountain range in the world.",
+        },
+        {
+            DatasetColumns.MODEL_INPUT.value.name: "Who won the most super bowls?",
+            DatasetColumns.TARGET_OUTPUT.value.name: "Pittsburgh Steelers<OR>New England Patriots",
+            DatasetColumns.RETRIEVED_CONTEXT.value.name: "The AFC's Pittsburgh Steelers and New England Patriots have the most Super Bowl titles at six each.",
+        },
+        {
+            DatasetColumns.MODEL_INPUT.value.name: "What do the 3 dots mean in math?",
+            DatasetColumns.TARGET_OUTPUT.value.name: "therefore sign",
+            DatasetColumns.RETRIEVED_CONTEXT.value.name: "The therefore sign is generally used before a logical consequence. <AND>The symbol consists of three dots placed in an upright triangle and is read therefore.",
+        },
+    ]
+)
+
+
+class TestContextQuality:
+    @pytest.mark.parametrize(
+        "test_case",
+        [
+            TestCaseContextQualityEvaluateSample(
+                model_input="What is the tallest mountain in the world?",
+                target_output="Mount Everest.",
+                retrieved_context="The Andes is the longest continental mountain range in the world<AND> located in South America. <AND>It stretches across seven countries and features many of the highest peaks in the Western Hemisphere. <AND>The range is known for its diverse ecosystems, including the high-altitude Andean Plateau and the Amazon rainforest.",
+                mocked_judge_model_responses=[("The score is 0", None), ("0", None), ("1", None), ("unknown", None)],
+                expected_response=[EvalScore(name=CONTEXT_PRECISION_SCORE, value=0.3333333333)],
+            )
+        ],
+    )
+    def test_context_quality_evaluate_sample(self, test_case):
+        """
+        GIVEN a dataset sample with model_input, target_output and retrieved_context
+        WHEN evaluate_sample is called.
+        THEN the correct score is returned.
+        """
+        mock_runner = Mock()
+        mock_runner.predict.side_effect = test_case.mocked_judge_model_responses
+        config = ContextQualityConfig()
+
+        eval_algorithm = ContextQuality(config)
+        actual_response = eval_algorithm.evaluate_sample(
+            model_input=test_case.model_input,
+            target_output=test_case.target_output,
+            retrieved_context=test_case.retrieved_context,
+            judge_model=mock_runner,
+        )
+        assert actual_response == test_case.expected_response
+
+    @pytest.mark.parametrize(
+        "test_case",
+        [
+            TestCaseContextQualityEvaluate(
+                dataset=CONTEXT_QUALITY_DATASET,
+                data_config=DataConfig(
+                    dataset_name="retrieved_dataset",
+                    dataset_uri="path",
+                    dataset_mime_type=MIME_TYPE_JSONLINES,
+                    model_input_location="model_input",
+                    target_output_location="target_output",
+                    retrieved_context_location="retrieved_context",
+                ),
+                mocked_judge_model_responses=[
+                    ("0", None),
+                    ("The score is 1", None),
+                    ("1", None),
+                    ("It's hard to say", None),
+                    ("1", None),
+                ],
+                expected_response=[
+                    EvalOutput(
+                        eval_name="context_quality",
+                        dataset_name="retrieved_dataset",
+                        dataset_scores=[EvalScore(name="context_precision_score", value=0.6666666666)],
+                        prompt_template=None,
+                        category_scores=None,
+                        output_path="/tmp/eval_results/context_quality_retrieved_dataset.jsonl",
+                        error=None,
+                    )
+                ],
+            )
+        ],
+    )
+    @patch("fmeval.eval_algorithms.common.save_dataset")
+    @patch("fmeval.eval_algorithms.context_quality.get_dataset")
+    def test_context_quality_evaluate(self, get_dataset, save_dataset, test_case):
+        """
+        GIVEN an input dataset with model_input, target_output and retrieved_context
+        WHEN evaluate is called.
+        THEN the correct eval output is returned.
+        """
+        get_dataset.return_value = test_case.dataset
+        mock_runner = Mock()
+        mock_runner.predict.side_effect = test_case.mocked_judge_model_responses
+
+        config = ContextQualityConfig()
+        eval_algorithm = ContextQuality(config)
+        actual_response = eval_algorithm.evaluate(
+            judge_model=mock_runner, dataset_config=test_case.data_config, save=True
+        )
+        assert actual_response == test_case.expected_response
+        assert save_dataset.called

--- a/test/unit/eval_algorithms/test_context_quality.py
+++ b/test/unit/eval_algorithms/test_context_quality.py
@@ -137,7 +137,7 @@ class TestContextQuality:
             )
         ],
     )
-    @patch("fmeval.eval_algorithms.common.save_dataset")
+    @patch("fmeval.eval_algorithms.context_quality.save_dataset")
     @patch("fmeval.eval_algorithms.context_quality.get_dataset")
     def test_context_quality_evaluate(self, get_dataset, save_dataset, test_case):
         """


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds the context precision metric under the context quality evaluation algorithm. This is the first of three evaluation metrics under context quality. 

Context Precision is a metric that evaluates whether all of the target output relevant items present in the retrieved contexts are ranked higher or not. Ideally all the relevant context chunks must appear at the top ranks. This metric is computed using the `model_input`, `target_output` and the `retrieved_contexts`, with values ranging between 0 and 1, where higher scores indicate better precision.

Notes:
* There are no built in datasets for context quality since the dataset context needs to be retrieved by the RAG system. 
* The default judge model is currently set to a sample Bedrock model because judge model selection is in progress. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
