### PR TITLE
feat: support embedding model runner

### DIFF
--- a/src/fmeval/constants.py
+++ b/src/fmeval/constants.py
@@ -131,6 +131,8 @@ JUMPSTART_BUCKET_BASE_URL_FORMAT = "https://jumpstart-cache-prod-{}.s3.{}.amazon
 JUMPSTART_BUCKET_BASE_URL_FORMAT_ENV_VAR = "JUMPSTART_BUCKET_BASE_URL_FORMAT"
 GENERATED_TEXT_JMESPATH_EXPRESSION = "*.output_keys.generated_text"
 INPUT_LOG_PROBS_JMESPATH_EXPRESSION = "*.output_keys.input_logprobs"
+EMBEDDING_JMESPATH_EXPRESSION = "embedding"
+IS_EMBEDDING_MODEL = "is_embedding_model"
 
 # BERTScore
 BERTSCORE_DEFAULT_MODEL = "microsoft/deberta-xlarge-mnli"

--- a/src/fmeval/model_runners/bedrock_model_runner.py
+++ b/src/fmeval/model_runners/bedrock_model_runner.py
@@ -4,7 +4,7 @@ Module to manage model runners for Bedrock models.
 import json
 import logging
 from fmeval.util import require
-from typing import Optional, Tuple
+from typing import Optional, Tuple, List, Union
 from fmeval.constants import MIME_TYPE_JSON
 from fmeval.model_runners.model_runner import ModelRunner
 from fmeval.model_runners.util import get_bedrock_runtime_client
@@ -24,6 +24,7 @@ class BedrockModelRunner(ModelRunner):
         content_template: str,
         output: Optional[str] = None,
         log_probability: Optional[str] = None,
+        embedding: Optional[str] = None,
         content_type: str = MIME_TYPE_JSON,
         accept_type: str = MIME_TYPE_JSON,
     ):
@@ -32,20 +33,22 @@ class BedrockModelRunner(ModelRunner):
         :param content_template: String template to compose the model input from the prompt
         :param output: JMESPath expression of output in the model output
         :param log_probability: JMESPath expression of log probability in the model output
+        :param embedding: JMESPath expression of embedding in the model output
         :param content_type: The content type of the request sent to the model for inference
         :param accept_type: The accept type of the request sent to the model for inference
         """
-        super().__init__(content_template, output, log_probability, content_type, accept_type)
+        super().__init__(content_template, output, log_probability, embedding, content_type, accept_type)
         self._model_id = model_id
         self._content_template = content_template
         self._output = output
         self._log_probability = log_probability
         self._content_type = content_type
         self._accept_type = accept_type
+        self._embedding = embedding
 
         require(
-            output is not None or log_probability is not None,
-            "One of output jmespath expression or log probability jmespath expression must be provided",
+            output is not None or log_probability is not None or embedding is not None,
+            "One of output jmespath expression, log probability or embedding jmespath expression must be provided",
         )
         require(self._accept_type == MIME_TYPE_JSON, f"Model accept type `{self._accept_type}` is not supported.")
         require(
@@ -54,7 +57,7 @@ class BedrockModelRunner(ModelRunner):
         )
         self._bedrock_runtime_client = get_bedrock_runtime_client()
 
-    def predict(self, prompt: str) -> Tuple[Optional[str], Optional[float]]:
+    def predict(self, prompt: str) -> Union[Tuple[Optional[str], Optional[float]], List[float]]:
         """
         Invoke the Bedrock model and parse the model response.
         :param prompt: Input data for which you want the model to provide inference.
@@ -65,6 +68,15 @@ class BedrockModelRunner(ModelRunner):
             body=body, modelId=self._model_id, accept=self._accept_type, contentType=self._content_type
         )
         model_output = json.loads(response.get("body").read())
+
+        embedding = (
+            self._extractor.extract_embedding(data=model_output, num_records=1)
+            if self._extractor.embedding_jmespath_expression
+            else None
+        )
+        if embedding:
+            return embedding
+
         output = (
             self._extractor.extract_output(data=model_output, num_records=1)
             if self._extractor.output_jmespath_expression
@@ -87,6 +99,7 @@ class BedrockModelRunner(ModelRunner):
             self._content_template,
             self._output,
             self._log_probability,
+            self._embedding,
             self._content_type,
             self._accept_type,
         )

--- a/src/fmeval/model_runners/composers/__init__.py
+++ b/src/fmeval/model_runners/composers/__init__.py
@@ -2,7 +2,7 @@ import logging
 from typing import Optional
 
 import fmeval.util as util
-from fmeval.constants import MIME_TYPE_JSON, JUMPSTART_MODEL_ID, JUMPSTART_MODEL_VERSION
+from fmeval.constants import MIME_TYPE_JSON, JUMPSTART_MODEL_ID, JUMPSTART_MODEL_VERSION, IS_EMBEDDING_MODEL
 from fmeval.exceptions import EvalAlgorithmClientError
 from fmeval.model_runners.composers.composers import Composer, JsonContentComposer
 from fmeval.model_runners.composers.jumpstart_composer import JumpStartComposer
@@ -28,6 +28,7 @@ def create_content_composer(template: Optional[str] = None, content_type: str = 
         composer = JumpStartComposer(
             jumpstart_model_id=kwargs[JUMPSTART_MODEL_ID],
             jumpstart_model_version=kwargs[JUMPSTART_MODEL_VERSION] if JUMPSTART_MODEL_VERSION in kwargs else "*",
+            is_embedding_model=kwargs[IS_EMBEDDING_MODEL] if IS_EMBEDDING_MODEL in kwargs else False,
         )
     else:  # pragma: no cover
         raise EvalAlgorithmClientError(f"Invalid accept type: {content_type} ")

--- a/src/fmeval/model_runners/composers/jumpstart_composer.py
+++ b/src/fmeval/model_runners/composers/jumpstart_composer.py
@@ -1,4 +1,5 @@
-from typing import Optional
+import json
+from typing import Optional, Union
 
 from sagemaker.jumpstart.payload_utils import _construct_payload
 from sagemaker.jumpstart.types import JumpStartSerializablePayload
@@ -24,13 +25,13 @@ class JumpStartComposer(Composer):
         self._model_version = jumpstart_model_version
         self._is_embedding_model = is_embedding_model
 
-    def compose(self, prompt: str) -> JumpStartSerializablePayload:
+    def compose(self, prompt: str) -> Union[JumpStartSerializablePayload, bytes]:
         """
         Composes the payload for the given JumpStartModel from the provided prompt.
         """
-        # embedding models take raw text as input payload
+        # embedding models input to the endpoint is any string of text dumped in json and encoded in `utf-8` format
         if self._is_embedding_model:
-            return prompt
+            return json.dumps(prompt).encode("utf-8")
         sagemaker_session = get_sagemaker_session()
         # Default model type is always OPEN_WEIGHTS. See https://tinyurl.com/yc58s6wj
         jumpstart_model_type = JumpStartModelType.OPEN_WEIGHTS

--- a/src/fmeval/model_runners/composers/jumpstart_composer.py
+++ b/src/fmeval/model_runners/composers/jumpstart_composer.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from sagemaker.jumpstart.payload_utils import _construct_payload
 from sagemaker.jumpstart.types import JumpStartSerializablePayload
 from sagemaker.jumpstart.enums import JumpStartModelType
@@ -12,17 +14,23 @@ class JumpStartComposer(Composer):
     Jumpstart model request composer
     """
 
-    def __init__(self, jumpstart_model_id: str, jumpstart_model_version: str):
+    def __init__(
+        self, jumpstart_model_id: str, jumpstart_model_version: str, is_embedding_model: Optional[bool] = False
+    ):
         """
         Initialize the JumpStartComposer for the given JumpStart model_id and model_version.
         """
         self._model_id = jumpstart_model_id
         self._model_version = jumpstart_model_version
+        self._is_embedding_model = is_embedding_model
 
     def compose(self, prompt: str) -> JumpStartSerializablePayload:
         """
         Composes the payload for the given JumpStartModel from the provided prompt.
         """
+        # embedding models take raw text as input payload
+        if self._is_embedding_model:
+            return prompt
         sagemaker_session = get_sagemaker_session()
         # Default model type is always OPEN_WEIGHTS. See https://tinyurl.com/yc58s6wj
         jumpstart_model_type = JumpStartModelType.OPEN_WEIGHTS

--- a/src/fmeval/model_runners/extractors/__init__.py
+++ b/src/fmeval/model_runners/extractors/__init__.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from fmeval.constants import MIME_TYPE_JSON, JUMPSTART_MODEL_ID, JUMPSTART_MODEL_VERSION
+from fmeval.constants import MIME_TYPE_JSON, JUMPSTART_MODEL_ID, JUMPSTART_MODEL_VERSION, IS_EMBEDDING_MODEL
 from fmeval.exceptions import EvalAlgorithmClientError
 from fmeval.model_runners.extractors.json_extractor import JsonExtractor
 from fmeval.model_runners.extractors.jumpstart_extractor import JumpStartExtractor
@@ -10,23 +10,28 @@ def create_extractor(
     model_accept_type: str = MIME_TYPE_JSON,
     output_location: Optional[str] = None,
     log_probability_location: Optional[str] = None,
+    embedding_location: Optional[str] = None,
     **kwargs,
 ):
-    if model_accept_type == MIME_TYPE_JSON and (output_location is not None or log_probability_location is not None):
+    if model_accept_type == MIME_TYPE_JSON and (
+        output_location is not None or log_probability_location is not None or embedding_location is not None
+    ):
         extractor = JsonExtractor(
             output_jmespath_expression=output_location,
             log_probability_jmespath_expression=log_probability_location,
+            embedding_jmespath_expression=embedding_location,
         )
     elif JUMPSTART_MODEL_ID in kwargs:
         extractor = JumpStartExtractor(
             jumpstart_model_id=kwargs[JUMPSTART_MODEL_ID],
             jumpstart_model_version=kwargs[JUMPSTART_MODEL_VERSION] if JUMPSTART_MODEL_VERSION in kwargs else "*",
+            is_embedding_model=kwargs[IS_EMBEDDING_MODEL] if IS_EMBEDDING_MODEL in kwargs else False,
         )
     else:  # pragma: no cover
         error_message = (
             f"Invalid accept type: {model_accept_type}."
             if model_accept_type is None
-            else "One of output jmespath expression or log probability jmespath expression must be provided"
+            else "One of output jmespath expression, log probability or embedding jmespath expression must be provided"
         )
         raise EvalAlgorithmClientError(error_message)
 

--- a/src/fmeval/model_runners/extractors/extractor.py
+++ b/src/fmeval/model_runners/extractors/extractor.py
@@ -28,3 +28,12 @@ class Extractor(ABC):
         :param data: Model response.
         :return: model output
         """
+
+    @abstractmethod
+    def extract_embedding(self, data: Union[List, Dict], num_records: int) -> Union[List[List[float]], List[float]]:
+        """
+        Extract embedding from model response.
+
+        :param data: Model response.
+        :return: model output
+        """

--- a/src/fmeval/model_runners/model_runner.py
+++ b/src/fmeval/model_runners/model_runner.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Optional, Tuple
+from typing import Optional, Tuple, List, Union
 
 from fmeval.constants import MIME_TYPE_JSON
 from fmeval.model_runners.composers import create_content_composer
@@ -19,6 +19,7 @@ class ModelRunner(ABC):
         content_template: Optional[str] = None,
         output: Optional[str] = None,
         log_probability: Optional[str] = None,
+        embedding: Optional[str] = None,
         content_type: str = MIME_TYPE_JSON,
         accept_type: str = MIME_TYPE_JSON,
         **kwargs
@@ -27,6 +28,7 @@ class ModelRunner(ABC):
         :param content_template: String template to compose the model input from the prompt
         :param output: JMESPath expression of output in the model output
         :param log_probability: JMESPath expression of log probability in the model output
+        :param embedding: JMESPath expression of embedding in the model output
         :param content_type: The content type of the request sent to the model for inference
         :param accept_type: The accept type of the request sent to the model for inference
         """
@@ -35,16 +37,17 @@ class ModelRunner(ABC):
             model_accept_type=accept_type,
             output_location=output,
             log_probability_location=log_probability,
+            embedding_location=embedding,
             **kwargs,
         )
 
     @abstractmethod
-    def predict(self, prompt: str) -> Tuple[Optional[str], Optional[float]]:
+    def predict(self, prompt: str) -> Union[Tuple[Optional[str], Optional[float]], List[float]]:
         """
         Runs the model on the given prompt. This includes updating the prompt to fit the request format that the model
         expects, and extracting the output and log probability from the model response. The response of the ModelRunner
-        will be a tuple of (output, log_probability)
+        will be a tuple of (output, log_probability) or embedding
 
         :param prompt: the prompt
-        :return: the tuple containing model output string and the log probability
+        :return: the tuple containing model output string and the log probability, or embedding
         """

--- a/src/fmeval/model_runners/util.py
+++ b/src/fmeval/model_runners/util.py
@@ -24,6 +24,7 @@ from fmeval.constants import (
 from fmeval.util import get_fmeval_package_version
 from mypy_boto3_bedrock.client import BedrockClient
 from sagemaker.user_agent import get_user_agent_extra_suffix
+from sagemaker.jumpstart.notebook_utils import list_jumpstart_models
 
 logger = logging.getLogger(__name__)
 
@@ -129,6 +130,15 @@ def is_endpoint_in_service(
     if not desc or "EndpointStatus" not in desc or desc["EndpointStatus"] != "InService":
         in_service = False
     return in_service
+
+
+def is_text_embedding_js_model(jumpstart_model_id: str) -> bool:
+    """
+    :param jumpstart_model_id: JumpStart model id.
+    :return: Whether the provided model id is text embedding model or not.
+    """
+    text_embedding_models = list_jumpstart_models("search_keywords includes Text Embedding")
+    return jumpstart_model_id in text_embedding_models
 
 
 def is_proprietary_js_model(region: str, jumpstart_model_id: str) -> bool:

--- a/test/unit/model_runners/composers/test_jumpstart_composer.py
+++ b/test/unit/model_runners/composers/test_jumpstart_composer.py
@@ -88,7 +88,7 @@ class TestJumpStartComposer:
         js_composer = JumpStartComposer(
             jumpstart_model_id=EMBEDDING_MODEL_ID, jumpstart_model_version="*", is_embedding_model=True
         )
-        assert js_composer.compose(PROMPT) == PROMPT
+        assert js_composer.compose(PROMPT) == b'"Hello, how are you?"'
         construct_payload.assert_not_called()
 
     @patch(

--- a/test/unit/model_runners/composers/test_jumpstart_composer.py
+++ b/test/unit/model_runners/composers/test_jumpstart_composer.py
@@ -10,6 +10,8 @@ from fmeval.model_runners.composers.jumpstart_composer import JumpStartComposer
 
 OSS_MODEL_ID = "huggingface-eqa-roberta-large"
 PROPRIETARY_MODEL_ID = "cohere-gpt-medium"
+EMBEDDING_MODEL_ID = "tcembedding-model-id"
+PROMPT = "Hello, how are you?"
 
 
 class TestJumpStartComposer:
@@ -80,6 +82,14 @@ class TestJumpStartComposer:
                 tolerate_deprecated_model=True,
                 tolerate_vulnerable_model=True,
             )
+
+    @patch("fmeval.model_runners.composers.jumpstart_composer._construct_payload")
+    def test_compose_embedding_model(self, construct_payload):
+        js_composer = JumpStartComposer(
+            jumpstart_model_id=EMBEDDING_MODEL_ID, jumpstart_model_version="*", is_embedding_model=True
+        )
+        assert js_composer.compose(PROMPT) == PROMPT
+        construct_payload.assert_not_called()
 
     @patch(
         "fmeval.model_runners.composers.jumpstart_composer._construct_payload",

--- a/test/unit/model_runners/extractors/test_create_extractor.py
+++ b/test/unit/model_runners/extractors/test_create_extractor.py
@@ -26,6 +26,6 @@ def test_create_extractor_jumpstart_proprietary():
 def test_create_extractor_exception():
     with pytest.raises(
         EvalAlgorithmClientError,
-        match="One of output jmespath expression or log probability jmespath expression must be provided",
+        match="One of output jmespath expression, log probability or embedding jmespath expression must be provided",
     ):
         assert isinstance(create_extractor(model_accept_type=MIME_TYPE_JSON), JsonExtractor)

--- a/test/unit/model_runners/test_sm_jumpstart_model_runner.py
+++ b/test/unit/model_runners/test_sm_jumpstart_model_runner.py
@@ -24,7 +24,10 @@ OUTPUT = "This is the model output"
 LOG_PROBABILITY = 0.9
 OUTPUT_JMES_PATH = "predictions.output"
 LOG_PROBABILITY_JMES_PATH = "predictions.log_prob"
+EMBEDDING_JMES_PATH = "embedding"
 MODEL_OUTPUT = {"predictions": {"output": OUTPUT, "log_prob": LOG_PROBABILITY}}
+VECTOR = [-0.64453125, -0.20996094, 0.4296875, 0.29296875, 0.484375, 0.29296875]
+EMBEDDING_MODEL_OUTPUT = {"embedding": VECTOR, "inputTextTokenCount": 10}
 
 # NOTE: Here the original class name can be used to mock the class, because sm_model_runner.py uses "import sagemaker"
 # and then refers to Predictor class by its full path. If the module uses "from sagemaker.predictor import Predictor"
@@ -47,7 +50,10 @@ class TestJumpStartModelRunner:
     )
     @patch("sagemaker.session.Session")
     @patch("sagemaker.predictor.Predictor")
-    def test_jumpstart_model_runner_init(self, sagemaker_predictor_class, sagemaker_session_class, test_case_init):
+    @patch("fmeval.model_runners.sm_jumpstart_model_runner.is_text_embedding_js_model", return_value=False)
+    def test_jumpstart_model_runner_init(
+        self, is_text_embedding_js_model, sagemaker_predictor_class, sagemaker_session_class, test_case_init
+    ):
         """
         GIVEN valid Jumpstart model runner parameters
         WHEN try to create JumpStartModelRunner
@@ -121,7 +127,8 @@ class TestJumpStartModelRunner:
         ],
     )
     @patch("sagemaker.session.Session")
-    def test_jumpstart_model_runner_predict(self, sagemaker_session_class, test_case):
+    @patch("fmeval.model_runners.sm_jumpstart_model_runner.is_text_embedding_js_model", return_value=False)
+    def test_jumpstart_model_runner_predict(self, is_text_embedding_js_model, sagemaker_session_class, test_case):
         """
         GIVEN valid JumpStartModelRunner
         WHEN predict() called
@@ -168,7 +175,8 @@ class TestJumpStartModelRunner:
             assert result == (test_case.output, test_case.log_probability)
 
     @patch("sagemaker.session.Session")
-    def test_jumpstart_model_runner_predict_no_output(self, sagemaker_session_class):
+    @patch("fmeval.model_runners.sm_jumpstart_model_runner.is_text_embedding_js_model", return_value=False)
+    def test_jumpstart_model_runner_predict_no_output(self, is_text_embedding_js_model, sagemaker_session_class):
         """
         GIVEN valid JumpStartModelRunner
         WHEN predict() called
@@ -213,7 +221,54 @@ class TestJumpStartModelRunner:
             assert result == (OUTPUT, LOG_PROBABILITY)
 
     @patch("sagemaker.session.Session")
-    def test_jumpstart_model_runner_serializer(self, sagemaker_session_class):
+    @patch("fmeval.model_runners.sm_jumpstart_model_runner.is_text_embedding_js_model", return_value=True)
+    def test_jumpstart_model_runner_predict_embedding(self, is_text_embedding_js_model, sagemaker_session_class):
+        """
+        GIVEN valid embedding model JumpStartModelRunner
+        WHEN predict() called
+        THEN SageMaker Predictor predict method is called once with expected parameters,
+            and extract embedding as expected
+        """
+        mock_sagemaker_session = sagemaker_session_class()
+        mock_sagemaker_session.sagemaker_client.describe_endpoint.return_value = {"EndpointStatus": "InService"}
+        mock_sagemaker_session.boto_region_name = "us-west-2"
+
+        with patch.object(
+            sagemaker.serializers, "retrieve_default", return_value=sagemaker.serializers.JSONSerializer()
+        ) as default_serializer, patch.object(
+            sagemaker.deserializers, "retrieve_default", return_value=sagemaker.deserializers.JSONDeserializer()
+        ) as default_deserializer, patch.object(
+            sagemaker.accept_types, "retrieve_default", return_value=MIME_TYPE_JSON
+        ) as default_accept_type, patch.object(
+            sagemaker.content_types, "retrieve_default", return_value=MIME_TYPE_JSON
+        ):
+            js_model_runner = JumpStartModelRunner(
+                endpoint_name=ENDPOINT_NAME,
+                model_id=MODEL_ID,
+                model_version=MODEL_VERSION,
+                content_template=CONTENT_TEMPLATE,
+                custom_attributes=CUSTOM_ATTRIBUTES,
+                component_name=INFERENCE_COMPONENT_NAME,
+            )
+            # Mocking sagemaker.predictor serializing byte into JSON
+            js_model_runner._predictor.deserializer.deserialize = Mock(return_value=EMBEDDING_MODEL_OUTPUT)
+
+            result = js_model_runner.predict(PROMPT)
+            assert mock_sagemaker_session.sagemaker_runtime_client.invoke_endpoint.called
+            call_args, kwargs = mock_sagemaker_session.sagemaker_runtime_client.invoke_endpoint.call_args
+            assert kwargs == {
+                "Accept": MIME_TYPE_JSON,
+                "Body": MODEL_INPUT,
+                "ContentType": MIME_TYPE_JSON,
+                "CustomAttributes": CUSTOM_ATTRIBUTES,
+                "EndpointName": ENDPOINT_NAME,
+                "InferenceComponentName": INFERENCE_COMPONENT_NAME,
+            }
+            assert result == VECTOR
+
+    @patch("sagemaker.session.Session")
+    @patch("fmeval.model_runners.sm_jumpstart_model_runner.is_text_embedding_js_model", return_value=False)
+    def test_jumpstart_model_runner_serializer(self, is_text_embedding_js_model, sagemaker_session_class):
         """
         GIVEN a valid JumpStartModelRunner
         WHEN it is serialized (via pickle.dumps)
@@ -241,6 +296,7 @@ class TestJumpStartModelRunner:
                 custom_attributes=CUSTOM_ATTRIBUTES,
                 output=OUTPUT_JMES_PATH,
                 log_probability=LOG_PROBABILITY_JMES_PATH,
+                embedding=EMBEDDING_JMES_PATH,
                 component_name=INFERENCE_COMPONENT_NAME,
             )
             deserialized: JumpStartModelRunner = pickle.loads(pickle.dumps(js_model_runner))
@@ -251,5 +307,6 @@ class TestJumpStartModelRunner:
             assert deserialized._custom_attributes == js_model_runner._custom_attributes
             assert deserialized._output == js_model_runner._output
             assert deserialized._log_probability == js_model_runner._log_probability
+            assert deserialized._embedding == js_model_runner._embedding
             assert deserialized._component_name == js_model_runner._component_name
             assert isinstance(deserialized._predictor, sagemaker.predictor.Predictor)

--- a/test/unit/model_runners/test_util.py
+++ b/test/unit/model_runners/test_util.py
@@ -7,6 +7,7 @@ from fmeval.model_runners.util import (
     get_bedrock_runtime_client,
     get_user_agent_extra,
     is_proprietary_js_model,
+    is_text_embedding_js_model,
 )
 from fmeval.constants import DISABLE_FMEVAL_TELEMETRY
 
@@ -79,3 +80,9 @@ def test_is_proprietary_js_model_false():
 
 def test_is_proprietary_js_model_true():
     assert is_proprietary_js_model("us-west-2", "cohere-gpt-medium") == True
+
+
+@patch("fmeval.model_runners.util.list_jumpstart_models", return_value=["tcembedding-model-id"])
+def test_is_text_embedding_js_model_false(mock_list_jumpstart_models):
+    assert is_text_embedding_js_model("huggingface-llm-falcon-7b-bf16") == False
+    assert is_text_embedding_js_model("tcembedding-model-id") == True


### PR DESCRIPTION
*Issue #, if available:*
Support text embedding model runner.

*Description of changes:*
1. add `embedding` jmes path filed for model runners 
2. if `embedding` field can be extracted from `predict` model output, then return

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
