### PR TITLE
fix: Context precision score computation

### DIFF
--- a/src/fmeval/eval_algorithms/context_quality.py
+++ b/src/fmeval/eval_algorithms/context_quality.py
@@ -303,7 +303,7 @@ class ContextPrecisionScore(Transform):
         denominator = sum(model_verdicts)
         # If none of model verdicts are 1, return 0
         if not denominator:
-            return 0.
+            return 0.0
         numerator = sum(
             [(sum(model_verdicts[: i + 1]) / (i + 1)) * model_verdicts[i] for i in range(len(model_verdicts))]
         )

--- a/src/fmeval/eval_algorithms/context_quality.py
+++ b/src/fmeval/eval_algorithms/context_quality.py
@@ -300,7 +300,10 @@ class ContextPrecisionScore(Transform):
         :param model_verdicts: A list of judge model verdicts of 0 or 1.
         :return: the context precision score for the record.
         """
-        denominator = sum(model_verdicts) + 1e-10
+        denominator = sum(model_verdicts)
+        # If none of model verdicts are 1, return 0
+        if not denominator:
+            return 0.
         numerator = sum(
             [(sum(model_verdicts[: i + 1]) / (i + 1)) * model_verdicts[i] for i in range(len(model_verdicts))]
         )


### PR DESCRIPTION
*Description of changes:*
This code: `denominator = sum(model_verdicts) + 1e-10` will lead to inaccurate context precision score when `sum(model_verdicts) > 0` and `numerator > 0`. For example: `1 / (1 + 1e-10) = 0.9999999999`
Fixed this by returning `0` if `sum(model_verdicts)` is `0`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
