### PR TITLE
Create CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @aws/amazon-fmeval-team


### PR DESCRIPTION
*Description of changes:*
This PR adds a `CODEOWNERS` file to manage ownership of the repo. See [the docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners). The current configuration is to grant ownership of the whole repo to the `amazon-fmeval-team` Github team.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
