### PR TITLE
feat: faithfulness handle no statements edge case

### DIFF
--- a/src/fmeval/eval_algorithms/faithfulness.py
+++ b/src/fmeval/eval_algorithms/faithfulness.py
@@ -113,7 +113,7 @@ class FaithfulnessScore(Transform):
         verdict_output = record[RAW_VERDICTS]
         statements = record[STATEMENTS]
         record[self.output_key], error = self._get_score(verdict_output, statements)
-        if error is not None:
+        if error:
             record[DatasetColumns.ERROR.value.name] = error
         return record
 

--- a/src/fmeval/eval_algorithms/faithfulness.py
+++ b/src/fmeval/eval_algorithms/faithfulness.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, List, Dict, Any
+from typing import Optional, List, Dict, Any, Tuple
 
 from fmeval.constants import (
     DatasetColumns,
@@ -35,6 +35,7 @@ LONG_FORM_PROMPT = "long_form_prompt"
 NLI_STATEMENTS_PROMT = "nli_statements_prompt"
 QUESTION = "question"
 ANSWER = "answer"
+
 
 LONG_FORM_ANSWER_PROMPT = """\
 Human: You are given a question and its answer. Your task is to rewrite the answer into one or more simple and coherent statements. Make sure that each statement is faithful to the answer and begins with "Statement:".
@@ -111,24 +112,27 @@ class FaithfulnessScore(Transform):
         """
         verdict_output = record[RAW_VERDICTS]
         statements = record[STATEMENTS]
-        record[self.output_key] = self._get_score(verdict_output, statements)
+        record[self.output_key], error = self._get_score(verdict_output, statements)
+        if error is not None:
+            record[DatasetColumns.ERROR.value.name] = error
         return record
 
     @staticmethod
-    def _get_score(verdict_output: str, statements: str) -> float:
+    def _get_score(verdict_output: str, statements: str) -> Tuple[Optional[float], Optional[str]]:
         """Given generated statements and verdicts, compute Faithfulness score.
 
         :param verdict_output: Verdicts(Yes/No) and explanations string get from Judge model.
         :param statements: Statements string get from `GetStatements` Transform.
-        :returns: 0 to 1. See the docstring for `Faithfulness` for more details
-            on what these numerical values represent.
+        :returns: a tuple of (score, error). Score can range from 0 to 1. See the docstring for `Faithfulness`
+            for more details on what these numerical values represent.
         """
         output = verdict_output.lower().strip()
-        num_statements = len(statements.split("\n"))
-        # TODO: handle edge case that num_statements is 0
-
-        score = float(max(0, output.count("verdict: yes")) / num_statements)
-        return score
+        if statements != "":
+            num_statements = len(statements.split("\n"))
+            score = float(max(0, output.count("verdict: yes")) / num_statements)
+            return score, None
+        else:
+            return None, "No statements were generated from the answer."
 
 
 class GetStatements(Transform):
@@ -256,6 +260,10 @@ class Faithfulness(EvalAlgorithmInterface):
             nli_statements_prompt_template=nli_statements_prompt_template,
         )
         result = pipeline.execute_record(sample)
+        if DatasetColumns.ERROR.value.name in result:
+            return [
+                EvalScore(name=FAITHFULNESS, value=result[FAITHFULNESS], error=result[DatasetColumns.ERROR.value.name])
+            ]
         return [EvalScore(name=FAITHFULNESS, value=result[FAITHFULNESS])]
 
     def evaluate(

--- a/test/unit/eval_algorithms/test_faithfulness.py
+++ b/test/unit/eval_algorithms/test_faithfulness.py
@@ -20,12 +20,18 @@ from fmeval.eval_algorithms.faithfulness import (
     NLI_STATEMENTS_MESSAGE,
 )
 
+SAMPLE_MODEL_INPUT = "Where and when was Einstein born?"
+SAMPLE_MODEL_OUTPUT = "Einstein was born in Germany on 20th March 1879."
+SAMPLE_TARGET_CONTEXT = "Albert Einstein (born 14 March 1879) was a German-born theoretical physicist, widely held to be one of the greatest and most influential scientists of all time"
+SAMPLE_STATEMENTS_OUTPUT = "Here are the statements created from the given answer:\nStatement: Einstein was born in Germany.\nStatement: Einstein was born on 20th March 1879."
+SAMPLE_VERDICTS_OUTPUT = 'here are the verdicts for the statements:\n1. statement: einstein was born in germany.\nexplanation: the context states that einstein was "a german-born theoretical physicist". this supports that he was born in germany.\nverdict: yes\n2. statement: einstein was born on 20th march 1879.  \nexplanation: the context states that einstein was "born 14 march 1879". this contradicts the statement that he was born on 20th march 1879.\nverdict: no\nfinal verdicts in order:\nyes. no.'
+
 DATASET_WITH_CONTEXT = ray.data.from_items(
     [
         {
-            DatasetColumns.MODEL_INPUT.value.name: "Where and when was Einstein born?",
-            DatasetColumns.MODEL_OUTPUT.value.name: "Einstein was born in Germany on 20th March 1879.",
-            DatasetColumns.TARGET_CONTEXT.value.name: "Albert Einstein (born 14 March 1879) was a German-born theoretical physicist, widely held to be one of the greatest and most influential scientists of all time",
+            DatasetColumns.MODEL_INPUT.value.name: SAMPLE_MODEL_INPUT,
+            DatasetColumns.MODEL_OUTPUT.value.name: SAMPLE_MODEL_OUTPUT,
+            DatasetColumns.TARGET_CONTEXT.value.name: SAMPLE_TARGET_CONTEXT,
         },
     ]
 )
@@ -47,13 +53,29 @@ class TestFaithfulness:
     @pytest.mark.parametrize(
         "test_case",
         [
+            # successful case
             TestCaseFaithfulnessEvaluateSample(
-                model_input="Where and when was Einstein born?",
-                model_output="Einstein was born in Germany on 20th March 1879.",
-                target_context="Albert Einstein (born 14 March 1879) was a German-born theoretical physicist, widely held to be one of the greatest and most influential scientists of all time",
-                statements_output="Here are the statements created from the given answer:\nStatement: Einstein was born in Germany.\nStatement: Einstein was born on 20th March 1879.",
-                verdicts_output='here are the verdicts for the statements:\n1. statement: einstein was born in germany.\nexplanation: the context states that einstein was "a german-born theoretical physicist". this supports that he was born in germany.\nverdict: yes\n2. statement: einstein was born on 20th march 1879.  \nexplanation: the context states that einstein was "born 14 march 1879". this contradicts the statement that he was born on 20th march 1879.\nverdict: no\nfinal verdicts in order:\nyes. no.',
+                model_input=SAMPLE_MODEL_INPUT,
+                model_output=SAMPLE_MODEL_OUTPUT,
+                target_context=SAMPLE_TARGET_CONTEXT,
+                statements_output=SAMPLE_STATEMENTS_OUTPUT,
+                verdicts_output=SAMPLE_VERDICTS_OUTPUT,
                 expected_score=[EvalScore(name=EvalAlgorithm.FAITHFULNESS.value, value=1 / 2)],
+            ),
+            # No statements get from judge model
+            TestCaseFaithfulnessEvaluateSample(
+                model_input=SAMPLE_MODEL_INPUT,
+                model_output=SAMPLE_MODEL_OUTPUT,
+                target_context=SAMPLE_TARGET_CONTEXT,
+                statements_output="Can't find statements. Here are the statements created from the given answer",
+                verdicts_output="No verdicts as no statements can be found.",
+                expected_score=[
+                    EvalScore(
+                        name=EvalAlgorithm.FAITHFULNESS.value,
+                        value=None,
+                        error="No statements were generated from the answer.",
+                    )
+                ],
             ),
         ],
     )
@@ -166,8 +188,8 @@ class TestFaithfulness:
                     model_output_location=None,
                     category_location="tba",
                 ),
-                statements_output="Here are the statements created from the given answer:\nStatement: Einstein was born in Germany.\nStatement: Einstein was born on 20th March 1879.",
-                verdicts_output='here are the verdicts for the statements:\n1. statement: einstein was born in germany.\nexplanation: the context states that einstein was "a german-born theoretical physicist". this supports that he was born in germany.\nverdict: yes\n2. statement: einstein was born on 20th march 1879.  \nexplanation: the context states that einstein was "born 14 march 1879". this contradicts the statement that he was born on 20th march 1879.\nverdict: no\nfinal verdicts in order:\nyes. no.',
+                statements_output=SAMPLE_STATEMENTS_OUTPUT,
+                verdicts_output=SAMPLE_VERDICTS_OUTPUT,
                 expected_response=[
                     EvalOutput(
                         eval_name="faithfulness",
@@ -232,7 +254,12 @@ class TestFaithfulness:
                 statements="Statement: statement1\nStatement: statement2",
                 expected_score=0.0,
             ),
-            # TODO add test case for 0 statements
+            # no statements, score is None
+            TestCaseFaithfulnessScore(
+                raw_verdicts="judge model didn't output as expected",
+                statements="",
+                expected_score=None,
+            ),
         ],
     )
     def test_faithfulness_transform(self, test_case):
@@ -248,6 +275,8 @@ class TestFaithfulness:
         }
         result = get_scores(sample)
         assert result[EvalAlgorithm.FAITHFULNESS.value] == test_case.expected_score
+        if test_case.expected_score is None:
+            assert result["error"] != None
 
     class TestCaseGetStatements(NamedTuple):
         record: Dict[str, str]


### PR DESCRIPTION
*Issue #, if available:*
Handle edge case when no statements being generated from judge model.

*Description of changes:*
1. Rebased from https://github.com/aws/fmeval/pull/297.
2. Generate error in EvalScore if no statements

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
