### PR TITLE
build: bump fmeval version to 1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fmeval"
-version = "1.0.3"
+version = "1.1.0"
 description = "Amazon Foundation Model Evaluations"
 license = "Apache License 2.0"
 authors = ["Amazon FMEval Team <amazon-fmeval-team@amazon.com>"]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Version bump. Bumping minor version since semantic versioning states that you should bump the minor version "when you add functionality in a backward compatible manner". We actually should've been bumping the minor version instead of the patch version for several of the past releases.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
