### PR TITLE
feat: add col_to_validate to evaluate_dataset

### DIFF
--- a/src/fmeval/eval_algorithms/common.py
+++ b/src/fmeval/eval_algorithms/common.py
@@ -76,6 +76,7 @@ def evaluate_dataset(
     agg_method: str = MEAN,
     save: bool = False,
     save_strategy: Optional[SaveStrategy] = None,
+    col_to_validate: Optional[str] = DatasetColumns.MODEL_OUTPUT.value.name,
 ) -> EvalOutput:
     """Execute an evaluation algorithm's pipeline on a dataset.
 
@@ -98,12 +99,16 @@ def evaluate_dataset(
         Currently, only MEAN is supported.
     :param save: If set to true, prompt responses and scores will be saved to a file.
         The path that this file is stored at is configured by `eval_results_path`.
+    :param col_to_validate: The column to validate for model inference. This can be the model input if
+        the model is provided, the model output if the model is not provided, or None if the model output is not
+        required by the evaluation algorithm.
 
     :return: An EvalOutput object encapsulating the results of the evaluation.
     """
     if model:
         try:
-            validate_dataset(dataset, [DatasetColumns.MODEL_INPUT.value.name])
+            col_to_validate = DatasetColumns.MODEL_INPUT.value.name
+            validate_dataset(dataset, [col_to_validate])
         except EvalAlgorithmClientError:
             raise EvalAlgorithmClientError(
                 "evaluate_dataset has been given a ModelRunner to obtain outputs from "
@@ -119,7 +124,8 @@ def evaluate_dataset(
                 "Model outputs from the dataset will be used, and this prompt template will be ignored."
             )
         try:
-            validate_dataset(dataset, [DatasetColumns.MODEL_OUTPUT.value.name])
+            if col_to_validate:
+                validate_dataset(dataset, [col_to_validate])
         except EvalAlgorithmClientError:
             raise EvalAlgorithmClientError(
                 "evaluate_dataset has been given a dataset with no model output column "

--- a/test/unit/eval_algorithms/test_common.py
+++ b/test/unit/eval_algorithms/test_common.py
@@ -404,3 +404,37 @@ def test_evaluate_dataset_no_model_no_model_output_column():
             model=None,
             prompt_template=None,
         )
+
+
+@patch("fmeval.eval_algorithms.common.aggregate_evaluation_scores")
+@patch("fmeval.eval_algorithms.common.logging.Logger.warning")
+def test_evaluate_dataset_col_to_validate_is_none(mock_logger, mock_aggregate):
+    """
+    GIVEN col_to_validate is None
+    WHEN the `evaluate_dataset` function is called.
+    THEN no errors or warnings are raised and the correct eval output is returned.
+    """
+    mock_aggregate.return_value = [EvalScore(name="a", value=1.0)], None
+    dataset = Mock()
+    dataset.columns = Mock(return_value=[])
+
+    eval_output = evaluate_dataset(
+        dataset=dataset,
+        pipeline=Mock(),
+        dataset_name="my_dataset",
+        eval_name="MyEvalAlgo",
+        metric_names=["a"],
+        eval_results_path="/path/to/eval/results",
+        model=None,
+        prompt_template=None,
+        col_to_validate=None,
+    )
+
+    mock_logger.assert_not_called()
+    assert eval_output == EvalOutput(
+        eval_name="MyEvalAlgo",
+        dataset_name="my_dataset",
+        prompt_template=None,
+        dataset_scores=[EvalScore(name="a", value=1.0)],
+        output_path="path/to/output/dataset",
+    )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Add `col_to_validate` parameter to support instances where the model and model output are not required. See discussion here: https://github.com/aws/fmeval/pull/289#discussion_r1636956969.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
