### PR TITLE
feat: add error field in EvalScore

### DIFF
--- a/src/fmeval/constants.py
+++ b/src/fmeval/constants.py
@@ -75,6 +75,7 @@ class DatasetColumns(Enum):
     SENT_LESS_PROMPT = Column(name="sent_less_prompt")
     SENT_MORE_LOG_PROB = Column(name="sent_more_log_prob", should_cast=False)
     SENT_LESS_LOG_PROB = Column(name="sent_less_log_prob", should_cast=False)
+    ERROR = Column(name="error", should_cast=False)
 
 
 DATASET_COLUMNS = OrderedDict((col.value.name, col) for col in DatasetColumns)

--- a/src/fmeval/eval_algorithms/__init__.py
+++ b/src/fmeval/eval_algorithms/__init__.py
@@ -15,15 +15,26 @@ class EvalScore:
 
     :param name: The name of the eval score offering
     :param value: The aggregated score computed for the given eval offering
+    :param error: A string error message for a failed evaluation.
     """
 
     name: str
-    value: float
+    value: Optional[float] = None
+    error: Optional[str] = None
+
+    def __post_init__(self):  # pragma: no cover
+        """Post initialisation validations for EvalScore"""
+        assert self.value is not None or self.error is not None
 
     def __eq__(self, other: Type["EvalScore"]):  # type: ignore[override]
         try:
             assert self.name == other.name
-            assert math.isclose(self.value, other.value, abs_tol=ABS_TOL)
+            if self.value is not None and other.value is not None:
+                assert math.isclose(self.value, other.value, abs_tol=ABS_TOL)
+                assert self.error is None
+            else:
+                assert self.value == other.value
+                assert self.error == other.error
             return True
         except AssertionError:
             return False
@@ -105,7 +116,7 @@ class EvalOutput:
 
     def __post_init__(self):  # pragma: no cover
         """Post initialisation validations for EvalOutput"""
-        assert self.dataset_scores or self.error
+        assert self.dataset_scores is not None or self.error is not None
 
         if not self.category_scores:
             return

--- a/src/fmeval/eval_algorithms/util.py
+++ b/src/fmeval/eval_algorithms/util.py
@@ -174,7 +174,7 @@ def aggregate_evaluation_scores(
 
 def dataset_aggregation(dataset: Dataset, score_column_name: str, agg_method: str) -> float:
     if agg_method == MEAN:
-        aggregate = dataset.mean(score_column_name)
+        aggregate = dataset.mean(on=score_column_name, ignore_nulls=True)
         assert isinstance(aggregate, float)
         return aggregate
     else:
@@ -184,7 +184,7 @@ def dataset_aggregation(dataset: Dataset, score_column_name: str, agg_method: st
 def category_wise_aggregation(dataset: Dataset, score_column_name: str, agg_method: str) -> Dataset:
     category_aggregate: Dataset = dataset.groupby(DatasetColumns.CATEGORY.value.name)  # type: ignore
     if agg_method == MEAN:
-        category_aggregate = category_aggregate.mean(score_column_name)
+        category_aggregate = category_aggregate.mean(on=score_column_name, ignore_nulls=True)
     else:
         raise EvalAlgorithmInternalError(f"Aggregation method {agg_method} is not supported")
     return category_aggregate

--- a/test/unit/eval_algorithms/test_common.py
+++ b/test/unit/eval_algorithms/test_common.py
@@ -2,7 +2,7 @@ import json
 import os
 import tempfile
 from collections import OrderedDict
-from typing import NamedTuple, Optional
+from typing import NamedTuple, Optional, List, Dict
 from unittest.mock import Mock, patch
 
 import pytest
@@ -41,131 +41,120 @@ CATEGORY_SCORES = [
 ]
 
 
+class TestCaseSaveDataset(NamedTuple):
+    dataset_items: List[Dict]
+    expected_json_keys: List[str]
+    expected_model_input_1_scores: List[Dict]
+    expected_model_input_2_scores: List[Dict]
+
+
+UNUSED_COLUMN_NAME = "unused"
+
+
 @pytest.mark.parametrize("file_name", ["my_dataset.jsonl", "my_dataset"])
-def test_save_dataset(tmp_path, file_name):
-    """
-    Given a Ray Dataset, a list of score names, and a local path
-    WHEN save_dataset is called
-    THEN a JSON Lines file that adheres to the correct schema gets
-        written to the local path
-    """
-    unused_column_name = "unused"
-    # GIVEN
-    ds_items = [
-        {
-            DatasetColumns.MODEL_INPUT.value.name: "hello",
-            DatasetColumns.CATEGORY.value.name: "Age",
-            unused_column_name: "Arch",
-            "rouge": 0.5,
-            "bert_score": 0.42,
-        },
-        {
-            DatasetColumns.MODEL_INPUT.value.name: "world",
-            DatasetColumns.CATEGORY.value.name: "Gender",
-            unused_column_name: "btw",
-            "rouge": 0.314,
-            "bert_score": 0.271,
-        },
-    ]
-    dataset = ray.data.from_items(ds_items)
-    score_names = ["rouge", "bert_score"]
-
-    # WHEN
-    full_path_to_file = str(tmp_path / file_name)
-    save_dataset(dataset, score_names, FileSaveStrategy(full_path_to_file))
-
-    # THEN
-    assert os.path.isfile(full_path_to_file)
-    with open(full_path_to_file) as file_handle:
-        json_objects = [json.loads(line, object_pairs_hook=OrderedDict) for line in file_handle.readlines()]
-        assert json_objects  # if nothing gets written to the file, this test would trivially pass
-        for json_obj in json_objects:
-            # want to ensure ordering of keys is correct, so we use list instead of set
-            assert list(json_obj.keys()) == [
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCaseSaveDataset(
+            dataset_items=[
+                {
+                    DatasetColumns.MODEL_INPUT.value.name: "hello",
+                    DatasetColumns.CATEGORY.value.name: "Age",
+                    UNUSED_COLUMN_NAME: "Arch",
+                    "rouge": 0.5,
+                    "bert_score": 0.42,
+                },
+                {
+                    DatasetColumns.MODEL_INPUT.value.name: "world",
+                    DatasetColumns.CATEGORY.value.name: "Gender",
+                    UNUSED_COLUMN_NAME: "btw",
+                    "rouge": 0.314,
+                    "bert_score": 0.271,
+                },
+            ],
+            expected_json_keys=[
                 DatasetColumns.MODEL_INPUT.value.name,
                 DatasetColumns.CATEGORY.value.name,
                 "scores",
-            ]
-            assert json_obj[DatasetColumns.MODEL_INPUT.value.name] in {"hello", "world"}
-
-            if json_obj[DatasetColumns.MODEL_INPUT.value.name] == "hello":
-                assert json_obj[DatasetColumns.CATEGORY.value.name] == "Age"
-                assert json_obj["scores"] == [
-                    {"name": "rouge", "value": 0.5},
-                    {"name": "bert_score", "value": 0.42},
-                ]
-
-            if json_obj[DatasetColumns.MODEL_INPUT.value.name] == "world":
-                assert json_obj[DatasetColumns.CATEGORY.value.name] == "Gender"
-                assert json_obj["scores"] == [
-                    {"name": "rouge", "value": 0.314},
-                    {"name": "bert_score", "value": 0.271},
-                ]
-
-
-@pytest.mark.parametrize("file_name", ["my_dataset.jsonl", "my_dataset"])
-def test_save_dataset_with_error_eval_score(tmp_path, file_name):
-    """
-    Given a Ray Dataset, a list of score names, and a local path
-    WHEN save_dataset is called
-    THEN a JSON Lines file that adheres to the correct schema gets
-        written to the local path
-    """
-    unused_column_name = "unused"
-    # GIVEN
-    ds_items = [
-        {
-            DatasetColumns.MODEL_INPUT.value.name: "hello",
-            DatasetColumns.CATEGORY.value.name: "Age",
-            DatasetColumns.ERROR.value.name: "error generating rouge score",
-            unused_column_name: "Arch",
-            "rouge": None,
-            "bert_score": 0.42,
-        },
-        {
-            DatasetColumns.MODEL_INPUT.value.name: "world",
-            DatasetColumns.CATEGORY.value.name: "Gender",
-            DatasetColumns.ERROR.value.name: None,
-            unused_column_name: "btw",
-            "rouge": 0.314,
-            "bert_score": 0.271,
-        },
-    ]
-    dataset = ray.data.from_items(ds_items)
-    score_names = ["rouge", "bert_score"]
-
-    # WHEN
-    full_path_to_file = str(tmp_path / file_name)
-    save_dataset(dataset, score_names, FileSaveStrategy(full_path_to_file))
-
-    # THEN
-    assert os.path.isfile(full_path_to_file)
-    with open(full_path_to_file) as file_handle:
-        json_objects = [json.loads(line, object_pairs_hook=OrderedDict) for line in file_handle.readlines()]
-        assert json_objects  # if nothing gets written to the file, this test would trivially pass
-        for json_obj in json_objects:
-            # want to ensure ordering of keys is correct, so we use list instead of set
-            assert list(json_obj.keys()) == [
+            ],
+            expected_model_input_1_scores=[
+                {"name": "rouge", "value": 0.5},
+                {"name": "bert_score", "value": 0.42},
+            ],
+            expected_model_input_2_scores=[
+                {"name": "rouge", "value": 0.314},
+                {"name": "bert_score", "value": 0.271},
+            ],
+        ),
+        TestCaseSaveDataset(
+            dataset_items=[
+                {
+                    DatasetColumns.MODEL_INPUT.value.name: "hello",
+                    DatasetColumns.CATEGORY.value.name: "Age",
+                    DatasetColumns.ERROR.value.name: "error generating rouge score",
+                    UNUSED_COLUMN_NAME: "Arch",
+                    "rouge": None,
+                    "bert_score": 0.42,
+                },
+                {
+                    DatasetColumns.MODEL_INPUT.value.name: "world",
+                    DatasetColumns.CATEGORY.value.name: "Gender",
+                    DatasetColumns.ERROR.value.name: None,
+                    UNUSED_COLUMN_NAME: "btw",
+                    "rouge": 0.314,
+                    "bert_score": 0.271,
+                },
+            ],
+            expected_json_keys=[
                 DatasetColumns.MODEL_INPUT.value.name,
                 DatasetColumns.CATEGORY.value.name,
                 DatasetColumns.ERROR.value.name,
                 "scores",
-            ]
+            ],
+            expected_model_input_1_scores=[
+                {"name": "rouge", "error": "error generating rouge score"},
+                {"name": "bert_score", "value": 0.42},
+            ],
+            expected_model_input_2_scores=[
+                {"name": "rouge", "value": 0.314},
+                {"name": "bert_score", "value": 0.271},
+            ],
+        ),
+    ],
+)
+def test_save_dataset(tmp_path, file_name, test_case):
+    """
+    Given a Ray Dataset, a list of score names, and a local path
+    WHEN save_dataset is called
+    THEN a JSON Lines file that adheres to the correct schema gets
+        written to the local path
+    """
+    # GIVEN
+    ds_items = test_case.dataset_items
+    dataset = ray.data.from_items(ds_items)
+    score_names = ["rouge", "bert_score"]
+
+    # WHEN
+    full_path_to_file = str(tmp_path / file_name)
+    save_dataset(dataset, score_names, FileSaveStrategy(full_path_to_file))
+
+    # THEN
+    assert os.path.isfile(full_path_to_file)
+    with open(full_path_to_file) as file_handle:
+        json_objects = [json.loads(line, object_pairs_hook=OrderedDict) for line in file_handle.readlines()]
+        assert json_objects  # if nothing gets written to the file, this test would trivially pass
+        for json_obj in json_objects:
+            # want to ensure ordering of keys is correct, so we use list instead of set
+            assert list(json_obj.keys()) == test_case.expected_json_keys
             assert json_obj[DatasetColumns.MODEL_INPUT.value.name] in {"hello", "world"}
 
             if json_obj[DatasetColumns.MODEL_INPUT.value.name] == "hello":
                 assert json_obj[DatasetColumns.CATEGORY.value.name] == "Age"
-                assert json_obj["scores"] == [
-                    {"name": "rouge", "error": "error generating rouge score"},
-                    {"name": "bert_score", "value": 0.42},
-                ]
+                assert json_obj["scores"] == test_case.expected_model_input_1_scores
 
             if json_obj[DatasetColumns.MODEL_INPUT.value.name] == "world":
                 assert json_obj[DatasetColumns.CATEGORY.value.name] == "Gender"
-                assert json_obj["scores"] == [
-                    {"name": "rouge", "value": 0.314},
-                    {"name": "bert_score", "value": 0.271},
-                ]
+                assert json_obj["scores"] == test_case.expected_model_input_2_scores
 
 
 def test_save_dataset_many_rows(tmp_path):

--- a/test/unit/eval_algorithms/test_common.py
+++ b/test/unit/eval_algorithms/test_common.py
@@ -90,11 +90,17 @@ def test_save_dataset(tmp_path, file_name):
 
             if json_obj[DatasetColumns.MODEL_INPUT.value.name] == "hello":
                 assert json_obj[DatasetColumns.CATEGORY.value.name] == "Age"
-                assert json_obj["scores"] == [{"name": "rouge", "value": 0.5}, {"name": "bert_score", "value": 0.42}]
+                assert json_obj["scores"] == [
+                    {"name": "rouge", "value": 0.5, "error": None},
+                    {"name": "bert_score", "value": 0.42, "error": None},
+                ]
 
             if json_obj[DatasetColumns.MODEL_INPUT.value.name] == "world":
                 assert json_obj[DatasetColumns.CATEGORY.value.name] == "Gender"
-                assert json_obj["scores"] == [{"name": "rouge", "value": 0.314}, {"name": "bert_score", "value": 0.271}]
+                assert json_obj["scores"] == [
+                    {"name": "rouge", "value": 0.314, "error": None},
+                    {"name": "bert_score", "value": 0.271, "error": None},
+                ]
 
 
 def test_save_dataset_many_rows(tmp_path):

--- a/test/unit/eval_algorithms/test_eval_algorithm.py
+++ b/test/unit/eval_algorithms/test_eval_algorithm.py
@@ -210,10 +210,14 @@ class TestEvalScore:
     def test_equality(self):
         assert EvalScore(name="name1", value=0.7) == EvalScore(name="name1", value=0.7)
         assert EvalScore(name="name1", value=0.7) == EvalScore(name="name1", value=0.6999999999999)
+        assert EvalScore(name="name1", value=None, error="error1") == EvalScore(
+            name="name1", value=None, error="error1"
+        )
 
     def test_inequality(self):
         assert EvalScore(name="name1", value=0.7) != EvalScore(name="name2", value=0.7)
         assert EvalScore(name="name1", value=0.7) != EvalScore(name="name1", value=0.69)
+        assert EvalScore(name="name1", value=None, error="error1") != EvalScore(name="name1", value=0.7)
 
 
 class TestModelTask:

--- a/test/unit/eval_algorithms/test_util.py
+++ b/test/unit/eval_algorithms/test_util.py
@@ -385,7 +385,7 @@ def test_eval_output_record_str():
         [
             (DatasetColumns.MODEL_INPUT.value.name, "input"),
             (DatasetColumns.MODEL_OUTPUT.value.name, "output"),
-            ("scores", [{"name": "rouge", "value": 0.5}, {"name": "bert", "value": 0.4}]),
+            ("scores", [{"name": "rouge", "value": 0.5, "error": None}, {"name": "bert", "value": 0.4, "error": None}]),
         ]
     )
     assert json.loads(str(record), object_pairs_hook=OrderedDict) == expected_record

--- a/test/unit/eval_algorithms/test_util.py
+++ b/test/unit/eval_algorithms/test_util.py
@@ -375,7 +375,7 @@ def test_eval_output_record_str():
         list, and "scores" comes at the end.
     """
     record = EvalOutputRecord(
-        scores=[EvalScore(name="rouge", value=0.5), EvalScore(name="bert", value=0.4)],
+        scores=[EvalScore(name="rouge", value=0.5), EvalScore(name="bert", error="error generating bert score")],
         dataset_columns={
             DatasetColumns.MODEL_OUTPUT.value.name: "output",
             DatasetColumns.MODEL_INPUT.value.name: "input",
@@ -385,7 +385,7 @@ def test_eval_output_record_str():
         [
             (DatasetColumns.MODEL_INPUT.value.name, "input"),
             (DatasetColumns.MODEL_OUTPUT.value.name, "output"),
-            ("scores", [{"name": "rouge", "value": 0.5, "error": None}, {"name": "bert", "value": 0.4, "error": None}]),
+            ("scores", [{"name": "rouge", "value": 0.5}, {"name": "bert", "error": "error generating bert score"}]),
         ]
     )
     assert json.loads(str(record), object_pairs_hook=OrderedDict) == expected_record
@@ -401,16 +401,18 @@ def test_eval_output_record_from_row():
     row = {
         "rouge": 0.42,
         DatasetColumns.MODEL_OUTPUT.value.name: "output",
-        "bert": 0.162,
+        "bert": None,
         "invalid_col_1": "hello",
         DatasetColumns.MODEL_INPUT.value.name: "input",
         "invalid_col_2": "world",
+        DatasetColumns.ERROR.value.name: "error generating bert score",
     }
     expected_record = EvalOutputRecord(
-        scores=[EvalScore(name="rouge", value=0.42), EvalScore(name="bert", value=0.162)],
+        scores=[EvalScore(name="rouge", value=0.42), EvalScore(name="bert", error="error generating bert score")],
         dataset_columns={
             DatasetColumns.MODEL_INPUT.value.name: "input",
             DatasetColumns.MODEL_OUTPUT.value.name: "output",
+            DatasetColumns.ERROR.value.name: "error generating bert score",
         },
     )
 


### PR DESCRIPTION
*Issue #, if available:*
Add error fields in `EvalScore`. Ignore None value when aggregate dataset score.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
