### PR TITLE
build(deps): pinned nltk version to address build failure

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4887,4 +4887,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "64ffcc42f92a252dbbe84f437143ca54e300d043f91c81e9376fbb692ee46a10"
+content-hash = "510e5e539369b82665d6009db68735969ca08527664d1bcafc422f9c92e0e1f7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ torch = ">=2.0.0, !=2.0.1, !=2.1.0"
 matplotlib = "^3.8.3"
 # https://discuss.ray.io/t/pandas-importerror-with-ray-data-dataset-show/13486
 pandas = "2.1.4"
-nltk = "^3.8.1"
+nltk = "3.8.1"
 markdown = "*"
 IPython = "*"
 evaluate = "^0.4.0"


### PR DESCRIPTION
Build failed due to nltk version update, so I downgraded the version to temporarily fix the issue.
Here's the error that was generated: 

```
E       LookupError:
--
4975 | E       **********************************************************************
4976 | E         Resource punkt_tab not found.
4977 | E         Please use the NLTK Downloader to obtain the resource:
4978 | E
4979 | E         >>> import nltk
4980 | E         >>> nltk.download('punkt_tab')
4981 | E
4982 | E         For more information see: https://www.nltk.org/data.html
4983 | E
4984 | E         Attempted to load tokenizers/punkt_tab/english/
4985 | E
4986 | E         Searched in:
4987 | E           - '/root/nltk_data'
4988 | E           - '/codebuild/output/src862412924/src/venv/nltk_data'
4989 | E           - '/codebuild/output/src862412924/src/venv/share/nltk_data'
4990 | E           - '/codebuild/output/src862412924/src/venv/lib/nltk_data'
4991 | E           - '/usr/share/nltk_data'
4992 | E           - '/usr/local/share/nltk_data'
4993 | E           - '/usr/lib/nltk_data'
4994 | E           - '/usr/local/lib/nltk_data'
4995 | E       **********************************************************************
4996 |  
4997 | venv/lib/python3.10/site-packages/nltk/data.py:582: LookupError
``` 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
